### PR TITLE
Support PRM with soft labels and change PRM dataset format

### DIFF
--- a/examples/scripts/train_prm_mistral.sh
+++ b/examples/scripts/train_prm_mistral.sh
@@ -14,9 +14,9 @@ openrlhf.cli.train_prm \
    --max_len 8192 \
    --zero_stage 3 \
    --learning_rate 1e-6 \
-   --dataset peiyi9979/Math-Shepherd \
+   --dataset zhuzilin/Math-Shepherd \
    --input_key input \
-   --label_key label \
+   --label_key value \
    --flash_attn \
    --load_checkpoint \
    --gradient_checkpointing \

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -163,8 +163,6 @@ if __name__ == "__main__":
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
     parser.add_argument("--placeholder_token", type=str, default=None)
-    parser.add_argument("--positive_token", type=str, default=None)
-    parser.add_argument("--negative_token", type=str, default=None)
     parser.add_argument("--reward_tokens", type=str, nargs="*", default=None)
 
     # packing samples using Flash Attention2
@@ -196,12 +194,10 @@ if __name__ == "__main__":
 
     # Add positive token and negative token to reward_tokens and remove duplicates
     if args.reward_tokens is not None:
-        reward_tokens = args.reward_tokens
-        if args.positive_token is not None:
-            args.reward_tokens.append(args.positive_token)
-        if args.negative_token is not None:
-            args.reward_tokens.append(args.negative_token)
-        reward_tokens = list(set(reward_tokens))
-        args.reward_tokens = reward_tokens
+        print(
+            "If you are running with soft labels (float values), "
+            f"the first token in reward_tokens ({args.reward_tokens[0]}) should be the positive token "
+            "and the second token should be the negative token."
+        )
 
     train(args)

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -163,6 +163,8 @@ if __name__ == "__main__":
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
     parser.add_argument("--placeholder_token", type=str, default=None)
+    parser.add_argument("--positive_token", type=str, default=None)
+    parser.add_argument("--negative_token", type=str, default=None)
     parser.add_argument("--reward_tokens", type=str, nargs="*", default=None)
 
     # packing samples using Flash Attention2
@@ -191,5 +193,15 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+
+    # Add positive token and negative token to reward_tokens and remove duplicates
+    if args.reward_tokens is not None:
+        reward_tokens = args.reward_tokens
+        if args.positive_token is not None:
+            args.reward_tokens.append(args.positive_token)
+        if args.negative_token is not None:
+            args.reward_tokens.append(args.negative_token)
+        reward_tokens = list(set(reward_tokens))
+        args.reward_tokens = reward_tokens
 
     train(args)

--- a/openrlhf/datasets/process_reward_dataset.py
+++ b/openrlhf/datasets/process_reward_dataset.py
@@ -67,7 +67,7 @@ class ProcessRewardDataset(Dataset):
             label_tokens = []
             for label in label_values:
                 assert (
-                    label in self.reward_tokens
+                    self.reward_tokens is None or label in self.reward_tokens
                 ), f"label should be in reward tokens {self.reward_tokens}, got {label}"
                 label_tokens.append(convert_token_to_id(label, self.tokenizer))
 

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -261,20 +261,12 @@ class PRMLoss(nn.Module):
     Process Reward Model Loss
     """
 
-    def __init__(
-        self,
-        placeholder_token_id: int,
-        reward_token_ids: Optional[list[int]] = None,
-        positive_token_id: Optional[int] = None,
-        negative_token_id: Optional[int] = None,
-    ):
+    def __init__(self, placeholder_token_id: int, reward_token_ids: Optional[list[int]] = None):
         super().__init__()
         self.IGNORE_INDEX = -100
         self.loss = nn.CrossEntropyLoss(ignore_index=self.IGNORE_INDEX)
         self.placeholder_token_id = placeholder_token_id
         self.reward_token_ids = reward_token_ids
-        self.positive_token_id = positive_token_id
-        self.negative_token_id = negative_token_id
 
     def forward(self, inputs: torch.Tensor, logits: torch.Tensor, labels: torch.Tensor, *, return_acc: bool = False):
         placeholder_mask = inputs == self.placeholder_token_id
@@ -282,14 +274,17 @@ class PRMLoss(nn.Module):
         labels = labels[placeholder_mask]
 
         if labels.dtype == torch.float:
-            logits = logits[..., [self.positive_token_id, self.negative_token_id]]
+            # soft label
+            assert len(self.reward_token_ids) == 2, "reward_token_ids should have 2 tokens for soft labels"
+            logits = logits[..., self.reward_token_ids]
             positive_labels = labels.to(logits.dtype)
             negative_labels = 1 - positive_labels
             negative_labels[positive_labels != -100] = 1 - positive_labels[positive_labels != -100]
             labels = torch.stack([positive_labels, negative_labels], dim=-1)
         elif self.reward_token_ids is not None:
+            # hard label with reward_token_ids set. (otherwise the whole vocab will be trained together.)
             logits = logits[..., self.reward_token_ids]
-            # this is bad....
+            # this is slow....
             for i, token in enumerate(self.reward_token_ids):
                 labels = torch.where(labels == token, i, labels)
 

--- a/openrlhf/trainer/prm_trainer.py
+++ b/openrlhf/trainer/prm_trainer.py
@@ -56,19 +56,10 @@ class ProcessRewardModelTrainer(ABC):
         self.placeholder_token_id = convert_token_to_id(strategy.args.placeholder_token, self.tokenizer)
         self.reward_token_ids = self.args.reward_tokens
         if self.reward_token_ids is not None:
-            self.reward_token_ids = sorted(
-                [convert_token_to_id(token, self.tokenizer) for token in self.reward_token_ids]
-            )
-        self.positive_token_id = convert_token_to_id(self.args.positive_token, self.tokenizer)
-        self.negative_token_id = convert_token_to_id(self.args.negative_token, self.tokenizer)
+            self.reward_token_ids = [convert_token_to_id(token, self.tokenizer) for token in self.reward_token_ids]
 
         self.ignore_index = -100
-        self.loss_fn = PRMLoss(
-            self.placeholder_token_id,
-            self.reward_token_ids,
-            self.positive_token_id,
-            self.negative_token_id,
-        )
+        self.loss_fn = PRMLoss(self.placeholder_token_id, self.reward_token_ids)
 
         # Mixtral 8*7b
         self.aux_loss = self.args.aux_loss_coef > 1e-8

--- a/openrlhf/trainer/prm_trainer.py
+++ b/openrlhf/trainer/prm_trainer.py
@@ -59,9 +59,16 @@ class ProcessRewardModelTrainer(ABC):
             self.reward_token_ids = sorted(
                 [convert_token_to_id(token, self.tokenizer) for token in self.reward_token_ids]
             )
+        self.positive_token_id = convert_token_to_id(self.args.positive_token, self.tokenizer)
+        self.negative_token_id = convert_token_to_id(self.args.negative_token, self.tokenizer)
 
         self.ignore_index = -100
-        self.loss_fn = PRMLoss(self.placeholder_token_id, self.reward_token_ids)
+        self.loss_fn = PRMLoss(
+            self.placeholder_token_id,
+            self.reward_token_ids,
+            self.positive_token_id,
+            self.negative_token_id,
+        )
 
         # Mixtral 8*7b
         self.aux_loss = self.args.aux_loss_coef > 1e-8

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -127,4 +127,5 @@ def convert_token_to_id(token, tokenizer):
         token = tokenizer.encode(token, add_special_tokens=False)
         assert len(token) == 1
         return token[0]
-    return None
+    else:
+        raise ValueError("token should be int or str")

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -127,5 +127,4 @@ def convert_token_to_id(token, tokenizer):
         token = tokenizer.encode(token, add_special_tokens=False)
         assert len(token) == 1
         return token[0]
-    else:
-        raise ValueError("token should be int or str")
+    return None


### PR DESCRIPTION
This PR introduces support for training Process Reward Models (PRM) with soft labels, allowing for continuous (float) labels instead of categorical (token) labels. It also updates the dataset format used by the PRM trainer.

The dataset I’m using to demonstrate this functionality is [HanningZhang/ER-PRM-Data](https://huggingface.co/datasets/HanningZhang/ER-PRM-Data), from the paper [Entropy-Regularized Process Reward Model](https://hanningzhang.github.io/math-prm/). The loss function for soft-labeled PRM remains consistent with the paper, using cross_entropy rather than MSE regression.

Here’s an example script to train with [HanningZhang/ER-PRM-Data](https://huggingface.co/datasets/HanningZhang/ER-PRM-Data). Note that the first token in `--reward_tokens` (in the following case `+`) will be used as the positive token and the second as the negative token:

```bash
deepspeed --module openrlhf.cli.train_prm \
   --save_path ./checkpoint/mistal-7b-prm \
   --save_steps 500 \
   --logging_steps 1 \
   --eval_steps 100 \
   --train_batch_size 256 \
   --micro_train_batch_size 8 \
   --pretrain mistralai/Mistral-7B-v0.1  \
   --bf16 \
   --max_epochs 1 \
   --max_len 8192 \
   --zero_stage 3 \
   --learning_rate 1e-6 \
   --dataset HanningZhang/ER-PRM-Data \
   --input_key text \
   --label_key value \
   --flash_attn \
   --load_checkpoint \
   --gradient_checkpointing \
   --packing_samples \
   --wandb_group prm \
   --placeholder_token ки \
   --reward_tokens + -
```

And the wandb is: https://wandb.ai/zhuzilin/openrlhf_train_prm/runs/8jccv08c?nw=nwuserzhuzilin

For the hard-labeled PRM, I’ve aligned its dataset format with the soft-labeled alternative for consistency. This includes reformatting the [peiyi9979/Math-Shepherd](https://huggingface.co/datasets/peiyi9979/Math-Shepherd) dataset by adding a value column. The modified version is available at [zhuzilin/Math-Shepherd](https://huggingface.co/datasets/zhuzilin/Math-Shepherd).

Here’s the code used to add the value column:

```python
from datasets import load_dataset, DatasetDict
from transformers import AutoTokenizer

dataset = load_dataset("peiyi9979/Math-Shepherd")["train"]
tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1")

placeholder_token = tokenizer.encode("ки", add_special_tokens=False)[0]
print("placeholder_token:", placeholder_token)

def add_value(sample):
    query_tokens = tokenizer(sample["input"], return_tensors="pt", add_special_tokens=False)["input_ids"]
    label_tokens = tokenizer(sample["label"], return_tensors="pt", add_special_tokens=False)["input_ids"]
    label_tokens = label_tokens[query_tokens == placeholder_token].tolist()
    values = [tokenizer.decode(token) for token in label_tokens]
    assert len(values) == sample["input"].count("ки")
    sample["value"] = values
    return sample

dataset = dataset.map(add_value, num_proc=8)
dataset = DatasetDict({"train": dataset})

dataset.push_to_hub("zhuzilin/Math-Shepherd")
```

With this updated format, the existing training script can still be used — only `--label_key value` needs to be set. Here’s an example script with the updated format:
```bash
deepspeed --module openrlhf.cli.train_prm \
   --save_path ./checkpoint/mistal-7b-prm \
   --save_steps 500 \
   --logging_steps 1 \
   --eval_steps 100 \
   --train_batch_size 256 \
   --micro_train_batch_size 8 \
   --pretrain mistralai/Mistral-7B-v0.1  \
   --bf16 \
   --max_epochs 1 \
   --max_len 8192 \
   --zero_stage 3 \
   --learning_rate 1e-6 \
   --dataset zhuzilin/Math-Shepherd \
   --input_key input \
   --label_key value \
   --flash_attn \
   --load_checkpoint \
   --gradient_checkpointing \
   --packing_samples \
   --wandb_group prm \
   --placeholder_token "ки" \
   --reward_tokens "+" "-"
```

with the wandb: https://wandb.ai/zhuzilin/openrlhf_train_prm/runs/g5acx5mf?nw=nwuserzhuzilin

Thank you for your time on this PR:) Special thanks to one of the dataset authors for his assistance!