### PR TITLE
Fix server_rm hanging on long input

### DIFF
--- a/openrlhf/cli/serve_rm.py
+++ b/openrlhf/cli/serve_rm.py
@@ -17,10 +17,10 @@ def strip_sequence(text, pad_token, eos_token):
     pad_token_escaped = re.escape(pad_token)
     eos_token_escaped = re.escape(eos_token)
 
-    pattern = f"({eos_token_escaped}|{pad_token_escaped})+$"
+    pattern = f"^({eos_token_escaped}|{pad_token_escaped})+"
     text = re.sub(pattern, "", text)
 
-    pattern = f"^({eos_token_escaped}|{pad_token_escaped})+"
+    pattern = f"({eos_token_escaped}|{pad_token_escaped})+$"
     text = re.sub(pattern, "", text)
     return text
 


### PR DESCRIPTION
Stripping trailing tokens was scaling O(n^2) w.r.t. leading tokens, making it effectively hang forever on sufficiently long input:

```py
# will take days to run
text = '<|eot_id|>' * 1000 + 'text' + '<|eot_id|>'
print(serve_rm.strip_sequence(text, '<|eot_id|>', '<|eot_id|>'))
```

Stripping leading tokens first solves it.