### PR TITLE
Make remote_rm_url type consistent

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -141,7 +141,7 @@ class NaiveExperienceMaker(ABC):
         prompt_max_len: int,
         kl_controller,
         strategy=None,
-        remote_rm_url: list[str] = None,
+        remote_rm_url: Union[list[str], str] = None,
         reward_fn=None,
     ) -> None:
         super().__init__()
@@ -160,6 +160,7 @@ class NaiveExperienceMaker(ABC):
 
         # custom reward func for reinforced finetuning
         self.custom_reward_func = None
+        remote_rm_url = [remote_rm_url] if isinstance(remote_rm_url, str) else remote_rm_url
         if remote_rm_url and remote_rm_url[0].endswith(".py"):
             print(f"Loading custom `reward_func(queries, prompts, labels)` from {remote_rm_url[0]}")
             import importlib.util


### PR DESCRIPTION
Fix #786 #802. The non-ray version ppo's `remote_rm_url` is a string.