### PR TITLE
Raise warning on faulty input template

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ deepspeed --module openrlhf.cli.train_sft \
    --dataset Open-Orca/OpenOrca \
    --input_key question \
    --output_key response \
-   --input_template 'User: {}\nAssistant: ' \
+   --input_template $'User: {}\nAssistant: ' \
    --train_batch_size 256 \
    --micro_train_batch_size 2 \
    --max_samples 500000 \

--- a/README_zh.md
+++ b/README_zh.md
@@ -172,7 +172,7 @@ deepspeed --module openrlhf.cli.train_sft \
    --dataset Open-Orca/OpenOrca \
    --input_key question \
    --output_key response \
-   --input_template 'User: {}\nAssistant: ' \
+   --input_template $'User: {}\nAssistant: ' \
    --train_batch_size 256 \
    --micro_train_batch_size 2 \
    --max_samples 500000 \

--- a/openrlhf/cli/interactive_chat.py
+++ b/openrlhf/cli/interactive_chat.py
@@ -114,5 +114,13 @@ if __name__ == "__main__":
     parser.add_argument("--csft_prompt", type=str, default="<rm_score>: 5.00", help="conditional SFT prompt")
     args = parser.parse_args()
 
+    if args.input_template and "{}" not in args.input_template:
+        print("[Warning] {} not in args.input_template, set to None")
+        args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
+
     print(args)
     generate(args)

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -255,9 +255,13 @@ if __name__ == "__main__":
     if args.ref_pretrain is None or args.ref_pretrain == "":
         args.ref_pretrain = args.pretrain
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
 
     if args.packing_samples and not args.flash_attn:
         print("[Warning] Please --flash_attn to accelerate when --packing_samples is enabled.")

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -217,4 +217,13 @@ if __name__ == "__main__":
     parser.add_argument("--use_tensorboard", type=str, default=None, help="TensorBoard logging path")
 
     args = parser.parse_args()
+
+    if args.input_template and "{}" not in args.input_template:
+        print("[Warning] {} not in args.input_template, set to None")
+        args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
+
     train(args)

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -210,7 +210,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
+
     train(args)

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -423,7 +423,12 @@ if __name__ == "__main__":
         else:
             args.critic_pretrain = args.pretrain
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
+
     train(args)

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -369,9 +369,13 @@ if __name__ == "__main__":
         args.enable_prefix_caching = False
         print("[Warning] Disable prefix cache because vLLM updates weights without updating the old KV Cache.")
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
 
     if args.packing_samples:
         if not args.flash_attn:

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -236,9 +236,13 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
 
     if args.packing_samples and not args.flash_attn:
         print("[Warning] Please --flash_attn to accelerate when --packing_samples is enabled.")

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -214,9 +214,13 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    if args.input_template and not "{}" in args.input_template:
+    if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")
         args.input_template = None
+
+    if args.input_template and '\\n' in args.input_template:
+        print("[Warning] input_template contains \\n chracters instead of newline. "
+              "You likely want to pass $'\\n' in Bash or \"`n\" in PowerShell.")
 
     if args.packing_samples and not args.flash_attn:
         print("[Warning] Please --flash_attn to accelerate when --packing_samples is enabled.")


### PR DESCRIPTION
Passing `--input_template '\n'` as an arg in Bash/Zsh passes the string '\\n' to Python (2 characters), rather than a new line character. The correct syntax is: `--input_template $'\n'`

This likely leads to confusion (see: it's wrong in the docs & README).

I've made the CLI modules raise an explicit warning & updated the docs.

I'll open a separate PR for the OpenRLHF-Docs repo