### PR TITLE
[small change] Use selective log-softmax to reduce peak vram consumption

### DIFF
--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -1,7 +1,6 @@
 from typing import Optional, Tuple, Union
 
 import torch
-import torch.nn.functional as F
 
 
 def compute_approx_kl(
@@ -75,9 +74,10 @@ def compute_reward(
 
 
 def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-    log_probs = F.log_softmax(logits, dim=-1)
-    log_probs_labels = log_probs.gather(dim=-1, index=labels.unsqueeze(-1))
-    return log_probs_labels.squeeze(-1)
+    logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
+    logsumexp_values = torch.stack([torch.logsumexp(l, dim=-1) for l in logits])  # loop to reduce peak mem consumption
+    log_probs_labels = logits_labels - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
+    return log_probs_labels
 
 
 def masked_mean(tensor: torch.Tensor, mask: Optional[torch.Tensor], dim: int = None) -> torch.Tensor:

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -78,13 +78,12 @@ def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor) -> torch.T
     if logits.dtype in [torch.float32, torch.float64]:
         logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
         logsumexp_values = torch.stack(
-            [torch.logsumexp(l, dim=-1) for l in logits]
-        )  # loop to reduce peak mem consumption
+            [torch.logsumexp(l, dim=-1) for l in logits]  # loop to reduce peak mem consumption
+        )
         log_probs_labels = logits_labels - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
     else:
         log_probs = F.log_softmax(logits, dim=-1)
-        log_probs_labels = log_probs.gather(dim=-1, index=labels.unsqueeze(-1))
-        return log_probs_labels.squeeze(-1)
+        log_probs_labels = log_probs.gather(dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
     return log_probs_labels
 
 

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -75,6 +75,7 @@ def compute_reward(
 
 
 def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    # https://github.com/OpenRLHF/OpenRLHF/pull/718#issuecomment-2641081881
     if logits.dtype in [torch.float32, torch.float64]:
         logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
         logsumexp_values = torch.stack(

--- a/openrlhf/trainer/kto_trainer.py
+++ b/openrlhf/trainer/kto_trainer.py
@@ -6,6 +6,7 @@ from torch.optim import Optimizer
 from tqdm import tqdm
 
 from openrlhf.models import KTOLoss
+from openrlhf.models.utils import log_probs_from_logits
 from openrlhf.utils.distributed_sampler import DistributedSampler
 
 
@@ -335,7 +336,7 @@ class KTOTrainer(ABC):
 
         # dummy token; we'll ignore the losses on these tokens later
         labels[~loss_masks] = 0
-        per_token_logps = torch.gather(logits.log_softmax(-1), dim=2, index=labels.unsqueeze(2)).squeeze(2)
+        per_token_logps = log_probs_from_logits(logits, labels)
 
         if average_log_prob:
             return (per_token_logps * loss_masks).sum(-1) / loss_masks.sum(-1)


### PR DESCRIPTION
When training language models, we often need to convert logits (raw model outputs) into log probabilities. The standard approach uses log_softmax which requires computing probabilities for every token in the vocabulary at every position in the sequence. For large vocabulary sizes, this can consume significant VRAM.

For example, with a modest vocabulary size of 32768, sequence length of 1024, and batch size of 16, computing log_softmax naively can consume 2.1GB of VRAM. And that is in addition to the 2.1GB required to hold the logits in the first place. However, in many cases, we only need the log probabilities for specific tokens - usually the ones that were actually generated or appear in the training data.

We can optimize this by:
1. First gathering just the logits for the tokens we care about
2. Computing the softmax denominator (logsumexp) over the full logit distribution
3. Subtracting the denominator from our gathered logits to get the final log probabilities

In this example setting, vram usage is reduced from 4295MB to 2282MB (2147MB of which is required to store the logits in the first place).