### PR TITLE
Support RLOO

### DIFF
--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -357,9 +357,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--advantage_estimator",
         type=str,
-        choices=["gae", "reinforce"],
+        choices=["gae", "reinforce", "rloo"],
         default="gae",
-        help="Choose advantage estimation method: gae, reinforce",
+        help="Choose advantage estimation method: gae, reinforce, rloo",
     )
 
     # LoRA
@@ -422,6 +422,9 @@ if __name__ == "__main__":
             args.critic_pretrain = args.reward_pretrain
         else:
             args.critic_pretrain = args.pretrain
+
+    if args.advantage_estimator == "rloo":
+        assert args.n_samples_per_prompt > 1, "RLOO requires n_samples_per_prompt > 1"
 
     if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -298,9 +298,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--advantage_estimator",
         type=str,
-        choices=["gae", "reinforce"],
+        choices=["gae", "reinforce", "rloo"],
         default="gae",
-        help="Choose advantage estimation method: gae, reinforce",
+        help="Choose advantage estimation method: gae, reinforce, rloo",
     )
 
     #  Models
@@ -361,6 +361,9 @@ if __name__ == "__main__":
             args.critic_pretrain = args.reward_pretrain.split(",")[0]
         else:
             args.critic_pretrain = args.pretrain
+
+    if args.advantage_estimator == "rloo":
+        assert args.n_samples_per_prompt > 1, "RLOO requires n_samples_per_prompt > 1"
 
     if args.remote_rm_url:
         args.remote_rm_url = args.remote_rm_url.split(",")

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -187,13 +187,13 @@ class NaiveExperienceMaker(ABC):
         ):
             experiences.append(self.make_experience(samples))
 
-        experiences = self.process_experiences(experiences)
+        experiences, rewards = self.process_experiences(experiences)
 
         # calculate return and advantages
-        for experience in experiences:
+        for experience, reward in zip(experiences, rewards):
             num_actions = experience.info["num_actions"]
             reward = compute_reward(
-                experience.info["reward"],
+                reward,
                 self.kl_ctl.value,
                 experience.kl,
                 action_mask=experience.action_mask,
@@ -209,7 +209,7 @@ class NaiveExperienceMaker(ABC):
                     generate_kwargs["gamma"],
                     generate_kwargs["lambd"],
                 )
-            elif self.advantage_estimator == "reinforce":
+            elif self.advantage_estimator in ["reinforce", "rloo"]:
                 experience.returns = self.get_cumulative_returns(
                     reward,
                     experience.action_mask,
@@ -330,9 +330,23 @@ class NaiveExperienceMaker(ABC):
         )
 
     @torch.no_grad()
-    def process_experiences(self, experiences: List[Experience]) -> List[Experience]:
-        # TODO: add more methods to process experiences
-        return experiences
+    def process_experiences(self, experiences: List[Experience]) -> Tuple[List[Experience], List[torch.Tensor]]:
+        """
+        Process experiences, this can be used to filter out some experiences or do some processing on the rewards.
+
+        Output:
+        - experiences: List of Experience
+        - rewards: List of rewards
+        """
+        args = self.strategy.args
+        if args.advantage_estimator == "rloo":
+            rewards = torch.cat([experience.info["reward"] for experience in experiences])
+            rewards = rewards.reshape(-1, args.n_samples_per_prompt)
+            baseline = (rewards.sum(-1, keepdim=True) - rewards) / (args.n_samples_per_prompt - 1)
+            rewards = rewards - baseline
+            rewards = rewards.flatten().chunk(len(experiences))
+            return experiences, rewards
+        return experiences, [experience.info["reward"] for experience in experiences]
 
     @torch.no_grad()
     def get_advantages_and_returns(


### PR DESCRIPTION
This PR brings in RLOO (REINFORCE Leave-One-Out), using an approach similar to the one in [TRL](https://github.com/huggingface/trl/blob/0238d96c6f43abd808804ddb0065883964073060/trl/trainer/rloo_trainer.py#L386).

One thing to note: I didn’t change `experience.info["reward"]` in place. This way, wandb still logs the actual reward values, which makes it easier to compare results across different algorithms.

Thank you for your time on reviewing this PR:)