### PR TITLE
Move the n_samples_per_prompt into replay buffer

### DIFF
--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -139,7 +139,9 @@ def train(args):
         )
         pretrain_max_len = args.max_len if args.max_len else args.prompt_max_len + args.generate_max_len
         pretrain_dataset = SFTDataset(
-            pretrain_data.select(range(min(len(pretrain_data), args.max_epochs * len(prompts_dataset)))),
+            pretrain_data.select(
+                range(min(len(pretrain_data), args.max_epochs * len(prompts_dataset) * args.n_samples_per_prompt))
+            ),
             tokenizer,
             pretrain_max_len,
             strategy,
@@ -166,7 +168,9 @@ def train(args):
         pretrain_dataloader = None
 
     # configure scheduler
-    num_update_steps_per_episodes = len(prompts_dataset) // args.train_batch_size * args.max_epochs
+    num_update_steps_per_episodes = (
+        len(prompts_dataset) * args.n_samples_per_prompt // args.train_batch_size * args.max_epochs
+    )
     max_steps = math.ceil(args.num_episodes * num_update_steps_per_episodes)
 
     actor_scheduler = get_scheduler(

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -147,7 +147,9 @@ def train(args):
         )
 
     # prepare dataloader
-    prompts_dataloader = strategy.setup_dataloader(prompts_dataset, args.micro_rollout_batch_size, True, True)
+    prompts_dataloader = strategy.setup_dataloader(
+        prompts_dataset, args.rollout_batch_size // strategy.world_size, True, True
+    )
     if args.pretrain_data:
         pretrain_dataloader = itertools.cycle(
             iter(

--- a/openrlhf/datasets/prompts_dataset.py
+++ b/openrlhf/datasets/prompts_dataset.py
@@ -5,7 +5,10 @@ from .utils import exist_and_not_none
 
 def preprocess_data(data, input_template=None, input_key="input", apply_chat_template=None) -> str:
     if apply_chat_template:
-        prompt = apply_chat_template(data[input_key], tokenize=False, add_generation_prompt=True)
+        chat = data[input_key]
+        if isinstance(chat, str):
+            chat = [{"role": "user", "content": chat}]
+        prompt = apply_chat_template(chat, tokenize=False, add_generation_prompt=True)
     else:
         prompt = data[input_key]
         if input_template:
@@ -33,7 +36,6 @@ class PromptDataset(Dataset):
         super().__init__()
         self.strategy = strategy
         self.tokenizer = tokenizer
-        self.n_samples_per_prompt = getattr(self.strategy.args, "n_samples_per_prompt", 1)
 
         # chat_template
         self.input_template = input_template
@@ -50,7 +52,7 @@ class PromptDataset(Dataset):
 
     def __len__(self):
         length = len(self.prompts)
-        return length * self.n_samples_per_prompt
+        return length
 
     def __getitem__(self, idx):
-        return self.prompts[idx // self.n_samples_per_prompt]
+        return self.prompts[idx]

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -1,6 +1,6 @@
 import math
-import os.path
 import os
+import os.path
 from abc import ABC
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -185,7 +185,6 @@ class PPOTrainer(ABC):
         num_rollouts_per_episodes = (
             num_update_steps_per_episodes * args.train_batch_size // args.max_epochs // args.rollout_batch_size
         )
-        update_timesteps = args.rollout_batch_size // (self.strategy.world_size * self.micro_rollout_batch_size)
 
         # get eval and save steps
         if args.eval_steps == -1:
@@ -197,7 +196,7 @@ class PPOTrainer(ABC):
         self.pretrain_dataloader = pretrain_dataloader
 
         # Restore step and start_epoch
-        steps = consumed_samples // args.rollout_batch_size * update_timesteps + 1
+        steps = consumed_samples // args.rollout_batch_size + 1
         start_episode = consumed_samples // args.rollout_batch_size // num_rollouts_per_episodes
         consumed_samples = consumed_samples % (num_rollouts_per_episodes * args.rollout_batch_size)
 
@@ -213,31 +212,31 @@ class PPOTrainer(ABC):
             )
 
             for rand_prompts in self.prompts_dataloader:
-                experience = self.experience_maker.make_experience(rand_prompts, **self.generate_kwargs)
-                # print prompt/answer in each update step
-                if steps % update_timesteps == 0:
-                    output = self.tokenizer.batch_decode(
-                        experience.sequences[0].unsqueeze(0), skip_special_tokens=True
-                    )
+                rand_prompts = sum([[prompt] * args.n_samples_per_prompt for prompt in rand_prompts], [])
+                for i in range(0, len(rand_prompts), args.micro_rollout_batch_size):
+                    prompts = rand_prompts[i : i + args.micro_rollout_batch_size]
+                    experience = self.experience_maker.make_experience(prompts, **self.generate_kwargs)
+                    if i == 0:
+                        # print prompt/answer in each update step
+                        output = self.tokenizer.batch_decode(
+                            experience.sequences[0].unsqueeze(0), skip_special_tokens=True
+                        )
                     self.strategy.print(output)
-                self.replay_buffer.append(experience)
+                    self.replay_buffer.append(experience)
 
-                if steps % update_timesteps == 0:
-                    global_steps = steps // update_timesteps
+                torch.cuda.empty_cache()
+                self.replay_buffer.normalize("advantages", self.strategy)
+                status = self.ppo_train(steps)
+                self.replay_buffer.clear()
+                torch.cuda.empty_cache()
 
-                    torch.cuda.empty_cache()
-                    self.replay_buffer.normalize("advantages", self.strategy)
-                    status = self.ppo_train(global_steps)
-                    self.replay_buffer.clear()
-                    torch.cuda.empty_cache()
+                if "kl" in status:
+                    self.kl_ctl.update(status["kl"], args.rollout_batch_size)
+                pbar.set_postfix(status)
 
-                    if "kl" in status:
-                        self.kl_ctl.update(status["kl"], args.rollout_batch_size)
-                    pbar.set_postfix(status)
-
-                    # logs/checkpoints
-                    client_states = {"consumed_samples": global_steps * args.rollout_batch_size}
-                    self.save_logs_and_checkpoints(args, global_steps, pbar, status, client_states)
+                # logs/checkpoints
+                client_states = {"consumed_samples": steps * args.rollout_batch_size}
+                self.save_logs_and_checkpoints(args, steps, pbar, status, client_states)
 
                 pbar.update()
                 steps = steps + 1

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -229,7 +229,9 @@ class ActorModelRayActor(BasePPORole):
         self.prepare_datasets()
 
         # configure scheduler
-        self.num_update_steps_per_episodes = len(self.prompts_dataset) // args.train_batch_size * args.max_epochs
+        self.num_update_steps_per_episodes = (
+            len(self.prompts_dataset) * args.n_samples_per_prompt // args.train_batch_size * args.max_epochs
+        )
         max_steps = math.ceil(args.num_episodes * self.num_update_steps_per_episodes)
         self._max_steps = max_steps
 
@@ -299,7 +301,13 @@ class ActorModelRayActor(BasePPORole):
             )
             pretrain_max_len = args.max_len if args.max_len else args.prompt_max_len + args.generate_max_len
             pretrain_dataset = SFTDataset(
-                pretrain_data.select(range(min(len(pretrain_data), args.max_epochs * len(self.prompts_dataset)))),
+                pretrain_data.select(
+                    range(
+                        min(
+                            len(pretrain_data), args.max_epochs * len(self.prompts_dataset) * args.n_samples_per_prompt
+                        )
+                    )
+                ),
                 self.tokenizer,
                 pretrain_max_len,
                 strategy,

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -285,7 +285,7 @@ class ActorModelRayActor(BasePPORole):
             prompts_data, self.tokenizer, strategy, input_template=args.input_template
         )
         self.prompts_dataloader = strategy.setup_dataloader(
-            self.prompts_dataset, args.micro_rollout_batch_size, True, True
+            self.prompts_dataset, args.rollout_batch_size // strategy.world_size, True, True
         )
 
         if args.pretrain_data:


### PR DESCRIPTION
This PR is trying to change the behavior of `n_samples_per_prompt`. The old behavior is similar to increase epoch, while the new behavior is repetitively sample the same prompt within the same reply buffer.

This is also an preparation for normalizing the reward as GRPO and separate the generation batch size and `rollout_batch_size` for ref model and critic model.

This is a testing wandb for loading checkpoint:
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/8442855e-9760-495d-a449-d837221ebf6a">

The unmatch part is due to the randomness of vllm sampling.

Thank you for your time on reviewing this PR :)