### PR TITLE
Loosen dependency version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,12 @@ loralib
 optimum
 packaging
 peft
-ray[default]>=2.12.0
+ray[default]==2.39.0
 tensorboard
 torch
 torchmetrics
 tqdm
-transformers>=4.46.1
+transformers==4.46.3
 transformers_stream_generator
 wandb
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,12 +10,12 @@ loralib
 optimum
 packaging
 peft
-ray[default]==2.12.0
+ray[default]>=2.12.0
 tensorboard
 torch
 torchmetrics
 tqdm
-transformers==4.46.1
+transformers>=4.46.1
 transformers_stream_generator
 wandb
 wheel


### PR DESCRIPTION
Hi thanks for the library! It would be great if the dependency version requirements can be loosen a little. For example, the recently released transformers 4.46.2 has some nice things to have (e.g. this one https://github.com/huggingface/transformers/pull/34511).