### PR TITLE
only import bitsandbytes when necessary

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -4,7 +4,6 @@ import deepspeed
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from peft import LoraConfig, TaskType, get_peft_model
 from peft.tuners.lora import LoraLayer
 from transformers import AutoModelForCausalLM, BitsAndBytesConfig, PreTrainedModel

--- a/openrlhf/models/model.py
+++ b/openrlhf/models/model.py
@@ -9,9 +9,10 @@ from transformers import AutoConfig, AutoModel, BitsAndBytesConfig
 from transformers.deepspeed import HfDeepSpeedConfig
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
+from openrlhf.utils.logging_utils import init_logger
+
 from .packing_utils import patch_for_block_diag_attn
 from .utils import reset_position_ids
-from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -1,6 +1,5 @@
 from typing import Optional, Tuple, Union
 
-import bitsandbytes as bnb
 import deepspeed
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Hi, this PR is trying to removing the explicit `import bitsandbytes as bnb`, so that we can bypass avoid manually building bitsandbytes from source in cuda 12.4 :)

The relevant issue is: https://github.com/bitsandbytes-foundation/bitsandbytes/issues/1152

P.S. The other 2 formatting changes are from the pre-commit hook.