### PR TITLE
Copy the all_gather function from flash-attention

### DIFF
--- a/openrlhf/models/model.py
+++ b/openrlhf/models/model.py
@@ -3,13 +3,13 @@ from typing import Optional, Union
 import deepspeed
 import torch
 import torch.nn as nn
-from flash_attn.utils.distributed import all_gather
 from peft import LoraConfig, get_peft_model
 from peft.tuners.lora import LoraLayer
 from transformers import AutoConfig, AutoModel, BitsAndBytesConfig
 from transformers.integrations.deepspeed import HfDeepSpeedConfig
 
 from openrlhf.utils.logging_utils import init_logger
+from openrlhf.utils.distributed_util import all_gather
 
 from .ring_attn_utils import convert_ring_attn_params
 from .utils import reset_position_ids

--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -2,13 +2,13 @@ import os
 from abc import ABC
 
 import torch
-from flash_attn.utils.distributed import all_gather
 from torch.nn import functional as F
 from torch.optim import Optimizer
 from tqdm import tqdm
 
 from openrlhf.models import DPOLoss
 from openrlhf.utils.distributed_sampler import DistributedSampler
+from openrlhf.utils.distributed_util import all_gather
 
 
 class DPOTrainer(ABC):
@@ -440,7 +440,7 @@ class DPOTrainer(ABC):
                 logits.log_softmax(-1), dim=2, index=local_label.unsqueeze(2)
             ).squeeze(2)
             # we may not need to all_gather the entire tensor, but it's easier to implement.
-            # use the flash_attn all_gather so that the all_gather has correct backward.
+            # use the all_gather copied from flash_attn so that the all_gather has correct backward.
             per_token_logps = all_gather(local_per_token_logps, self.strategy.ring_attn_group).reshape((1, -1))
             per_token_logps = per_token_logps[:, :-1]
 

--- a/openrlhf/utils/distributed_util.py
+++ b/openrlhf/utils/distributed_util.py
@@ -3,6 +3,8 @@ from typing import Any, Optional, Union
 
 import torch
 import torch.distributed
+from torch import Tensor
+from torch.distributed import ProcessGroup
 from torch.distributed.distributed_c10d import (
     Backend,
     PrefixStore,
@@ -70,3 +72,56 @@ def init_process_group(
     _world.pg_group_ranks[pg] = {i: i for i in range(world_size)}
 
     return pg
+
+
+# Copy from flash-attention to make all_gather has correct backward.
+# https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/utils/distributed.py
+# The following 4 lines are for backward compatibility with older PyTorch.
+if "all_gather_into_tensor" not in dir(torch.distributed):
+    torch.distributed.all_gather_into_tensor = torch.distributed._all_gather_base
+if "reduce_scatter_tensor" not in dir(torch.distributed):
+    torch.distributed.reduce_scatter_tensor = torch.distributed._reduce_scatter_base
+
+
+# Raw operation, does not support autograd, but does support async
+def all_gather_raw(input_: Tensor, process_group: ProcessGroup, async_op: bool = False):
+    world_size = torch.distributed.get_world_size(process_group)
+    output = torch.empty(
+        world_size * input_.shape[0], *input_.shape[1:], dtype=input_.dtype, device=input_.device
+    )
+    handle = torch.distributed.all_gather_into_tensor(
+        output, input_.contiguous(), group=process_group, async_op=async_op
+    )
+    return output, handle
+
+
+# Raw operation, does not support autograd, but does support async
+def reduce_scatter_raw(input_: Tensor, process_group: ProcessGroup, async_op: bool = False):
+    world_size = torch.distributed.get_world_size(process_group)
+    assert input_.shape[0] % world_size == 0
+    output = torch.empty(
+        input_.shape[0] // world_size, *input_.shape[1:], dtype=input_.dtype, device=input_.device
+    )
+    handle = torch.distributed.reduce_scatter_tensor(
+        output, input_.contiguous(), group=process_group, async_op=async_op
+    )
+    return output, handle
+
+
+class AllGatherFunc(torch.autograd.Function):
+    """Gather the input from sequence parallel region and concatenate."""
+
+    @staticmethod
+    def forward(ctx, input_: Tensor, process_group: ProcessGroup) -> Tensor:
+        ctx.process_group = process_group
+        output, _ = all_gather_raw(input_, process_group)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        grad_input, _ = reduce_scatter_raw(grad_output, ctx.process_group)
+        return grad_input, None
+
+
+# Supports autograd, but does not support async
+all_gather = AllGatherFunc.apply


### PR DESCRIPTION
I want to use OpenRLHF with v100, but OpenRLHF directly depends on flash-attention at the code level, see: 

https://github.com/OpenRLHF/OpenRLHF/blob/4e856485ef3811398c907db38d307131b1d92474/openrlhf/trainer/dpo_trainer.py#L5

As we all know, flash-attention does not support Volta series GPUs, so this PR copies the required all_gather function from the flash-attention to remove the explicit dependency on flash-attention.

Thank you for your time on reviewing this PR :)

cc @hijkzzz @zhuzilin 