### PR TITLE
Change the vLLM sleep level default to 2

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -41,9 +41,6 @@ class LLMRayActor:
 
         self.llm = LLM(*args, **kwargs)
 
-    def generate(self, *args, **kwargs):
-        return self.llm.generate(*args, **kwargs)
-
     def init_process_group(self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray):
         return self.llm.collective_rpc(
             "init_process_group",

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -56,7 +56,7 @@ class LLMRayActor:
     def reset_prefix_cache(self):
         self.llm.llm_engine.reset_prefix_cache()
 
-    def sleep(self, level=1):
+    def sleep(self, level=2):
         self.llm.sleep(level=level)
 
     def wake_up(self):


### PR DESCRIPTION
According to https://github.com/vllm-project/vllm/pull/11743/files#diff-1661f61c5087d7770dd252ba3fbe544871ec5554a38f247d189ba25343770232R1141-R1151, level 1 will offload the model weights to CPU, but this is not needed in our use case and can be simply discarded here, since we will load the new weight in `update_weight` later when we `_broadcast_to_vllm`.