### PR TITLE
Add support for max time per run

### DIFF
--- a/openrlhf/utils/__init__.py
+++ b/openrlhf/utils/__init__.py
@@ -1,5 +1,5 @@
 from .processor import get_processor, reward_normalization
-from .utils import blending_datasets, get_strategy, get_tokenizer
+from .utils import blending_datasets, get_strategy, get_tokenizer, MaxTimeManager
 
 __all__ = [
     "get_processor",
@@ -7,4 +7,5 @@ __all__ = [
     "blending_datasets",
     "get_strategy",
     "get_tokenizer",
+    "MaxTimeManager",
 ]


### PR DESCRIPTION
# Changelog
- Adds support for max time per run for instances where compute cluster has a maximum duration for a job.
- Calculates checkpoint at current step, then exits the script. (An option can be to raise KeyboardException, or simply pass signal.SIGINT, if deepspeed supports it - but i haven't verified this).