### PR TITLE
Fix nan for sft-ring when labels are all IGNORE_INDEX

### DIFF
--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -32,6 +32,11 @@ class GPTLMLoss(nn.Module):
 
         shift_logits = logits[..., :-1, :].contiguous()
         shift_labels = labels[..., 1:].contiguous()
+        
+        if torch.all(shift_labels == self.IGNORE_INDEX): # if labels are all IGNORE_INDEX, then nn.CrossEntropyLoss will be nan
+            shift_logits = torch.cat([shift_logits, shift_logits.new_zeros(shift_logits.size(0), 1, shift_logits.size(-1))], dim=1)
+            shift_labels = torch.cat([shift_labels, shift_labels.new_zeros(shift_labels.size(0), 1)], dim=1)
+
         loss = self.loss(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         
         if self.ring_attn_group is not None:


### PR DESCRIPTION
In pytorch implementation, nn.CrossEntropyLoss will return `nan` when `torch.all(labels == ignore_index)`.
Currently, for ring-attn during sft phase, we calculate loss for individual ring group for less communacation budget. But it will cause cases where `torch.all(labels == ignore_index)`. We should manually append zeros after labels and logits in this scenario

```python
import torch
from torch import nn
loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
logits = torch.tensor([[0.2, 1.0, 0.5], 
                       [0.1, 0.3, 0.6]], requires_grad=True)
labels = torch.tensor([-100, -100])
loss = loss_fn(logits, labels)
print("loss is:", loss)
```