### PR TITLE
Support broadcast vllm params by chunks

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -213,6 +213,9 @@ if __name__ == "__main__":
     parser.add_argument("--vllm_sync_backend", type=str, default="gloo", help="DeepSpeed -> vLLM weight sync backend")
     parser.add_argument("--enable_prefix_caching", action="store_true", default=False)
     parser.add_argument("--enforce_eager", action="store_true", default=False, help="Disable CUDA graph in vLLM")
+    parser.add_argument(
+        "--vllm_broadcast_chunk_size", type=int, default=128 * 1024 * 1024, help="vLLM broadcast chunk size in bytes"
+    )
 
     # Checkpoints
     parser.add_argument("--eval_steps", type=int, default=-1)

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -147,23 +147,50 @@ class ActorPPOTrainer(PPOTrainer):
         # avoid OOM
         torch.cuda.empty_cache()
         model = self.actor.model.module
-        count, num_params = 0, len(list(model.named_parameters()))
+
+        param_chunk_list = []
+        current_chunk_size = 0
+        param_chunk = []
         for name, param in model.named_parameters():
-            count += 1  # empty_cache at last param
+            shape = param.shape if self.strategy.args.zero_stage != 3 else param.ds_shape
+            size_in_bytes = shape.numel() * param.element_size()
 
-            # Fire all vllm engines for broadcast
-            if torch.distributed.get_rank() == 0:
-                shape = param.shape if self.strategy.args.zero_stage != 3 else param.ds_shape
-                refs = [
-                    engine.update_weight.remote(name, dtype=param.dtype, shape=shape, empty_cache=count == num_params)
-                    for engine in self.vllm_engines
-                ]
+            if current_chunk_size + size_in_bytes > self.strategy.args.vllm_broadcast_chunk_size:
+                param_chunk_list.append(param_chunk)
+                param_chunk = []
+                current_chunk_size = 0
+            param_chunk.append((name, param, shape))
+            current_chunk_size += size_in_bytes
+        if len(param_chunk) > 0:
+            param_chunk_list.append(param_chunk)
 
+        # Fire all vllm engines for broadcast
+        if torch.distributed.get_rank() == 0:
+            refs = [
+                engine.update_weight.remote(
+                    [
+                        [(name, param.dtype, shape) for name, param, shape in param_chunk]
+                        for param_chunk in param_chunk_list
+                    ]
+                )
+                for engine in self.vllm_engines
+            ]
+
+        for param_chunk in param_chunk_list:
             # For ZeRO-3, allgather sharded parameter and broadcast to all vllm engines by rank 0
-            with deepspeed.zero.GatheredParameters([param], enabled=self.strategy.args.zero_stage == 3):
+            with deepspeed.zero.GatheredParameters(
+                [param for _, param, _ in param_chunk], enabled=self.strategy.args.zero_stage == 3
+            ):
                 if torch.distributed.get_rank() == 0:
-                    torch.distributed.broadcast(param.data, 0, group=self._model_update_group)
-                    ray.get(refs)
+                    handles = [
+                        torch.distributed.broadcast(param.data, 0, group=self._model_update_group, async_op=True)
+                        for _, param, _ in param_chunk
+                    ]
+                    for handle in handles:
+                        handle.wait()
+
+        if torch.distributed.get_rank() == 0:
+            ray.get(refs)
 
     def _save_checkpoint(self, args, tag, client_states):
         # call remote critic

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -66,13 +66,13 @@ class LLMRayActor:
                 "init_process_group", master_address, master_port, rank_offset, world_size, group_name, backend
             )
 
-    def update_weight(self, name, dtype, shape, empty_cache=False):
+    def update_weight(self, param_chunk_list):
         self.stop_remote_worker_execution_loop()
 
         if self.use_gpu_executor:
-            return self.llm.llm_engine.model_executor.driver_worker.update_weight(name, dtype, shape, empty_cache)
+            return self.llm.llm_engine.model_executor.driver_worker.update_weight(param_chunk_list)
         else:
-            return self.llm.llm_engine.model_executor._run_workers("update_weight", name, dtype, shape, empty_cache)
+            return self.llm.llm_engine.model_executor._run_workers("update_weight", param_chunk_list)
 
     def stop_remote_worker_execution_loop(self):
         # Fix error for using 2 communication group


### PR DESCRIPTION
This PR optimizes the weight update process from the actor to vLLM by grouping parameters into chunks using the newly introduced vllm_broadcast_chunk_size parameter. This adjustment improves bandwidth utilization, particularly for MoE models with small experts. In on-premise MoE settings, this change can reduce broadcast time from 50 seconds to 5 seconds, significantly boosting performance.

Thank you for your time on reviewing this PR :)