### PR TITLE
Separate the rollout generation and advantage calculation

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -216,10 +216,9 @@ class PPOTrainer(ABC):
             )
 
             for rand_prompts in self.prompts_dataloader:
-                rand_prompts = sum([[prompt] * args.n_samples_per_prompt for prompt in rand_prompts], [])
-                for i in range(0, len(rand_prompts), args.micro_rollout_batch_size):
-                    prompts = rand_prompts[i : i + args.micro_rollout_batch_size]
-                    experience = self.experience_maker.make_experience(prompts, **self.generate_kwargs)
+                for i, experience in enumerate(
+                    self.experience_maker.make_experience_list(rand_prompts, **self.generate_kwargs)
+                ):
                     if i == 0:
                         output = self.tokenizer.batch_decode(
                             experience.sequences[0].unsqueeze(0), skip_special_tokens=True


### PR DESCRIPTION
This PR is trying to turn `make_experience` into 3 steps:

1. Generate the responses from prompts and get the reward score from reward models.
2. Process all the reward values of a whole rollout, e.g. normalize them as in the the GRPO paper, or filter the samples as in PF-PPO.
3. Calculate the advantages and returns with the processed samples.

Here is the comparison with `--packing_samples` (pink line is this PR, blue is the old code):
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/657e5376-4fe8-4b4a-adcb-100ef6e172e6">

Here is the comparison without `--packing_samples`:
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/6896816b-2ccb-4cf7-af6e-10734c67ad18">

Thank you for your time on reviewing this PR:)

---

The above 2 experiments are run with shuffle disabled (both the prompt dataloader and the replay buffer dataloader are set with `shuffle=False`). That's the reason of the anormalies in the training process.

With `shuffle=True`, I rerun the experiments with `--packing_samples`, and the results is (dark red line is this PR with shuffle, grey line is the old code with shuffle):

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/61456b3e-621c-4bae-bc6b-709a07deed90">
