### PR TITLE
Change pg_options param into backend_options in _new_process_group_helper for PyTorch version greater than 2.6

### DIFF
--- a/openrlhf/utils/distributed_util.py
+++ b/openrlhf/utils/distributed_util.py
@@ -53,6 +53,10 @@ def init_process_group(
         # different systems (e.g. RPC) in case the store is multi-tenant.
         store = PrefixStore(group_name, store)
 
+    # NOTE: The pg_options parameter was renamed into backend_options in PyTorch 2.6.0
+    # https://github.com/pytorch/pytorch/commit/a0c7029a75628cd5fa8df83c0de0ea98ee7fd844
+    # We need to determine the appropriate parameter name based on PyTorch version
+    pg_options_param_name = "backend_options" if str(torch.__version__) >= "2.6" else "pg_options"
     pg, _ = _new_process_group_helper(
         world_size,
         rank,
@@ -60,7 +64,7 @@ def init_process_group(
         backend,
         store,
         group_name=group_name,
-        pg_options=pg_options,
+        **{pg_options_param_name: pg_options},
         timeout=timeout,
     )
 


### PR DESCRIPTION
As per changes at PyTorch side:
https://github.com/pytorch/pytorch/commit/a0c7029a75628cd5fa8df83c0de0ea98ee7fd844

```bash
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/rlhf/OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 355, in <module>
    train(args)
  File "/rlhf/OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 161, in train
    ray.get(refs)
  File "/rlhf/venv/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 22, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/rlhf/venv/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/rlhf/venv/lib/python3.11/site-packages/ray/_private/worker.py", line 2624, in get
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(TypeError): [36mray::ActorModelRayActor.fit()[39m (pid=12538, ip=10.253.57.158, actor_id=b20df983be503aac7b1c760903000000, repr=<openrlhf.trainer.ray.ppo_actor.ActorModelRayActor object at 0x147b9d7539d0>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/rlhf/OpenRLHF/openrlhf/trainer/ray/ppo_actor.py", line 341, in fit
    trainer = ActorPPOTrainer(
              ^^^^^^^^^^^^^^^^
  File "/rlhf/OpenRLHF/openrlhf/trainer/ray/ppo_actor.py", line 105, in __init__
    self._model_update_group = init_process_group(
                               ^^^^^^^^^^^^^^^^^^^
  File "/rlhf/OpenRLHF/openrlhf/utils/distributed_util.py", line 56, in init_process_group
    pg, _ = _new_process_group_helper(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: _new_process_group_helper() got an unexpected keyword argument 'pg_options'
```