### PR TITLE
Add support for clearing prefix cache in vLLM

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -374,8 +374,10 @@ if __name__ == "__main__":
         args.remote_rm_url = args.remote_rm_url.split(",")
 
     if args.vllm_num_engines >= 1 and args.enable_prefix_caching:
-        args.enable_prefix_caching = False
-        print("[Warning] Disable prefix cache because vLLM updates weights without updating the old KV Cache.")
+        import vllm
+        if vllm.__version__ < "0.7.0":
+            args.enable_prefix_caching = False
+            print("[Warning] Disable prefix cache because vLLM updates weights without updating the old KV Cache for vLLM version below 0.7.0.")
 
     if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -74,6 +74,14 @@ class LLMRayActor:
         else:
             return self.llm.llm_engine.model_executor._run_workers("update_weight", name, dtype, shape, empty_cache)
 
+    def reset_prefix_cache(self):
+        import vllm
+        if vllm.__version__ < "0.7.0":
+            # https://github.com/vllm-project/vllm/commit/7206ce4ce112ed117796a59045c968a6d353f691
+            logger.warning("Reset prefix cache API is available only from vLLM 0.7.0!")
+            return
+        self.llm.llm_engine.reset_prefix_cache()
+
     def stop_remote_worker_execution_loop(self):
         # Fix error for using 2 communication group
         # https://github.com/vllm-project/vllm/commit/eb6d3c264d0cd8e44dec16bca7947fbe96415ce9#diff-e1ad69e38e033accddfa5480ec808c4740eb39244d1ef51cc3407e20dde8cfd4


### PR DESCRIPTION
vLLM now officially supports resetting prefix cache in 0.7.0

https://github.com/vllm-project/vllm/commit/7206ce4ce112ed117796a59045c968a6d353f691