### PR TITLE
fix ring attn in create_vllm_engines

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -88,7 +88,7 @@ def train(args):
             args.enable_prefix_caching,
             args.enforce_eager,
             max_len,
-            args.actor_num_nodes * args.actor_num_gpus_per_node,
+            args.actor_num_nodes * args.actor_num_gpus_per_node // args.ring_attn_size,
             pg if args.colocate_all_models else None,
             args.vllm_gpu_memory_utilization,
             args.vllm_enable_sleep,


### PR DESCRIPTION
When ring_attn is enable, only `args.actor_num_nodes * args.actor_num_gpus_per_node // args.ring_attn_size` actor will call `generate_samples` in make_experience_list.

The existed code will have a large `self.num_actors` which make the vllm can not get into `if self.actor_counter == self.num_actors:` in `add_requests`