### PR TITLE
Fix 'worker_use_ray' not found in vLLM 0.7.0

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -35,7 +35,11 @@ class LLMRayActor:
         else:
             # RayGPUExecutor
             # See the patch https://github.com/vllm-project/vllm/commit/479d69fad0538f04cb22bf13e76ff91cfeb8a4e5
-            kwargs["worker_use_ray"] = True
+            if vllm.__version__ >= "0.4.3":
+                # https://github.com/vllm-project/vllm/commit/676a99982fe9aabe72fd52a91e08988a653a7359
+                kwargs["distributed_executor_backend"] = "ray"
+            else:
+                kwargs["worker_use_ray"] = True
 
             if vllm.__version__ > "0.6.4.post1":
                 # https://github.com/vllm-project/vllm/pull/10555


### PR DESCRIPTION
Related to https://github.com/vllm-project/vllm/pull/12383

`--worker-use-ray` is deprecated since 0.4.3:
https://github.com/vllm-project/vllm/commit/676a99982fe9aabe72fd52a91e08988a653a7359

```log
Exception raised in creation task: The actor died because of an error raised in its creation task, [36mray::LLMRayActor.__init__()[39m (repr=<openrlhf.trainer.ray.vllm_engine.LLMRayActor object at 0x150cf7b4b910>)
 File "openrlhf/trainer/ray/vllm_engine.py", line 58, in __init__
 self.llm = vllm.LLM(*args, **kwargs)
 File "vllm/utils.py", line 1039, in inner
 return fn(*args, **kwargs)
 File "vllm/entrypoints/llm.py", line 210, in __init__
 engine_args = EngineArgs(
TypeError: EngineArgs.__init__() got an unexpected keyword argument 'worker_use_ray'
```