### PR TITLE
Fix ring attn when n_samples_per_prompt > 1

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -209,7 +209,7 @@ class NaiveExperienceMaker(ABC):
                 dist.broadcast_object_list(samples_list, src=dist.get_rank(), group=self.strategy.ring_attn_group)
             else:
                 world_size = torch.distributed.get_world_size() // args.ring_attn_size
-                samples_list = [None] * (args.rollout_batch_size // world_size // args.micro_rollout_batch_size)
+                samples_list = [None] * (args.rollout_batch_size * args.n_samples_per_prompt // world_size // args.micro_rollout_batch_size)
                 dist.broadcast_object_list(samples_list, src=self.strategy.ring_attn_ranks[0], group=self.strategy.ring_attn_group)
         else:
             samples_list = self.generate_samples(all_prompts, all_labels, **generate_kwargs)


### PR DESCRIPTION
As for the func `make_experience_list`
```
            if self.strategy.ring_attn_rank == 0:
                samples_list = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
                dist.broadcast_object_list(samples_list, src=dist.get_rank(), group=self.strategy.ring_attn_group)
            else:
                world_size = torch.distributed.get_world_size() // args.ring_attn_size
                samples_list = [None] * (args.rollout_batch_size // world_size // args.micro_rollout_batch_size)
                dist.broadcast_object_list(samples_list, src=self.strategy.ring_attn_ranks[0], group=self.strategy.ring_attn_group)
        else:
            samples_list = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
        torch.distributed.barrier()
```

When `n_samples_per_prompt > 1`, the size of samples_list mismatch across ring_attn_group.

Should be `samples_list = [None] * (args.rollout_batch_size * args.n_samples_per_prompt // world_size // args.micro_rollout_batch_size)`