### PR TITLE
Mitigate CUDA illegal memory access error when vLLM generate right after wake up

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -567,6 +567,8 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
         # vLLM wakeup when vllm_enable_sleep
         if self.strategy.args.vllm_enable_sleep:
             batch_vllm_engine_call(self.vllm_engines, "wake_up")
+            # TODO: Maybe better way to handle CUDA illegal memory access error?
+            time.sleep(1)
 
         if self.vllm_engines is None:
             return super().generate_samples(all_prompts, all_labels, **generate_kwargs)

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -67,10 +67,14 @@ class LLMRayActor:
         self.llm.llm_engine.reset_prefix_cache()
 
     def sleep(self, level=1):
+        self.llm.collective_rpc("sync_empty_cache")
         self.llm.sleep(level=level)
+        self.llm.collective_rpc("sync_empty_cache")
 
     def wake_up(self):
+        self.llm.collective_rpc("sync_empty_cache")
         self.llm.wake_up()
+        self.llm.collective_rpc("sync_empty_cache")
 
     def add_requests(self, actor_rank, *, sampling_params, prompt_token_ids):
         """

--- a/openrlhf/trainer/ray/vllm_worker_wrap.py
+++ b/openrlhf/trainer/ray/vllm_worker_wrap.py
@@ -73,3 +73,7 @@ class WorkerWrap(Worker):
         weight = func(*list_args)
         self.model_runner.model.load_weights(weights=[(name, weight)])
         torch.cuda.synchronize()
+
+    def sync_empty_cache(self):
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()


### PR DESCRIPTION
This error can happen when you run hybrid engine cross nodes, with small models (such as 1b). `torch.cuda.synchronize()` alone on each vLLM worker seems to be not enough, so we introduced 1 second of sleep as the mitigation here.

```log
  File "openrlhf/trainer/ray/vllm_engine.py", line 91, in add_requests
    responses = self.llm.generate(sampling_params=sampling_params, prompt_token_ids=requests)
  File ".conda/lib/python3.10/site-packages/vllm/utils.py", line 1080, in inner
    return fn(*args, **kwargs)
  File ".conda/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 470, in generate
    outputs = self._run_engine(use_tqdm=use_tqdm)
  File ".conda/lib/python3.10/site-packages/vllm/entrypoints/llm.py", line 1377, in _run_engine
    step_outputs = self.llm_engine.step()
  File ".conda/lib/python3.10/site-packages/vllm/engine/llm_engine.py", line 1391, in step
    outputs = self.model_executor.execute_model(
  File ".conda/lib/python3.10/site-packages/vllm/executor/executor_base.py", line 139, in execute_model
    output = self.collective_rpc("execute_model",
  File ".conda/lib/python3.10/site-packages/vllm/executor/uniproc_executor.py", line 56, in collective_rpc
    answer = run_method(self.driver_worker, method, args, kwargs)
  File ".conda/lib/python3.10/site-packages/vllm/utils.py", line 2232, in run_method
    return func(*args, **kwargs)
  File ".conda/lib/python3.10/site-packages/vllm/worker/worker_base.py", line 420, in execute_model
    output = self.model_runner.execute_model(
  File ".conda/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File ".conda/lib/python3.10/site-packages/vllm/worker/model_runner.py", line 1783, in execute_model
    output: SamplerOutput = self.model.sample(
  File ".conda/lib/python3.10/site-packages/vllm/model_executor/models/llama.py", line 545, in sample
    next_tokens = self.sampler(logits, sampling_metadata)
  File ".conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File ".conda/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1747, in _call_impl
    return forward_call(*args, **kwargs)
  File ".conda/lib/python3.10/site-packages/vllm/model_executor/layers/sampler.py", line 244, in forward
    self._init_sampling_tensors(logits, sampling_metadata)
  File ".conda/lib/python3.10/site-packages/vllm/model_executor/layers/sampler.py", line 208, in _init_sampling_tensors
    do_min_p) = SamplingTensors.from_sampling_metadata(
  File ".conda/lib/python3.10/site-packages/vllm/model_executor/sampling_metadata.py", line 480, in from_sampling_metadata
    sampling_tensors = SamplingTensors.from_lists(
  File ".conda/lib/python3.10/site-packages/vllm/model_executor/sampling_metadata.py", line 538, in from_lists
    temperatures_t = torch.tensor(
RuntimeError: CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```