### PR TITLE
Fix loading dataset from local text files

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -63,12 +63,19 @@ def blending_datasets(
         dataset = dataset.split("@")[0].strip()
         dataset_basename = os.path.basename(dataset)
 
+        ext = os.path.splitext(dataset)[-1]
         # local python script
-        if dataset.endswith(".py") or (
+        if ext == ".py" or (
             os.path.isdir(dataset) and os.path.exists(os.path.join(dataset, f"{dataset_basename}.py"))
         ):
             data = load_dataset(dataset, trust_remote_code=True)
             strategy.print(f"loaded {dataset} with python script")
+        # local text file
+        elif ext in [".json", ".jsonl", ".csv"]:
+            ext = ext.lower().strip(".")
+            if ext == "jsonl":
+                ext = "json"
+            data = load_dataset(ext, data_files=dataset)
         # remote/local folder or common file
         else:
             data = load_dataset(dataset, data_dir=data_dir)


### PR DESCRIPTION
The original implementation fails to load local text files like `*.jsonl` in [Iterative DPO](https://github.com/OpenRLHF/OpenRLHF/blob/aae9fd4a25110a5b3770b789fff31d89c2d8c34d/examples/scripts/train_iterative_dpo_llama.sh#L11-L12), which causes errors like:
```
FileNotFoundError: Couldn't find a dataset script at /path/to/checkpoint/llama-3-8b-iter-dpo/generate.jsonl/generate.jsonl.py or any data file in the same directory.
```