### PR TITLE
Fix lm_head.weight in save_model

### DIFF
--- a/openrlhf/utils/deepspeed.py
+++ b/openrlhf/utils/deepspeed.py
@@ -324,7 +324,7 @@ class DeepspeedStrategy(ABC):
             output_state_dict_keys = set(output_state_dict.keys())
 
             # corner case for tie_word_embeddings, such as Qwen2-0.5B
-            if getattr(model_to_save.config, "tie_word_embeddings", False):
+            if getattr(model_to_save.config, "tie_word_embeddings", False) and "lm_head.weight" in state_dict_keys:
                 state_dict_keys.remove("lm_head.weight")
 
             assert state_dict_keys.issubset(


### PR DESCRIPTION
Sometimes the model to be saved has no `lm_head.weight` but with `True` `tie_word_embeddings` in model config.

For example, when training a reward model, the `lm_head` of pretrained model is discarded and a `value_head` is appended to the base model.

Therefore, `lm_head.weight` should be removed only when it exists in the model config.