### PR TITLE
Make sure vLLM driver (LLMRayActor) gets scheduled to the correct placement_group

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -131,6 +131,7 @@ def create_vllm_engines(
                 scheduling_strategy = PlacementGroupSchedulingStrategy(
                     placement_group=shared_pg,
                     placement_group_capture_child_tasks=True,
+                    placement_group_bundle_index=i * tensor_parallel_size
                 )
                 bundle_indices = np.arange(i * tensor_parallel_size, (i + 1) * tensor_parallel_size).tolist()
             else:


### PR DESCRIPTION
placement_group_bundle_index:
- the index of the bundle if the actor belongs to a placement group, which may be -1 (default) to specify any available bundle.

While default value won't work correctly, since vLLM requires that at least one worker is on the same node as the driver:

https://github.com/vllm-project/vllm/blob/bc1bdecebf76cca0dfafe4924d529b30c8a24795/vllm/executor/ray_distributed_executor.py#L210-L222

So, this PR fixes the following error when running hybrid engine on multiple nodes with tp=2 or greater:

> ValueError: Ray does not allocate any GPUs on the driver node. Consider adjusting the Ray placement group or running the driver on a GPU node.