### PR TITLE
Replace deprecated/removed transformers.deepspeed module

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from peft import LoraConfig, TaskType, get_peft_model
 from peft.tuners.lora import LoraLayer
 from transformers import AutoModelForCausalLM, BitsAndBytesConfig, PreTrainedModel
-from transformers.deepspeed import HfDeepSpeedConfig
+from transformers.integrations.deepspeed import HfDeepSpeedConfig
 
 from .ring_attn_utils import convert_ring_attn_params
 from .utils import log_probs_from_logits, reset_position_ids

--- a/openrlhf/models/model.py
+++ b/openrlhf/models/model.py
@@ -8,7 +8,7 @@ from flash_attn.utils.distributed import all_gather
 from peft import LoraConfig, get_peft_model
 from peft.tuners.lora import LoraLayer
 from transformers import AutoConfig, AutoModel, BitsAndBytesConfig
-from transformers.deepspeed import HfDeepSpeedConfig
+from transformers.integrations.deepspeed import HfDeepSpeedConfig
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 
 from openrlhf.utils.logging_utils import init_logger


### PR DESCRIPTION
In latest transformers version 4.46.1, transformers.deepspeed has officially been removed, while for the current version 4.44.2 OpenRLHF is using, it generates the warning. So it's better to update the code immediately.

venv/lib/python3.10/site-packages/transformers/deepspeed.py:23: FutureWarning: transformers.deepspeed module is deprecated and will be removed in a future version. Please import deepspeed modules directly from transformers.integrations
  warnings.warn(
