### PR TITLE
early_stopping conditional on beam search

### DIFF
--- a/openrlhf/cli/batch_inference.py
+++ b/openrlhf/cli/batch_inference.py
@@ -164,7 +164,7 @@ def batch_generate(args):
                 max_new_tokens=args.max_new_tokens,
                 do_sample=not args.greedy_sampling,
                 top_p=args.top_p,
-                early_stopping=True,
+                early_stopping=False,
                 num_beams=1,
                 temperature=args.temperature,
                 repetition_penalty=args.repetition_penalty,

--- a/openrlhf/cli/interactive_chat.py
+++ b/openrlhf/cli/interactive_chat.py
@@ -67,7 +67,7 @@ def generate(args):
             max_length=args.max_len,
             do_sample=not args.greedy_sampling,
             top_p=args.top_p,
-            early_stopping=True,
+            early_stopping=False,
             num_beams=1,
             temperature=args.temperature,
             repetition_penalty=args.repetition_penalty,

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -128,7 +128,7 @@ class Actor(nn.Module):
             "top_k": kwargs.get("top_k", None),
             "top_p": kwargs.get("top_p", None),
             "do_sample": kwargs.get("do_sample", True),
-            "early_stopping": True,
+            "early_stopping": kwargs.get("num_beams", 1) > 1,
             "temperature": kwargs.get("temperature", 1),
             "use_cache": True,
             "num_beams": kwargs.get("num_beams", 1),


### PR DESCRIPTION
early_stopping is a stopping rule for when beam search is enabled. This change will prevent transformers from raising dozens of warnings during training.