### PR TITLE
[WIP] Support training ppo with prm

### DIFF
--- a/openrlhf/utils/remote_rm_utils.py
+++ b/openrlhf/utils/remote_rm_utils.py
@@ -1,7 +1,6 @@
 import time
 import ray
 import requests
-import torch
 
 from openrlhf.utils.logging_utils import init_logger
 
@@ -37,7 +36,7 @@ def remote_rm_fn(api_url, queries, score_key="rewards"):
     score_key: RM score key
     """
     scores = request_api_wrapper(api_url, {"query": queries}, score_key)
-    return torch.tensor(scores)
+    return scores
 
 
 @ray.remote


### PR DESCRIPTION
This PR is trying to support PRM within the ppo training.

The main idea is
1. Reconstruct the `Samples` by spliting the response with `prm_step_separator`.
2. Convert the reward sent from remote prm into `list[torch.Tensor]` where the reward is added to the end of the step. 
3. Change the reward (`r`) into 2 types, one for wandb upload (`experience.info["reward"]`), the other for actual training (`experience.reward`) and make the `reward_fn` return both of them.

Known issues:

- Only support one remote PRM at the moment.
- Only support when packing samples is on, but it shouldn't be hard to implement the padding version.

Thank you for your time on reviewing this PR:)