### PR TITLE
[Relanding] Add support when RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,15 @@ ray job submit --address="http://127.0.0.1:8265" \
 > Do not set `--vllm_num_engines` means not using the vLLM engine.
 > You can also use ``setup_commands`` to let Ray automatically deploy the environment, such as `--runtime-env-json='{"setup_commands": ["pip install openrlhf[vllm]"]}'`.
 
+> [!NOTE]
+> If you want to run on AMD GPUs, or for whatever reason you encounter an error related to index out of range when deepspeed sets up the GPU devices, you can try to set the environment variable [`RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES`](openrlhf/trainer/ray/utils.py) as a workaround.
+>   ```bash
+>   # For NVIDIA GPUs:
+>   export RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
+>   # For AMD GPUs:
+>   export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+>   ```
+
 The launch scripts and documents for supported algorithms are in [example/scripts](./examples/scripts/) and [Documents - Usage](https://openrlhf.readthedocs.io/en/latest/usage.html)
 
 ## Performance

--- a/README_zh.md
+++ b/README_zh.md
@@ -328,6 +328,15 @@ ray job submit --address="http://127.0.0.1:8265" \
 > 不设置 `--vllm_num_engines` 则是不使用 vLLM engine。
 > 您也可以通过 ``setup_commands`` 让 Ray 自动初始化环境, 比如 `--runtime-env-json='{"setup_commands": ["pip install openrlhf[vllm]"]}'`
 
+> [!NOTE]
+> 如果您想在 AMD 显卡上运行，或者由于某种原因，在 deepspeed 设置显卡设备时遇到与索引超出范围相关的错误，您可以尝试设置环境变量 [`RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES`](openrlhf/trainer/ray/utils.py)。
+> ```bash
+> # 对于 NVIDIA 显卡:
+> export RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
+> # 对于 AMD 显卡:
+> export RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+> ```
+
 所有支持算法的启动脚本和文档在 [example/scripts](./examples/scripts/) 和 [Documents - Usage](https://openrlhf.readthedocs.io/en/latest/usage.html)
 
 

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -11,9 +11,10 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from openrlhf.models import Actor, get_llm_for_sequence_regression
 from openrlhf.utils import DeepspeedStrategy, get_tokenizer
 
+from openrlhf.trainer.ray.utils import ray_noset_visible_devices
 
 class DistributedTorchRayActor:
-    def __init__(self, world_size, rank, local_rank, master_addr, master_port):
+    def __init__(self, world_size, rank, master_addr, master_port):
         logging.basicConfig(
             format="%(asctime)s %(levelname)-8s %(message)s",
             level=logging.INFO,
@@ -21,17 +22,17 @@ class DistributedTorchRayActor:
         )
         self._world_size = world_size
         self._rank = rank
-        self._local_rank = local_rank
         self._master_addr = master_addr if master_addr else self._get_current_node_ip()
         self._master_port = master_port if master_port else self._get_free_port()
         os.environ["MASTER_ADDR"] = self._master_addr
         os.environ["MASTER_PORT"] = str(self._master_port)
         os.environ["WORLD_SIZE"] = str(self._world_size)
         os.environ["RANK"] = str(self._rank)
-        # NOTE: Ray will automatically set the CUDA_VISIBLE_DEVICES
-        # environment variable for each actor, so always set device to 0
-        # os.environ["LOCAL_RANK"] = str(self._local_rank)
-        os.environ["LOCAL_RANK"] = "0"
+        # NOTE: Ray will automatically set the *_VISIBLE_DEVICES
+        # environment variable for each actor, unless
+        # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is set, so
+        # set local rank to 0 when the flag is not applicable.
+        os.environ["LOCAL_RANK"] = str(ray.get_gpu_ids()[0]) if ray_noset_visible_devices() else "0"
 
     @staticmethod
     def _get_current_node_ip():
@@ -197,20 +198,19 @@ class PPORayActorGroup:
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
                     placement_group=pg, placement_group_bundle_index=0
                 ),
-            ).remote(world_size, 0, 0, None, None)
+            ).remote(world_size, 0, None, None)
         else:
             master_actor = self.ray_actor_type.options(
                 num_cpus=num_gpus_per_actor,
                 num_gpus=num_gpus_per_actor,
                 resources=self._resources,
-            ).remote(world_size, 0, 0, None, None)
+            ).remote(world_size, 0, None, None)
         self._actor_handlers = [master_actor]
 
         # Create worker actors
         if world_size > 1:
             master_addr, master_port = ray.get(master_actor.get_master_addr_port.remote())
             for rank in range(1, world_size):
-                local_rank = rank % self._num_gpus_per_node
                 if pg:
                     worker_actor = self.ray_actor_type.options(
                         num_cpus=num_gpus_per_actor,
@@ -220,13 +220,13 @@ class PPORayActorGroup:
                             placement_group=pg,
                             placement_group_bundle_index=rank // self._num_gpus_per_node,
                         ),
-                    ).remote(world_size, rank, local_rank, master_addr, master_port)
+                    ).remote(world_size, rank, master_addr, master_port)
                 else:
                     worker_actor = self.ray_actor_type.options(
                         num_cpus=num_gpus_per_actor,
                         num_gpus=num_gpus_per_actor,
                         resources=self._resources,
-                    ).remote(world_size, rank, local_rank, master_addr, master_port)
+                    ).remote(world_size, rank, master_addr, master_port)
                 self._actor_handlers.append(worker_actor)
 
     def async_init_model_from_pretrained(

--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -1,0 +1,22 @@
+import os
+
+
+def ray_noset_visible_devices(env_vars=os.environ):
+    # Refer to
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/npu.py#L94-L95
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/hpu.py#L116-L117
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/neuron.py#L108-L109
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/tpu.py#L171-L172
+    # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/intel_gpu.py#L97-L98
+    NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
+        "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
+        "RAY_EXPERIMENTAL_NOSET_NEURON_RT_VISIBLE_CORES",
+        "RAY_EXPERIMENTAL_NOSET_TPU_VISIBLE_CHIPS",
+        "RAY_EXPERIMENTAL_NOSET_ONEAPI_DEVICE_SELECTOR",
+    ]
+    return any(env_vars.get(env_var) for env_var in NOSET_VISIBLE_DEVICES_ENV_VARS_LIST)

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -5,9 +5,17 @@ import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+from openrlhf.trainer.ray.utils import ray_noset_visible_devices
+
 from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
+
+
+@ray.remote
+def get_all_env_variables():
+    import os
+    return os.environ
 
 
 @ray.remote
@@ -18,7 +26,8 @@ class LLMRayActor:
         self.__version__ = vllm.__version__
         assert self.__version__ >= "0.4.1", "OpenRLHF only supports vLLM >= 0.4.1"
 
-        self.use_gpu_executor = kwargs["tensor_parallel_size"] == 1
+        noset_visible_devices = kwargs.pop("noset_visible_devices", False)
+        self.use_gpu_executor = kwargs["tensor_parallel_size"] == 1 and not noset_visible_devices
 
         # See https://github.com/vllm-project/vllm/blob/main/vllm/executor/gpu_executor.py
         if self.use_gpu_executor:
@@ -83,12 +92,17 @@ def create_vllm_engines(
     max_model_len: int,
 ):
     vllm_engines = []
+    # RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES will always be set in current context,
+    # So we need to get env variables from ray process to check if it is set.
+    noset_visible_devices = ray_noset_visible_devices(ray.get(get_all_env_variables.remote()))
     for i in range(num_engines):
-        # When tensor_parallel_size=1, vLLM init model in LLMEngine directly, assign 1 GPU for it.
-        num_gpus = int(tensor_parallel_size == 1)
+        # When tensor_parallel_size=1 and RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is not set
+        # (vLLM mp backend will work smoothly only when *_VISIBLE_DEVICES is modified),
+        # vLLM init model in LLMEngine directly, assign 1 GPU for it.
+        num_gpus = int(tensor_parallel_size == 1 and not noset_visible_devices)
         scheduling_strategy = None
 
-        if tensor_parallel_size > 1:
+        if tensor_parallel_size > 1 or noset_visible_devices:
             bundles = [{"GPU": 1, "CPU": 1}] * tensor_parallel_size
             pg = placement_group(bundles)
             ray.get(pg.ready())
@@ -104,6 +118,7 @@ def create_vllm_engines(
                 scheduling_strategy=scheduling_strategy,
             ).remote(
                 pretrain,
+                noset_visible_devices=noset_visible_devices,
                 trust_remote_code=True,
                 tensor_parallel_size=tensor_parallel_size,
                 dtype="bfloat16",


### PR DESCRIPTION
Relanding of PR https://github.com/OpenRLHF/OpenRLHF/pull/524

RAY_EXPERIMENTAL_NOSET_*_VISIBLE_DEVICES is used for overriding the auto setting of *_VISIBLE_DEVICES for each actor. This commit address the 2 issues when the flag is set:

1. LOCAL_RANK should reflect the actual value instead of "0", to select the correct GPU.
2. vLLM workers should be forced to use ray even if tensor_parallel_size is 1, as "mp" distributed executor backend won't work correctly when *_VISIBLE_DEVICES is not properly set.

Setting RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES flag is neccessary to get OpenRLHF running on AMD GPUs when ray >= 2.10.0 (Referring to https://github.com/vllm-project/vllm/blob/v0.6.4.post1/Dockerfile.rocm#L131-L132)

If without setting RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES, the
error log is as follows:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 396, in <module>
    train(args)
  File "OpenRLHF/openrlhf/cli/train_ppo_ray.py", line 146, in train
    ray.get(refs)
  File "venv/lib/python3.11/site-packages/ray/_private/auto_init_hook.py", line 21, in auto_init_wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/client_mode_hook.py", line 103, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/worker.py", line 2753, in get
    values, debugger_breakpoint = worker.get_objects(object_refs, timeout=timeout)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "venv/lib/python3.11/site-packages/ray/_private/worker.py", line 904, in get_objects
    raise value.as_instanceof_cause()
ray.exceptions.RayTaskError(DeferredCudaCallError): mray::RewardModelRayActor.init_model_from_pretrained()(repr=<openrlhf.trainer.ray.launcher.RewardModelRayActor object>)
  File "venv/lib/python3.11/site-packages/torch/cuda/random.py", line 126, in cb
    default_generator = torch.cuda.default_generators[i]
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: tuple index out of range

The above exception was the direct cause of the following exception:

ray::RewardModelRayActor.init_model_from_pretrained()[(repr=<openrlhf.trainer.ray.launcher.RewardModelRayActor object>)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 110, in init_model_from_pretrained
    self._setup_distributed(strategy)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 58, in _setup_distributed
    strategy.setup_distributed()
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 87, in setup_distributed
    torch.cuda.set_device(self.args.local_rank)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 478, in set_device
    torch._C._cuda_setDevice(device)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 338, in _lazy_init
    raise DeferredCudaCallError(msg) from e
torch.cuda.DeferredCudaCallError: CUDA call failed lazily at initialization with error: tuple index out of range

CUDA call was originally invoked at:

  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 110, in init_model_from_pretrained
    self._setup_distributed(strategy)
  File "OpenRLHF/openrlhf/trainer/ray/launcher.py", line 58, in _setup_distributed
    strategy.setup_distributed()
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 81, in setup_distributed
    self.set_seed(self.seed)
  File "OpenRLHF/openrlhf/utils/deepspeed.py", line 78, in set_seed
    torch.cuda.manual_seed_all(seed)
  File "venv/lib/python3.11/site-packages/torch/cuda/random.py", line 129, in manual_seed_all
    _lazy_call(cb, seed_all=True)
  File "venv/lib/python3.11/site-packages/torch/cuda/__init__.py", line 256, in _lazy_call
    _lazy_seed_tracker.queue_seed_all(callable, traceback.format_stack())
```