### PR TITLE
Add support for vLLM weight sync with Ray collective communication

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -213,6 +213,7 @@ if __name__ == "__main__":
         help="tensor parallel size of vLLM Engine for multi-GPU inference",
     )
     parser.add_argument("--vllm_sync_backend", type=str, default="nccl", help="DeepSpeed -> vLLM weight sync backend")
+    parser.add_argument("--vllm_sync_with_ray", action="store_true", default=False)
     parser.add_argument("--enable_prefix_caching", action="store_true", default=False)
     parser.add_argument("--enforce_eager", action="store_true", default=False, help="Disable CUDA graph in vLLM")
 

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -82,24 +82,37 @@ class ActorPPOTrainer(PPOTrainer):
             world_size = vllm_num_engines * vllm_tensor_parallel_size + 1
 
             backend = getattr(self.strategy.args, "vllm_sync_backend", "nccl")
+            use_ray = getattr(self.strategy.args, "vllm_sync_with_ray", False)
+            group_name = "openrlhf"
             refs = [
                 engine.init_process_group.remote(
                     master_address,
                     master_port,
                     i * vllm_tensor_parallel_size + 1,
                     world_size,
-                    "openrlhf",
+                    group_name,
                     backend=backend,
+                    use_ray=use_ray,
                 )
                 for i, engine in enumerate(self.vllm_engines)
             ]
-            self._model_update_group = init_process_group(
-                backend=backend,
-                init_method=f"tcp://{master_address}:{master_port}",
-                world_size=world_size,
-                rank=0,
-                group_name="openrlhf",
-            )
+            if use_ray:
+                import ray.util.collective as collective
+                collective.init_collective_group(
+                    world_size=world_size,
+                    rank=0,
+                    backend=backend,
+                    group_name=group_name
+                )
+                self._model_update_group = group_name
+            else:
+                self._model_update_group = init_process_group(
+                    backend=backend,
+                    init_method=f"tcp://{master_address}:{master_port}",
+                    world_size=world_size,
+                    rank=0,
+                    group_name=group_name,
+                )
 
             ray.get(refs)
 
@@ -138,6 +151,7 @@ class ActorPPOTrainer(PPOTrainer):
     def _broadcast_to_vllm(self):
         # avoid OOM
         torch.cuda.empty_cache()
+        use_ray = getattr(self.strategy.args, "vllm_sync_with_ray", False)
         model = self.actor.model.module
         count, num_params = 0, len(list(model.named_parameters()))
         for name, param in model.named_parameters():
@@ -154,7 +168,11 @@ class ActorPPOTrainer(PPOTrainer):
             # For ZeRO-3, allgather sharded parameter and broadcast to all vllm engines by rank 0
             with deepspeed.zero.GatheredParameters([param], enabled=self.strategy.args.zero_stage == 3):
                 if torch.distributed.get_rank() == 0:
-                    torch.distributed.broadcast(param.data, 0, group=self._model_update_group)
+                    if use_ray:
+                        import ray.util.collective as collective
+                        collective.broadcast(param.data, 0, group_name=self._model_update_group)
+                    else:
+                        torch.distributed.broadcast(param.data, 0, group=self._model_update_group)
                     ray.get(refs)
         torch.distributed.barrier()
 

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -56,14 +56,14 @@ class LLMRayActor:
     def generate(self, *args, **kwargs):
         return self.llm.generate(*args, **kwargs)
 
-    def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend):
+    def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray):
         if self.use_gpu_executor:
             return self.llm.llm_engine.model_executor.driver_worker.init_process_group(
-                master_address, master_port, rank_offset, world_size, group_name, backend
+                master_address, master_port, rank_offset, world_size, group_name, backend, use_ray
             )
         else:
             return self.llm.llm_engine.model_executor._run_workers(
-                "init_process_group", master_address, master_port, rank_offset, world_size, group_name, backend
+                "init_process_group", master_address, master_port, rank_offset, world_size, group_name, backend, use_ray
             )
 
     def update_weight(self, name, dtype, shape, empty_cache=False):

--- a/openrlhf/trainer/ray/vllm_worker_wrap.py
+++ b/openrlhf/trainer/ray/vllm_worker_wrap.py
@@ -8,19 +8,30 @@ logger = init_logger(__name__)
 
 
 class WorkerWrap(Worker):
-    def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl"):
+    def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl", use_ray=False):
         """Init torch process group for model weights update"""
         assert torch.distributed.is_initialized(), f"default torch process group must be initialized"
         assert group_name != "", f"group name must not be empty"
 
         rank = torch.distributed.get_rank() + rank_offset
-        self._model_update_group = init_process_group(
-            backend=backend,
-            init_method=f"tcp://{master_address}:{master_port}",
-            world_size=world_size,
-            rank=rank,
-            group_name=group_name,
-        )
+        if use_ray:
+            import ray.util.collective as collective
+            collective.init_collective_group(
+                world_size=world_size,
+                rank=rank,
+                backend=backend,
+                group_name=group_name
+            )
+            self._model_update_group = group_name
+        else:
+            self._model_update_group = init_process_group(
+                backend=backend,
+                init_method=f"tcp://{master_address}:{master_port}",
+                world_size=world_size,
+                rank=rank,
+                group_name=group_name,
+            )
+        self._model_update_with_ray = use_ray
         print(
             f"init_process_group: master_address={master_address}, master_port={master_port}, ",
             f"rank={rank}, world_size={world_size}, group_name={group_name}",
@@ -33,7 +44,11 @@ class WorkerWrap(Worker):
 
         assert dtype == self.model_config.dtype, f"mismatch dtype: src {dtype}, dst {self.model_config.dtype}"
         weight = torch.empty(shape, dtype=dtype, device="cuda")
-        torch.distributed.broadcast(weight, 0, group=self._model_update_group)
+        if self._model_update_with_ray:
+            import ray.util.collective as collective
+            collective.broadcast(weight, 0, group_name=self._model_update_group)
+        else:
+            torch.distributed.broadcast(weight, 0, group=self._model_update_group)
 
         self.model_runner.model.load_weights(weights=[(name, weight)])
 


### PR DESCRIPTION
Can be an alternative to / aside from #680 and fix #492, as in Ray collective communication lib, setting master addr/port is not needed.

Current torch vLLM weight sync implementation with NCCL sometimes causes hang, especially on AMD GPUs, this PR tries to address this issue by using Ray collective communication lib, so that we can benefit from the blazing fast NCCL (RCCL on AMD) smoothly.

https://docs.ray.io/en/latest/ray-more-libs/ray-collective.html

Note that Ray CC lib would need cupy for NCCL backend.