### PR TITLE
add 'num_return_sequences' feature in actor

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -132,6 +132,7 @@ class Actor(nn.Module):
             "eos_token_id": kwargs.get("eos_token_id"),
             "pad_token_id": kwargs.get("pad_token_id"),
             "min_new_tokens": kwargs.get("min_new_tokens", 1),
+            "num_return_sequences": kwargs.get("num_return_sequences", 1),
         }
 
         if kwargs.get("max_new_tokens", None):


### PR DESCRIPTION
The interface `num_return_sequences` is reserved for algorithms that require multiple samplings for a single prompt, such as [GRPO](https://github.com/deepseek-ai/DeepSeek-Math), which I'm currently developing. It should have no effect on current algorithms (e.g. PPO) since 'num_return_sequences' will use default value '1' when not specified.