### PR TITLE
Make sure there is always _some_ eval data

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -97,7 +97,7 @@ def blending_datasets(
                 eval_data = data[eval_split].select(range(min(max_count, len(data[eval_split]))))
             # train will contains eval? TODO
             else:
-                eval_data = train_data.select(range(min(max_count, int(len(train_data) * 0.03))))
+                eval_data = train_data.select(range(max(1, min(max_count, int(len(train_data) * 0.03)))))
             eval_data_list.append(eval_data)
 
     # merge datasets


### PR DESCRIPTION
This is already kind of an egregious hack corner case with overlapping data. This makes it even hackier, but ensures there is always at least one data point in eval in this corner case.