### PR TITLE
feat: add hybrid engine and vLLM/DeepSpeed API integration

### DIFF
--- a/examples/scripts/train_grpo_ray_hybrid_engine.sh
+++ b/examples/scripts/train_grpo_ray_hybrid_engine.sh
@@ -9,10 +9,10 @@ ray job submit --address="http://127.0.0.1:8265" \
    --reward_num_gpus_per_node 8 \
    --actor_num_nodes 1 \
    --actor_num_gpus_per_node 8 \
-   --vllm_num_engines 2 \
-   --vllm_tensor_parallel_size 4 \
+   --vllm_num_engines 8 \
+   --vllm_tensor_parallel_size 1 \
    --colocate_all_models \
-   --vllm_gpu_memory_utilization 0.6 \
+   --vllm_gpu_memory_utilization 0.8 \
    --init_kl_coef 1e-3 \
    --gamma 1.0 \
    --use_kl_loss \
@@ -40,9 +40,10 @@ ray job submit --address="http://127.0.0.1:8265" \
    --input_key context_messages \
    --apply_chat_template \
    --normalize_reward \
-   --adam_offload \
    --gradient_checkpointing \
    --packing_samples \
    --vllm_sync_backend nccl \
-   --enforce_eager \
-   --vllm_enable_sleep
+   --enforce_eager
+
+# colocate_all_models automatically configures vllm_enable_sleep 
+# and deepspeed_enable_sleep. It is not recommended to set adam_offload manually.

--- a/examples/scripts/train_ppo_llama_ray_hybrid_engine.sh
+++ b/examples/scripts/train_ppo_llama_ray_hybrid_engine.sh
@@ -11,10 +11,10 @@ ray job submit --address="http://127.0.0.1:8265" \
    --critic_num_gpus_per_node 8 \
    --actor_num_nodes 1 \
    --actor_num_gpus_per_node 8 \
-   --vllm_num_engines 2 \
-   --vllm_tensor_parallel_size 4 \
+   --vllm_num_engines 8 \
+   --vllm_tensor_parallel_size 1 \
    --colocate_all_models \
-   --vllm_gpu_memory_utilization 0.4 \
+   --vllm_gpu_memory_utilization 0.8 \
    --pretrain OpenRLHF/Llama-3-8b-sft-mixture \
    --reward_pretrain OpenRLHF/Llama-3-8b-rm-700k \
    --save_path /openrlhf/examples/test_scripts/final/llama3-8b-rlhf \
@@ -38,9 +38,10 @@ ray job submit --address="http://127.0.0.1:8265" \
    --input_key context_messages \
    --apply_chat_template \
    --normalize_reward \
-   --adam_offload \
    --gradient_checkpointing \
    --packing_samples \
    --vllm_sync_backend nccl \
-   --enforce_eager \
-   --vllm_enable_sleep
+   --enforce_eager
+
+# colocate_all_models automatically configures vllm_enable_sleep 
+# and deepspeed_enable_sleep. It is not recommended to set adam_offload manually.

--- a/examples/scripts/train_reinforce_llama_ray_hybrid_engine.sh
+++ b/examples/scripts/train_reinforce_llama_ray_hybrid_engine.sh
@@ -9,10 +9,10 @@ ray job submit --address="http://127.0.0.1:8265" \
    --reward_num_gpus_per_node 8 \
    --actor_num_nodes 1 \
    --actor_num_gpus_per_node 8 \
-   --vllm_num_engines 2 \
-   --vllm_tensor_parallel_size 4 \
+   --vllm_num_engines 8 \
+   --vllm_tensor_parallel_size 1 \
    --colocate_all_models \
-   --vllm_gpu_memory_utilization 0.6 \
+   --vllm_gpu_memory_utilization 0.8 \
    --advantage_estimator reinforce \
    --pretrain OpenRLHF/Llama-3-8b-sft-mixture \
    --reward_pretrain OpenRLHF/Llama-3-8b-rm-700k \
@@ -37,12 +37,13 @@ ray job submit --address="http://127.0.0.1:8265" \
    --input_key context_messages \
    --apply_chat_template \
    --normalize_reward \
-   --adam_offload \
    --gradient_checkpointing \
    --packing_samples \
    --vllm_sync_backend nccl \
-   --enforce_eager \
-   --vllm_enable_sleep
+   --enforce_eager
+
+# colocate_all_models automatically configures vllm_enable_sleep 
+# and deepspeed_enable_sleep. It is not recommended to set adam_offload manually.
 
 # You could also try
 #   --use_kl_loss \

--- a/openrlhf/trainer/ray/__init__.py
+++ b/openrlhf/trainer/ray/__init__.py
@@ -1,7 +1,7 @@
 from .launcher import DistributedTorchRayActor, PPORayActorGroup, ReferenceModelRayActor, RewardModelRayActor
 from .ppo_actor import ActorModelRayActor
 from .ppo_critic import CriticModelRayActor
-from .vllm_engine import create_vllm_engines
+from .vllm_engine import create_vllm_engines, batch_vllm_engine_call
 
 __all__ = [
     "DistributedTorchRayActor",
@@ -11,4 +11,5 @@ __all__ = [
     "ActorModelRayActor",
     "CriticModelRayActor",
     "create_vllm_engines",
+    "batch_vllm_engine_call",
 ]

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -172,7 +172,7 @@ class ActorPPOTrainer(PPOTrainer):
 
         return status
 
-    def training_step(self, experience: Experience, global_steps) -> Dict[str, float]:        
+    def training_step(self, experience: Experience, global_steps) -> Dict[str, float]:
         return self.training_step_actor(experience)
 
     def _broadcast_to_vllm(self):

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -369,7 +369,7 @@ class ActorModelRayActor(BasePPORole):
             self.consumed_samples = states["consumed_samples"]
             strategy.print(f"Loaded the checkpoint: {ckpt_path}, consumed_samples: {self.consumed_samples}")
         
-        # hack for deepseek offload
+        # hack for deepspeed offload
         from types import MethodType
         from .utils import offload_deepspeed_states, reload_deepspeed_states
         self.actor.offload_states = MethodType(offload_deepspeed_states, self.actor)

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -124,7 +124,7 @@ class CriticModelRayActor(BasePPORole):
             strategy.load_ckpt(self.critic, ckpt_path)
             strategy.print(f"Loaded the checkpoint: {ckpt_path}")
         
-        # hack for deepseek offload
+        # hack for deepspeed offload
         from types import MethodType
         from .utils import offload_deepspeed_states, reload_deepspeed_states
         self.critic.offload_states = MethodType(offload_deepspeed_states, self.critic)

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -58,15 +58,7 @@ class CriticPPOTrainer(PPOTrainer):
         return status_mean
 
     def training_step(self, experience: Experience) -> Dict[str, float]:
-        if self.strategy.args.deepspeed_enable_sleep:
-            self.critic.reload_states()
-
-        status = self.training_step_critic(experience)
-
-        if self.strategy.args.deepspeed_enable_sleep:
-            self.critic.offload_states()
-
-        return status
+        return self.training_step_critic(experience)
 
 
 @ray.remote(num_gpus=1)

--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -70,7 +70,7 @@ def offload_deepspeed_states(ctx, pin_memory=True, non_blocking=True):
             OffloadStateTypeEnum.contiguous_grad_buffer,
             OffloadStateTypeEnum.hp_params,
             # OffloadStateTypeEnum.lp_grads,
-            # OffloadStateTypeEnum.lp_params, # dangerous
+            # OffloadStateTypeEnum.lp_params, # Not released yet, fixed in https://github.com/deepspeedai/DeepSpeed/pull/7050
         ],
         device=OffloadDeviceEnum.cpu,
         pin_memory=pin_memory,

--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -28,3 +28,74 @@ def get_physical_gpu_id():
     device = torch.cuda.current_device()
     props = torch.cuda.get_device_properties(device)
     return str(props.uuid)
+
+
+#######################
+# deepspeed offload
+#######################
+from deepspeed.runtime.engine import DeepSpeedEngine
+
+
+def _get_deepspeed_engine(ctx) -> DeepSpeedEngine:
+    from openrlhf.models import Actor
+
+    model = ctx.model.model if isinstance(ctx.model, Actor) else ctx.model
+    assert isinstance(model, DeepSpeedEngine), "Model must be a DeepSpeedEngine instance"
+    
+    return model
+
+
+def offload_deepspeed_states(ctx, pin_memory=True, non_blocking=True):
+    assert ctx.model is not None
+
+    model = _get_deepspeed_engine(ctx)
+    zero_stage = model.zero_optimization_stage() # config['zero_optimization']['stage']
+    adam_offload = model.config['zero_optimization']['offload_optimizer']['device'] == 'cpu'
+
+    # state offloading not required when using Adam optimizer offloading
+    if adam_offload:
+        return
+
+    if zero_stage != 3:
+        raise NotImplementedError("Only Zero stage 3 is currently supported")
+
+    # if zero_stage == 3 and not adam_offload:
+    import torch
+
+    from deepspeed.runtime.zero.offload_config import OffloadStateTypeEnum, OffloadDeviceEnum
+
+    model.optimizer.offload_states(
+        include=[
+            OffloadStateTypeEnum.optim_states,
+            OffloadStateTypeEnum.contiguous_grad_buffer,
+            OffloadStateTypeEnum.hp_params,
+            # OffloadStateTypeEnum.lp_grads,
+            # OffloadStateTypeEnum.lp_params, # dangerous
+        ],
+        device=OffloadDeviceEnum.cpu,
+        pin_memory=pin_memory,
+        non_blocking=non_blocking,
+    )
+    model.empty_partition_cache()
+    torch.cuda.synchronize()
+
+
+def reload_deepspeed_states(ctx, non_blocking=True):
+    assert ctx.model is not None
+    
+    model = _get_deepspeed_engine(ctx)
+    zero_stage = model.zero_optimization_stage() # config['zero_optimization']['stage']
+    adam_offload = model.config['zero_optimization']['offload_optimizer']['device'] == 'cpu'
+    
+    # state offloading not required when using Adam optimizer offloading
+    if adam_offload:
+        return
+
+    if zero_stage != 3:
+        raise NotImplementedError("Only Zero stage 3 is currently supported")
+
+    # if zero_stage == 3 and not adam_offload:
+    import torch
+
+    ctx.model.reload_states(non_blocking=non_blocking)
+    torch.cuda.synchronize()

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -1,6 +1,7 @@
 import os
-
 import numpy as np
+from typing import Any, List
+
 import ray
 from ray.util.placement_group import placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
@@ -176,5 +177,33 @@ def create_vllm_engines(
                 enable_sleep_mode=vllm_enable_sleep,
             )
         )
+    
+    if vllm_enable_sleep:
+        batch_vllm_engine_call(vllm_engines, "sleep", rank_0_only=False)
 
     return vllm_engines
+
+
+def batch_vllm_engine_call(engines: List[Any], method_name: str, *args, rank_0_only: bool = True, **kwargs):
+    """
+    Batch call a method on multiple vLLM engines.
+    Args:
+        engines: List of vLLM engine instances
+        method_name: Name of the method to call
+        rank_0_only: Only execute on rank 0 if True
+        *args: Positional arguments to pass to the method
+        **kwargs: Keyword arguments to pass to the method
+    Returns:
+        List of results from ray.get() if on rank 0, None otherwise
+    """
+    import torch
+
+    if rank_0_only and torch.distributed.get_rank() != 0:
+        return None
+
+    refs = []
+    for engine in engines:
+        method = getattr(engine, method_name)
+        refs.append(method.remote(*args, **kwargs))
+
+    return ray.get(refs)


### PR DESCRIPTION
Currently, DeepSpeed has a [known bug](https://github.com/deepspeedai/DeepSpeed/pull/7050) where the implementation fails to offload `OffloadStateTypeEnum.lp_params`. This issue prevents the bug from being triggered under certain conditions.

As detailed in the [documentation](https://github.com/deepspeedai/DeepSpeed/blob/master/docs/code-docs/source/zero3.rst), I have configured the offloading settings as follows:

```python
include=[
    OffloadStateTypeEnum.optim_states,
    OffloadStateTypeEnum.contiguous_grad_buffer,
    OffloadStateTypeEnum.hp_params,
    # OffloadStateTypeEnum.lp_grads,
    # OffloadStateTypeEnum.lp_params,
]
```

By enabling the `--colocate_all_models` flag, we can seamlessly utilize the hybrid engine. However, since the `lp_params` and `lp_grads` of both the actor and critic models are not actually offloaded due to the aforementioned bug, it is advisable to slightly reduce the `--vllm_gpu_memory_utilization` parameter. For a 7B model in Reinforce++, a value of **0.8** is recommended to ensure stable performance while accounting for the additional memory overhead caused by this limitation.