### PR TITLE
Correctly load local datasets with train/test splits

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -197,7 +197,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
     parser.add_argument("--max_len", type=int, default=512)
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
     parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -359,7 +359,7 @@ if __name__ == "__main__":
         "--apply_chat_template", action="store_true", default=False, help="Use HF tokenizer chat template"
     )
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -294,7 +294,7 @@ if __name__ == "__main__":
         "--apply_chat_template", action="store_true", default=False, help="Use HF tokenizer chat template"
     )
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
     parser.add_argument("--max_len", type=int, default=512)
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
 
-    # wandb pamameters
+    # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)
     parser.add_argument("--wandb_org", type=str, default=None)
     parser.add_argument("--wandb_group", type=str, default=None)

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -57,46 +57,22 @@ def blending_datasets(
     eval_data_list = []
     for i, dataset in enumerate(datasets):
         dataset = dataset.strip()
-        dataset_subfold_list = dataset.split("@")
         strategy.print(f"dataset: {dataset}")
-        # local dir with python script or common local file
-        if os.path.isdir(os.path.join(os.getcwd(), dataset)) or dataset.endswith(
-            (".json", ".jsonl", ".csv", ".parquet", ".txt")
+
+        data_dir = None if "@" not in dataset else dataset.split("@")[1].strip()
+        dataset = dataset.split("@")[0].strip()
+        dataset_basename = os.path.basename(dataset)
+
+        # local python script
+        if dataset.endwith(".py") or (
+            os.path.isdir(dataset) and os.path.exists(os.path.join(dataset, f"{dataset_basename}.py"))
         ):
-            if dataset.endswith((".json", ".jsonl", ".csv", ".parquet", ".txt")):
-                files = dataset
-                data_type = os.path.splitext(files)[1][1:]
-            else:
-                path = Path(dataset)
-                script = [str(file.resolve()) for file in Path(path).rglob("*.py")]
-                extensions = ("*.json", "*.jsonl", "*.csv", "*.parquet", "*.txt")
-                files = [str(file) for ext in extensions for file in Path(path).rglob(ext)]
-                strategy.print(f"script: {script}")
-                strategy.print(f"files: {files}")
-                # For dir, follow python script or first file type
-                data_type = script[0] if len(script) == 1 else os.path.splitext(files[0])[1][1:]
-            # reformat data type
-            if data_type in ["json", "jsonl"]:
-                data_type = "json"
-            elif data_type == "txt":
-                data_type = "text"
-            elif data_type.endswith(".py"):
-                # load local dir with python script
-                files = None
-            if data_type.endswith(".py"):
-                strategy.print(f"load {dataset} with script {data_type}")
-            else:
-                strategy.print(f"load {files} from {dataset}")
-            data = load_dataset(data_type, data_files=files)
-        elif len(dataset_subfold_list) == 2:
-            dataset = dataset_subfold_list[0]
-            subfold = dataset_subfold_list[1]
-            data = load_dataset(dataset, data_dir=subfold.strip())
-        elif len(dataset_subfold_list) == 1:
-            dataset = dataset_subfold_list[0]
-            data = load_dataset(dataset)
+            data = load_dataset(dataset, trust_remote_code=True)
+            strategy.print(f"loaded {dataset} with python script")
+        # remote/local folder or common file
         else:
-            raise Exception(f"Dataset Name {dataset}: Format error")
+            data = load_dataset(dataset, data_dir=data_dir)
+            strategy.print(f"loaded {dataset} from files")
 
         if train_split and train_split in data:
             train_data = data[train_split].select(range(min(max_count, len(data[train_split]))))


### PR DESCRIPTION
The original code will load the following local dataset into a single `train` split. This PR simplifies the loading logic and can correctly load it as a DatasetDict with `train` and `test` splits.
```
local_dataset/
├── train.jsonl
└── test.jsonl
```