### PR TITLE
Add support when RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -5,10 +5,15 @@ import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from openrlhf.utils import ray_noset_visible_devices
+
 from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+@ray.remote
+def get_all_env_variables():
+    return os.environ
 
 @ray.remote
 class LLMRayActor:
@@ -18,7 +23,7 @@ class LLMRayActor:
         self.__version__ = vllm.__version__
         assert self.__version__ >= "0.4.1", "OpenRLHF only supports vLLM >= 0.4.1"
 
-        self.use_gpu_executor = kwargs["tensor_parallel_size"] == 1
+        self.use_gpu_executor = kwargs["tensor_parallel_size"] == 1 and not ray_noset_visible_devices()
 
         # See https://github.com/vllm-project/vllm/blob/main/vllm/executor/gpu_executor.py
         if self.use_gpu_executor:
@@ -83,12 +88,17 @@ def create_vllm_engines(
     max_model_len: int,
 ):
     vllm_engines = []
+    # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES will always be set in current context,
+    # So we need to get env variables from ray process to check if it is set.
+    noset_visible_devices = ray_noset_visible_devices(ray.get(get_all_env_variables.remote()))
     for i in range(num_engines):
-        # When tensor_parallel_size=1, vLLM init model in LLMEngine directly, assign 1 GPU for it.
-        num_gpus = int(tensor_parallel_size == 1)
+        # When tensor_parallel_size=1 and RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is not set
+        # (vLLM mp backend will work smoothly only when *_VISIBLE_DEVICES is modified),
+        # vLLM init model in LLMEngine directly, assign 1 GPU for it.
+        num_gpus = int(tensor_parallel_size == 1 and not noset_visible_devices)
         scheduling_strategy = None
 
-        if tensor_parallel_size > 1:
+        if tensor_parallel_size > 1 or noset_visible_devices:
             bundles = [{"GPU": 1, "CPU": 1}] * tensor_parallel_size
             pg = placement_group(bundles)
             ray.get(pg.ready())

--- a/openrlhf/utils/__init__.py
+++ b/openrlhf/utils/__init__.py
@@ -1,3 +1,3 @@
 from .deepspeed import DeepspeedStrategy
 from .processor import get_processor, reward_normalization
-from .utils import blending_datasets, get_strategy, get_tokenizer
+from .utils import blending_datasets, get_strategy, get_tokenizer, ray_noset_visible_devices

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -12,6 +12,27 @@ DEFAULT_BOS_TOKEN = "<s>"
 DEFAULT_UNK_TOKEN = "<unk>"
 
 
+def ray_noset_visible_devices(env_vars=os.environ):
+    # Refer to
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/npu.py#L94-L95
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/hpu.py#L116-L117
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/neuron.py#L108-L109
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/tpu.py#L171-L172
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/intel_gpu.py#L97-L98
+    NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
+        "RAY_EXPERIMENTAL_NOSET_NEURON_RT_VISIBLE_CORES",
+        "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
+        "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
+    ]
+    return any(env_vars.get(env_var) for env_var in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST)
+
+
 def get_tokenizer(pretrain, model, padding_side="left", strategy=None, use_fast=True):
     tokenizer = AutoTokenizer.from_pretrained(pretrain, trust_remote_code=True, use_fast=use_fast)
     tokenizer.padding_side = padding_side


### PR DESCRIPTION
RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is used for overriding the auto setting of *_VISIBLE_DEVICES for each actor. This commit address the 2 issues when the flag is set:

1. LOCAL_RANK should reflect the actual value instead of "0", to select the correct GPU.
2. vLLM workers should be forced to use ray even if tensor_parallel_size is 1, as "mp" distributed executor backend won't work correctly when *_VISIBLE_DEVICES is not properly set.

Setting RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES flag is neccessary to get OpenRLHF running on AMD GPUs when ray >= 2.10.0 (Referring to https://github.com/vllm-project/vllm/blob/v0.6.4.post1/Dockerfile.rocm#L131-L132)

PS: We also need the following flag to get this working properly:

```
export VLLM_USE_RAY_SPMD_WORKER=1
export VLLM_USE_RAY_COMPILED_DAG=1
```

If without setting RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES, the
error log is as follows:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 396, in <module>
    train(args)
  File "OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 146, in train
    ray.get(refs)
  File "venv/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/worker.py", line 2753, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/worker.py", line 904, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(DeferredCudaCallError): mray::RewardModelRayActor.init_model_from_pretrained()(repr=<openrlhf.trainer.ray.launcher.RewardModelRayActor object>)
  File "venv/lib/python3.11/site-packages/torch/cuda/random.py", line 126, in cb
    default_generator = torch.cuda.default_generators[i]
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

ray::RewardModelRayActor.init_model_from_pretrained()[(repr=<openrlhf.trainer.ray.launcher.RewardModelRayActor object>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 110, in init_model_from_pretrained
    self._setup_distributed(strategy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 58, in _setup_distributed
    strategy.setup_distributed()
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 87, in setup_distributed
    torch.cuda.set_device(self.args.local_rank)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 478, in set_device
    torch._C._cuda_setDevice(device)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 338, in _lazy_init
    raise DeferredCudaCallError(msg) from e
torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with error: tuple index out of range

CUDA call was originally invoked at:

  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 110, in init_model_from_pretrained
    self._setup_distributed(strategy)
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 58, in _setup_distributed
    strategy.setup_distributed()
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 81, in setup_distributed
    self.set_seed(self.seed)
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 78, in set_seed
    torch.cuda.manual_seed_all(seed)
  File "venv/lib/python3.11/site-packages/torch/cuda/random.py", line 129, in manual_seed_all
    _lazy_call(cb, seed_all=True)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 256, in _lazy_call
    _lazy_seed_tracker.queue_seed_all(callable, traceback.format_stack())
```