### PR TITLE
Add PRM training with hard estimation

### DIFF
--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -1,0 +1,195 @@
+import argparse
+import math
+import os
+from datetime import datetime
+
+from transformers.trainer import get_scheduler
+
+from openrlhf.datasets import ProcessRewardDataset
+from openrlhf.models import Actor
+from openrlhf.trainer import ProcessRewardModelTrainer
+from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
+
+
+def train(args):
+    # configure strategy
+    strategy = get_strategy(args)
+    strategy.setup_distributed()
+
+    # configure model
+    # load huggingface model
+    model = Actor(
+        args.pretrain,
+        use_flash_attention_2=args.flash_attn,
+        bf16=args.bf16,
+        load_in_4bit=args.load_in_4bit,
+        lora_rank=args.lora_rank,
+        lora_alpha=args.lora_alpha,
+        target_modules=args.target_modules,
+        lora_dropout=args.lora_dropout,
+        ds_config=strategy.get_ds_train_config(is_actor=True),
+        packing_samples=args.packing_samples,
+    )
+    # configure tokenizer
+    tokenizer = get_tokenizer(args.pretrain, model.model, "right", strategy, use_fast=not args.disable_fast_tokenizer)
+    strategy.print(model)
+
+    # gradient_checkpointing
+    if args.gradient_checkpointing:
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={"use_reentrant": args.gradient_checkpointing_use_reentrant}
+        )
+
+    # configure optimizer
+    optim = strategy.create_optimizer(model, lr=args.learning_rate, betas=args.adam_betas, weight_decay=args.l2)
+
+    # prepare for data and dataset
+    train_data, eval_data = blending_datasets(
+        args.dataset,
+        args.dataset_probs,
+        strategy,
+        args.seed,
+        max_count=args.max_samples,
+        train_split=args.train_split,
+        eval_split=args.eval_split,
+    )
+    train_data = train_data.select(range(min(args.max_samples, len(train_data))))
+    eval_data = eval_data.select(range(min(args.max_samples, len(eval_data))))
+    train_dataset = ProcessRewardDataset(train_data, tokenizer, args.max_len, strategy)
+    eval_dataset = ProcessRewardDataset(eval_data, tokenizer, args.max_len, strategy)
+
+    # prepare dataloader
+    train_dataloader = strategy.setup_dataloader(
+        train_dataset,
+        args.micro_train_batch_size,
+        True,
+        True,
+        train_dataset.packing_collate_fn if args.packing_samples else train_dataset.collate_fn,
+    )
+    eval_dataloader = strategy.setup_dataloader(
+        eval_dataset,
+        args.micro_train_batch_size,
+        True,
+        False,
+        eval_dataset.packing_collate_fn if args.packing_samples else eval_dataset.collate_fn,
+    )
+
+    # scheduler
+    num_update_steps_per_epoch = len(train_dataset) // args.train_batch_size
+    max_steps = math.ceil(args.max_epochs * num_update_steps_per_epoch)
+
+    scheduler = get_scheduler(
+        args.lr_scheduler,
+        optim,
+        num_warmup_steps=math.ceil(max_steps * 0.03),
+        num_training_steps=max_steps,
+        scheduler_specific_kwargs={"min_lr": args.learning_rate * 0.1},
+    )
+
+    # prepare models
+    (model, optim, scheduler) = strategy.prepare((model, optim, scheduler))
+
+    # load checkpoint
+    consumed_samples = 0
+    if args.load_checkpoint and os.path.exists(args.ckpt_path):
+        _, states = strategy.load_ckpt(model.model, args.ckpt_path)
+        consumed_samples = states["consumed_samples"]
+        strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
+
+    os.makedirs(args.save_path, exist_ok=True)
+
+    # configure Trainer
+    trainer = ProcessRewardModelTrainer(
+        model=model,
+        strategy=strategy,
+        optim=optim,
+        train_dataloader=train_dataloader,
+        eval_dataloader=eval_dataloader,
+        scheduler=scheduler,
+        max_norm=args.max_norm,
+        batch_size=args.train_batch_size,
+        max_epochs=args.max_epochs,
+        tokenizer=tokenizer,
+    )
+
+    trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
+
+    # save model checkpoint after fitting on only rank0
+    strategy.save_model(model, tokenizer, args.save_path)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # Checkpoint
+    parser.add_argument("--save_path", type=str, default="./ckpt")
+    parser.add_argument("--save_steps", type=int, default=-1)
+    parser.add_argument("--logging_steps", type=int, default=1)
+    parser.add_argument("--eval_steps", type=int, default=-1)
+    parser.add_argument("--ckpt_path", type=str, default="./ckpt/checkpoints_prm")
+    parser.add_argument("--max_ckpt_num", type=int, default=3)
+    parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
+    parser.add_argument("--load_checkpoint", action="store_true", default=False)
+
+    # DeepSpeed
+    parser.add_argument("--max_norm", type=float, default=1.0, help="Gradient clipping")
+    parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
+    parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
+    parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")
+    parser.add_argument("--zpg", type=int, default=1, help="ZeRO++ max partition size")
+    parser.add_argument("--adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument("--flash_attn", action="store_true", default=False, help="Enable FlashAttention2")
+    parser.add_argument("--grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")
+    parser.add_argument("--disable_trace_cache", action="store_true", default=False)
+    parser.add_argument("--gradient_checkpointing_use_reentrant", action="store_true", default=False)
+    parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
+
+    # LoRA
+    parser.add_argument("--load_in_4bit", action="store_true", default=False)
+    parser.add_argument("--lora_rank", type=int, default=0)
+    parser.add_argument("--lora_alpha", type=int, default=16)
+    parser.add_argument("--lora_dropout", type=float, default=0)
+    parser.add_argument("--target_modules", type=str, nargs="*", default="all-linear")
+
+    # PRM training
+    parser.add_argument("--pretrain", type=str, default=None)
+    parser.add_argument("--max_epochs", type=int, default=1)
+    parser.add_argument("--aux_loss_coef", type=float, default=0, help="MoE balancing loss")
+    parser.add_argument("--learning_rate", type=float, default=1e-6)
+    parser.add_argument("--micro_train_batch_size", type=int, default=1)
+    parser.add_argument("--train_batch_size", type=int, default=128, help="Global training batch size")
+    parser.add_argument("--lr_scheduler", type=str, default="cosine_with_min_lr")
+    parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
+    parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
+    parser.add_argument("--placeholder_token", type=str, default=None)
+    parser.add_argument("--reward_tokens", type=str, nargs="*", default=None)
+
+    # packing samples using Flash Attention2
+    parser.add_argument("--packing_samples", action="store_true", default=False)
+
+    # custom dataset
+    parser.add_argument("--dataset", type=str, default=None)
+    parser.add_argument("--dataset_probs", type=str, default="1.0", help="sampling probs for datasets")
+    parser.add_argument("--train_split", type=str, default="train", help="train split of the HF dataset")
+    parser.add_argument("--eval_split", type=str, default="test", help="test split of the dataset")
+
+    parser.add_argument("--input_key", type=str, default="input", help="JSON dataset key")
+    parser.add_argument("--label_key", type=str, default="label", help="JSON dataset key")
+    parser.add_argument("--max_samples", type=int, default=1e8, help="Max number of samples")
+    parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
+
+    # wandb parameters
+    parser.add_argument("--use_wandb", type=str, default=None)
+    parser.add_argument("--wandb_org", type=str, default=None)
+    parser.add_argument("--wandb_group", type=str, default=None)
+    parser.add_argument("--wandb_project", type=str, default="openrlhf_train_prm")
+    parser.add_argument(
+        "--wandb_run_name",
+        type=str,
+        default="prm_%s" % datetime.now().strftime("%m%dT%H:%M"),
+    )
+
+    args = parser.parse_args()
+
+    train(args)

--- a/openrlhf/datasets/__init__.py
+++ b/openrlhf/datasets/__init__.py
@@ -1,3 +1,4 @@
+from .process_reward_dataset import ProcessRewardDataset
 from .prompts_dataset import PromptDataset
 from .reward_dataset import RewardDataset
 from .sft_dataset import SFTDataset

--- a/openrlhf/datasets/process_reward_dataset.py
+++ b/openrlhf/datasets/process_reward_dataset.py
@@ -1,0 +1,114 @@
+from typing import Callable
+
+import torch
+import torch.nn.functional as F
+from torch.utils.data import Dataset
+from tqdm import tqdm
+
+from .utils import zero_pad_sequences
+
+
+class ProcessRewardDataset(Dataset):
+    """
+    Dataset for process reward model
+
+    Args:
+        dataset: dataset for reward model
+        self.tokenizer: self.tokenizer for reward model
+        self.max_length: max length of input
+    """
+
+    def __init__(
+        self,
+        dataset,
+        tokenizer: Callable,
+        max_length: int,
+        strategy,
+        multiple_of=1,
+    ) -> None:
+        super().__init__()
+        self.tokenizer = tokenizer
+        self.strategy = strategy
+        self.max_length = max_length
+        self.multiple_of = multiple_of
+
+        # chat_template
+        self.input_key = getattr(self.strategy.args, "input_key", None)
+        self.label_key = getattr(self.strategy.args, "label_key", None)
+
+        # Store the processed data in class attributes
+        self.inputs = dataset[self.input_key]
+        self.labels = dataset[self.label_key]
+
+    def __len__(self):
+        length = len(self.inputs)
+        return length
+
+    def __getitem__(self, idx):
+        input_token = self.tokenizer(
+            self.inputs[idx],
+            max_length=self.max_length,
+            padding=False,
+            truncation=True,
+            return_tensors="pt",
+            add_special_tokens=False,
+        )
+
+        label_token = self.tokenizer(
+            self.labels[idx],
+            max_length=self.max_length,
+            padding=False,
+            truncation=True,
+            return_tensors="pt",
+            add_special_tokens=False,
+            return_attention_mask=False,
+        )
+
+        assert input_token["input_ids"].numel() == label_token["input_ids"].numel()
+
+        return (
+            input_token["input_ids"],
+            input_token["attention_mask"],
+            label_token["input_ids"],
+        )
+
+    def collate_fn(self, item_list):
+        input_ids = []
+        input_masks = []
+        label_ids = []
+        for input_id, input_mask, label_id in item_list:
+            input_ids.append(input_id)
+            input_masks.append(input_mask)
+            label_ids.append(label_id)
+
+        padding_side = "right"
+        input_ids = zero_pad_sequences(input_ids, side=padding_side, value=self.tokenizer.pad_token_id)
+        input_masks = zero_pad_sequences(input_masks, side=padding_side)
+        label_ids = zero_pad_sequences(label_ids, side=padding_side, value=self.tokenizer.pad_token_id)
+        return input_ids, input_masks, label_ids
+
+    def packing_collate_fn(self, item_list):
+        input_ids = []
+        input_att_masks = []
+        input_seq_lens = []
+        label_ids = []
+        index = 1
+        for input_id, input_mask, label_id in item_list:
+            input_ids.append(input_id.flatten())
+            input_att_masks.append(torch.full_like(input_id.flatten(), index))
+            input_seq_lens.append(len(input_id.flatten()))
+
+            label_ids.append(label_id.flatten())
+            index += 1
+
+        packed_input_ids = torch.cat(input_ids, dim=0).unsqueeze(0)
+        packed_attention_masks = torch.cat(input_att_masks, dim=0).unsqueeze(0)
+        packed_seq_lens = input_seq_lens
+        packed_label_ids = torch.cat(label_ids, dim=0).unsqueeze(0)
+
+        if self.multiple_of > 1 and packed_input_ids.numel() % self.multiple_of != 0:
+            padding_len = self.multiple_of - (packed_input_ids.numel() % self.multiple_of)
+            packed_input_ids = F.pad(packed_input_ids, (0, padding_len), value=self.tokenizer.pad_token_id)
+            packed_attention_masks = F.pad(packed_attention_masks, (0, padding_len), value=0)
+
+        return packed_input_ids, packed_attention_masks, packed_seq_lens, packed_label_ids

--- a/openrlhf/models/__init__.py
+++ b/openrlhf/models/__init__.py
@@ -1,3 +1,14 @@
 from .actor import Actor
-from .loss import DPOLoss, GPTLMLoss, KDLoss, KTOLoss, LogExpLoss, PairWiseLoss, PolicyLoss, ValueLoss, VanillaKTOLoss
+from .loss import (
+    DPOLoss,
+    GPTLMLoss,
+    KDLoss,
+    KTOLoss,
+    LogExpLoss,
+    PairWiseLoss,
+    PolicyLoss,
+    PRMLoss,
+    ValueLoss,
+    VanillaKTOLoss,
+)
 from .model import get_llm_for_sequence_regression

--- a/openrlhf/trainer/__init__.py
+++ b/openrlhf/trainer/__init__.py
@@ -2,5 +2,6 @@ from .dpo_trainer import DPOTrainer
 from .kd_trainer import KDTrainer
 from .kto_trainer import KTOTrainer
 from .ppo_trainer import PPOTrainer
+from .prm_trainer import ProcessRewardModelTrainer
 from .rm_trainer import RewardModelTrainer
 from .sft_trainer import SFTTrainer

--- a/openrlhf/trainer/prm_trainer.py
+++ b/openrlhf/trainer/prm_trainer.py
@@ -1,0 +1,239 @@
+import math
+from abc import ABC
+
+import torch
+from torch import nn
+from torch.optim import Optimizer
+from tqdm import tqdm
+
+from openrlhf.models import PRMLoss
+from openrlhf.utils.distributed_sampler import DistributedSampler
+from openrlhf.utils.utils import convert_token_to_id
+
+
+class ProcessRewardModelTrainer(ABC):
+    """
+        Trainer to use while training reward model.
+
+    Args:
+        model (torch.nn.Module): the model to train
+        strategy (Strategy): the strategy to use for training
+        optim(Optimizer): the optimizer to use for training
+        train_dataset (RewardDataset): the dataset to use for training
+        eval_dataset (RewardDataset): the dataset to use for evaluation
+        batch_size (int, defaults to 1): the batch size while training
+        max_epochs (int, defaults to 2): the number of epochs to train
+        optim_kwargs (dict, defaults to {'lr':1e-4}): the kwargs to use while initializing optimizer
+    """
+
+    def __init__(
+        self,
+        model,
+        strategy,
+        optim: Optimizer,
+        train_dataloader,
+        eval_dataloader,
+        scheduler,
+        max_norm: float = 1,
+        batch_size: int = 1,
+        max_epochs: int = 2,
+        tokenizer=None,
+    ) -> None:
+        super().__init__()
+        self.strategy = strategy
+        self.epochs = max_epochs
+        self.batch_size = batch_size
+        self.max_norm = max_norm
+        self.train_dataloader = train_dataloader
+        self.eval_dataloader = eval_dataloader
+        self.scheduler = scheduler
+        self.model = model
+        self.tokenizer = tokenizer
+        self.optimizer = optim
+        self.args = strategy.args
+
+        # set placeholder token
+        self.placeholder_token_id = convert_token_to_id(strategy.args.placeholder_token, self.tokenizer)
+        self.reward_token_ids = self.args.reward_tokens
+        if self.reward_token_ids is not None:
+            self.reward_token_ids = sorted(
+                [convert_token_to_id(token, self.tokenizer) for token in self.reward_token_ids]
+            )
+
+        self.ignore_index = -100
+        self.loss_fn = PRMLoss(self.placeholder_token_id, self.reward_token_ids)
+
+        # Mixtral 8*7b
+        self.aux_loss = self.args.aux_loss_coef > 1e-8
+
+        # packing samples
+        self.packing_samples = strategy.args.packing_samples
+
+        # wandb setting
+        self._wandb = None
+        if self.strategy.args.use_wandb and self.strategy.is_rank_0():
+            import wandb
+
+            self._wandb = wandb
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.use_wandb)
+            wandb.init(
+                entity=strategy.args.wandb_org,
+                project=strategy.args.wandb_project,
+                group=strategy.args.wandb_group,
+                name=strategy.args.wandb_run_name,
+                config=strategy.args.__dict__,
+                reinit=True,
+            )
+
+            wandb.define_metric("train/global_step")
+            wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
+            wandb.define_metric("eval/global_step")
+            wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
+
+    def fit(self, args, consumed_samples=0, num_update_steps_per_epoch=None):
+        # get eval and save steps
+        if args.eval_steps == -1:
+            args.eval_steps = num_update_steps_per_epoch  # Evaluate once per epoch
+        if args.save_steps == -1:
+            args.save_steps = float("inf")  # do not save ckpt
+
+        # Restore step and start_epoch
+        step = consumed_samples // args.train_batch_size * self.strategy.accumulated_gradient + 1
+        start_epoch = consumed_samples // args.train_batch_size // num_update_steps_per_epoch
+        consumed_samples = consumed_samples % (num_update_steps_per_epoch * args.train_batch_size)
+
+        epoch_bar = tqdm(
+            range(start_epoch, self.epochs),
+            desc="Train epoch",
+            disable=not self.strategy.is_rank_0(),
+        )
+        for epoch in range(start_epoch, self.epochs):
+            if isinstance(self.train_dataloader.sampler, DistributedSampler):
+                self.train_dataloader.sampler.set_epoch(
+                    epoch, consumed_samples=0 if epoch > start_epoch else consumed_samples
+                )
+
+            step_bar = tqdm(
+                range(self.train_dataloader.__len__()),
+                desc="Train step of epoch %d" % epoch,
+                disable=not self.strategy.is_rank_0(),
+            )
+
+            # train
+            self.model.train()
+            loss_mean = 0
+            for data in self.train_dataloader:
+                if not self.packing_samples:
+                    inputs, attention_masks, labels = data
+                    inputs = inputs.to(torch.cuda.current_device())
+                    attention_mask = attention_masks.to(torch.cuda.current_device())
+                    labels = labels.to(torch.cuda.current_device())
+                else:
+                    inputs, attention_masks, packed_seq_lens, labels = data
+                    inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
+                    attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
+                    labels = labels.to(torch.cuda.current_device()).squeeze(1)
+
+                output = self.model(inputs, attention_mask=attention_mask, return_output=True)
+
+                # mixtral
+                if self.aux_loss:
+                    aux_loss = output.aux_loss
+                else:
+                    aux_loss = 0
+
+                prm_loss, acc = self.loss_fn(inputs, output.logits, labels, return_acc=True)
+                loss = prm_loss + aux_loss * self.args.aux_loss_coef
+                self.strategy.backward(loss, self.model, self.optimizer)
+                self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler)
+
+                loss_mean = loss_mean * 0.9 + 0.1 * loss.item()
+                logs_dict = {
+                    "prm_loss": prm_loss.item(),
+                    "loss_mean": loss_mean,
+                    "acc": acc.item(),
+                    "lr": self.scheduler.get_last_lr()[0],
+                }
+                if self.aux_loss:
+                    logs_dict["aux_loss"] = aux_loss.item()
+                # step bar
+                logs_dict = self.strategy.all_reduce(logs_dict)
+                step_bar.set_postfix(logs_dict)
+                step_bar.update()
+
+                # logs/checkpoints/evaluation
+                if step % self.strategy.accumulated_gradient == 0:
+                    global_step = step // self.strategy.accumulated_gradient
+                    client_states = {"consumed_samples": global_step * args.train_batch_size}
+                    self.save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
+
+                step += 1
+
+            epoch_bar.update()
+
+    # logs/checkpoints/evaluation
+    def save_logs_and_checkpoints(self, args, global_step, step_bar, logs_dict={}, client_states={}):
+        if global_step % args.logging_steps == 0:
+            # wandb
+            if self._wandb is not None and self.strategy.is_rank_0():
+                logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
+                self._wandb.log(logs)
+
+        # eval
+        if global_step % args.eval_steps == 0:
+            self.evaluate(self.eval_dataloader, global_step)
+        # save ckpt
+        # TODO: save best model on dev, use loss/perplexity on whole dev dataset as metric
+        if global_step % args.save_steps == 0:
+            tag = f"global_step{global_step}"
+            self.strategy.save_ckpt(
+                self.model.model, args.ckpt_path, tag, args.max_ckpt_num, args.max_ckpt_mem, client_states
+            )
+
+    def evaluate(self, eval_dataloader, steps=0):
+        times = 0
+        self.model.eval()
+        with torch.no_grad():
+            loss_sum = 0
+            acc_sum = 0
+            step_bar = tqdm(
+                range(eval_dataloader.__len__()),
+                desc="Eval stage of steps %d" % steps,
+                disable=not self.strategy.is_rank_0(),
+            )
+
+            for data in eval_dataloader:
+                if not self.packing_samples:
+                    inputs, attention_masks, labels = data
+                    inputs = inputs.to(torch.cuda.current_device())
+                    attention_mask = attention_masks.to(torch.cuda.current_device())
+                    labels = labels.to(torch.cuda.current_device())
+                else:
+                    inputs, attention_masks, packed_seq_lens, labels = data
+                    inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
+                    attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
+                    labels = labels.to(torch.cuda.current_device()).squeeze(1)
+
+                output = self.model(
+                    inputs,
+                    attention_mask=attention_mask,
+                    return_output=True,
+                    ring_attn_group=self.strategy.ring_attn_group,
+                    packed_seq_lens=packed_seq_lens,
+                )
+
+                loss, acc = self.loss_fn(inputs, output.logits, labels, return_acc=True)
+
+                times += 1
+                loss_sum += loss.item()
+                acc_sum += acc.item()
+                bar_dict = {"eval prm_loss": loss_sum / times, "eval acc": acc_sum / times}
+                step_bar.update()
+                logs = self.strategy.all_reduce(bar_dict)
+                step_bar.set_postfix(logs)
+
+            if self._wandb is not None and self.strategy.is_rank_0():
+                logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
+                self._wandb.log(logs)
+        self.model.train()  # reset model state

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -120,3 +120,12 @@ def blending_datasets(
         return train_dataset, eval_dataset
     else:
         return train_dataset
+
+
+def convert_token_to_id(token, tokenizer):
+    if isinstance(token, str):
+        token = tokenizer.encode(token, add_special_tokens=False)
+        assert len(token) == 1
+        return token[0]
+    else:
+        raise ValueError("token should be int or str")


### PR DESCRIPTION
This is an attempt to add process reward model (PRM) training. Currently I'm focusing on training with hard estimation loss in [Math-Shepherd](https://arxiv.org/abs/2312.08935) with its open sourced data [peiyi9979/Math-Shepherd](https://huggingface.co/datasets/peiyi9979/Math-Shepherd) and [mistral-7B](https://huggingface.co/mistralai/Mistral-7B-v0.1) (the same as [peiyi9979/math-shepherd-mistral-7b-prm](https://huggingface.co/peiyi9979/math-shepherd-mistral-7b-prm) ).

The current testing script is:
```bash
deepspeed --module openrlhf.cli.train_prm \
   --save_path ./checkpoint/mistal-7b-prm \
   --save_steps 500 \
   --logging_steps 1 \
   --eval_steps 100 \
   --train_batch_size 256 \
   --micro_train_batch_size 8 \
   --pretrain mistralai/Mistral-7B-v0.1  \
   --bf16 \
   --max_epochs 1 \
   --max_len 8192 \
   --zero_stage 3 \
   --learning_rate 1e-6 \
   --dataset peiyi9979/Math-Shepherd \
   --input_key input \
   --label_key label \
   --flash_attn \
   --load_checkpoint \
   --gradient_checkpointing \
   --packing_samples \
   --wandb_group prm \
   --placeholder_token "ки" \
   --reward_tokens "+" "-"
```

Note that the hyperparams are set casually, without reference (except the epoch and lr are the same as the paper). The resulting wandb is: https://wandb.ai/zhuzilin/openrlhf_train_prm/workspace