### PR TITLE
Make sure vLLM requests less resources than actors for hybrid engine

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -70,6 +70,15 @@ def train(args):
                 f"Set args.vllm_gpu_memory_utilization to {args.vllm_gpu_memory_utilization} for colocate_all_models!"
             )
 
+        assert (
+            args.actor_num_nodes * args.actor_num_gpus_per_node
+            >= args.vllm_num_engines * args.vllm_tensor_parallel_size
+        ), (
+            f"actor_num_nodes * actor_num_gpus_per_node must be greater than or equal to "
+            f"vllm_num_engines * vllm_tensor_parallel_size, got {args.actor_num_nodes * args.actor_num_gpus_per_node} "
+            f"and {args.vllm_num_engines * args.vllm_tensor_parallel_size}"
+        )
+
         vllm_engines = create_vllm_engines(
             args.vllm_num_engines,
             args.vllm_tensor_parallel_size,


### PR DESCRIPTION
As current hybrid engine placement group is created according to `actor_num_nodes * actor_num_gpus_per_node`, we need to make sure it has enough room for the vLLM workers.

If not, we could get errors like:

ValueError: placement group bundle index 6 is invalid. Valid placement group indexes: 0-4

Or:

```logs
Exception raised in creation task: The actor died because of an error raised in its creation task, ray::LLMRayActor.__init__()
(LLMRayActor pid=146238)   File "openrlhf/trainer/ray/vllm_engine.py", line 43, in __init__
(LLMRayActor pid=146238)     self.llm = LLM(*args, **kwargs)
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/utils.py", line 1051, in inner
(LLMRayActor pid=146238)     return fn(*args, **kwargs)
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 242, in __init__
(LLMRayActor pid=146238)     self.llm_engine = self.engine_class.from_engine_args(
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 484, in from_engine_args
(LLMRayActor pid=146238)     engine = cls(
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 273, in __init__
(LLMRayActor pid=146238)     self.model_executor = executor_class(vllm_config=vllm_config, )
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 262, in __init__
(LLMRayActor pid=146238)     super().__init__(*args, **kwargs)
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 51, in __init__
(LLMRayActor pid=146238)     self._init_executor()
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/executor/ray_distributed_executor.py", line 81, in _init_executor
(LLMRayActor pid=146238)     initialize_ray_cluster(self.parallel_config)
(LLMRayActor pid=146238)   File ".conda/lib/python3.10/site-packages/vllm/executor/ray_utils.py", line 309, in initialize_ray_cluster
(LLMRayActor pid=146238)     raise ValueError(
(LLMRayActor pid=146238) ValueError: The number of required GPUs exceeds the total number of available GPUs in the placement group.Required number of devices: 2. Total number of devices: 1.
```
