### PR TITLE
 remove unnecessary softmax in prm loss

### DIFF
--- a/examples/scripts/train_prm_mistral.sh
+++ b/examples/scripts/train_prm_mistral.sh
@@ -1,5 +1,7 @@
+set -x
 
-deepspeed --module openrlhf.cli.train_prm \
+read -r -d '' training_commands <<EOF
+openrlhf.cli.train_prm \
    --save_path ./checkpoint/mistal-7b-prm \
    --save_steps 500 \
    --logging_steps 1 \
@@ -20,5 +22,13 @@ deepspeed --module openrlhf.cli.train_prm \
    --gradient_checkpointing \
    --packing_samples \
    --wandb_group prm \
-   --placeholder_token "ки" \
-   --reward_tokens "+" "-"
+   --placeholder_token ки \
+   --reward_tokens + -
+EOF
+     # --use_wandb [WANDB_TOKENS] or True (use wandb login command)
+     # --packing_samples
+
+
+if [[ ${1} != "slurm" ]]; then
+    deepspeed --module $training_commands
+fi

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -274,7 +274,6 @@ class PRMLoss(nn.Module):
         labels = labels[placeholder_mask]
         if self.reward_token_ids is not None:
             logits = logits[..., self.reward_token_ids]
-            logits = logits.softmax(dim=-1)
             # this is bad....
             for i, token in enumerate(self.reward_token_ids):
                 labels = torch.where(labels == token, i, labels)


### PR DESCRIPTION
Two consecutive softmax operations can cause some negative effects, while a normal single softmax would perform better (and won't lead to any crashes; in fact, there is no fundamental difference between one softmax and two softmax operations). As for the specific impact of using two softmax operations, I will explain it in detail in a future blog. Essentially, it functions in a way similar to a temperature coefficient.