### PR TITLE
Fix: bug in actor logit's numerical precision when bf16 is on.

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -211,7 +211,7 @@ class Actor(nn.Module):
             assert return_output
             return output
 
-        log_probs = log_probs_from_logits(output["logits"][:, :-1, :], sequences[:, 1:])
+        log_probs = log_probs_from_logits(output["logits"][:, :-1, :].to(torch.float32), sequences[:, 1:])
 
         if not self.packing_samples:
             action_log_probs = log_probs[:, -num_actions:]


### PR DESCRIPTION
**Logits Precision Issue with BF16 in Transformers v4.46+**
**Background:**
Starting from Transformers v4.46, the logits model output maintains the same data type as the model, except during training where it defaults to FP32. This behavior is demonstrated in the following code from the Transformers repository:
[code from the Transformers repository](https://github.com/huggingface/transformers/blob/main/src/transformers/models/moshi/modeling_moshi.py#L1848-L1850)
```
        if labels is None and not is_torchdynamo_compiling():
            logger.warning_once(
                "Starting from v4.46, the `logits` model output will have the same type as the model (except at train time, where it will always be FP32)"
            )
        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
        logits = self.lm_head(hidden_states[:, -num_logits_to_keep:, :])
````
**Technical Impact:**
When BF16 precision is enabled, the actor's logit calculations maintain BF16 precision, which can lead to instability in KL divergence calculations under certain conditions.
**Reproduction Script:**
The issue can be reproduced using the PPO training script (examples/scripts/train_ppo_llama_ray.sh):
```
set -x 

ray job submit --address="http://127.0.0.1:8265" \
   --runtime-env-json='{"working_dir": "/openrlhf"}' \
   -- python3 -m openrlhf.cli.train_ppo_ray \
   --ref_num_nodes 1 \
   --ref_num_gpus_per_node 2 \
   --reward_num_nodes 1 \
   --reward_num_gpus_per_node 2 \
   --critic_num_nodes 1 \
   --critic_num_gpus_per_node 2 \
   --actor_num_nodes 1 \
   --actor_num_gpus_per_node 2 \
   --vllm_num_engines 2 \
   --vllm_tensor_parallel_size 2 \
   --colocate_critic_reward \
   --colocate_actor_ref \
   --pretrain OpenRLHF/Llama-3-8b-sft-mixture \
   --reward_pretrain OpenRLHF/Llama-3-8b-rm-mixture \
   --save_path /openrlhf/examples/checkpoint/llama3-8b-rlhf \
   --micro_train_batch_size 8 \
   --train_batch_size 128 \
   --micro_rollout_batch_size 32 \
   --rollout_batch_size 1024 \
   --max_samples 100000 \
   --max_epochs 1 \
   --prompt_max_len 1024 \
   --generate_max_len 1024 \
   --zero_stage 3 \
   --bf16 \
   --actor_learning_rate 5e-7 \
   --critic_learning_rate 9e-6 \
   --init_kl_coef 0.01 \
   --prompt_data OpenRLHF/prompt-collection-v0.1 \
   --input_key context_messages \
   --apply_chat_template \
   --normalize_reward \
   --packing_samples \
   --adam_offload \
   --flash_attn \
   --gradient_checkpointing \
   --load_checkpoint \
   --use_wandb {wandb_token}

# --runtime-env-json='{"setup_commands": ["pip install openrlhf[vllm]"]}' [Install deps]
# --ref_reward_offload [Offload to CPU]
# --remote_rm_url http://localhost:5000/get_reward

# --vllm_sync_backend nccl (Only for multi-nodes with vLLM 0.6.4+ or vLLM 0.4.2)
```
As can be seen, when bf16 is enabled, the dtype **will not autocast** to fp32 after Transformers version 4.46.
<img width="848" alt="a" src="https://github.com/user-attachments/assets/9a34c152-97f5-49a8-aaa9-e2f7018f044a" />
