### PR TITLE
[BUG] fix _max_steps not initialized bug

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -132,6 +132,8 @@ def train(args):
         for reward_model, reward_pretrain in zip(reward_models, reward_pretrains):
             refs.extend(reward_model.async_init_model_from_pretrained(strategy, reward_pretrain))
 
+    ray.get(refs)
+
     # init vLLM engine for text generation
     vllm_engines = None
     if args.vllm_num_engines is not None and args.vllm_num_engines > 0:


### PR DESCRIPTION
When I do RLHF task it occured an attribute not found bug due to `_max_steps` may not be initialized before using it.
<img width="1892" alt="image" src="https://github.com/user-attachments/assets/8029c0d4-21d3-49c9-a111-0ea0ac76da37">

reproduce:
```bash
bash OpenRLHF/examples/scripts/train_ppo_llama_ray.sh
```
