### PR TITLE
fix: load_from_disk

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -73,8 +73,13 @@ def blending_datasets(
             strategy.print(f"loaded {dataset} with data_files={dataset}")
         # local dataset saved with `datasets.Dataset.save_to_disk`
         elif os.path.isdir(dataset):
-            data = load_from_disk(dataset)
-            strategy.print(f"loaded {dataset} from disk")
+            try:
+                data = load_from_disk(dataset)
+                strategy.print(f"loaded {dataset} from disk")
+            except Exception as e:
+                strategy.print(f"failed to load {dataset} from disk: {e}")
+                data = load_dataset(dataset, data_dir=data_dir)
+                strategy.print(f"loaded {dataset} from files")
         # remote/local folder or common file
         else:
             data = load_dataset(dataset, data_dir=data_dir)


### PR DESCRIPTION
Close: #751 

The previous bug was that if the user loaded a downloaded model folder (which is very common), it was still considered a file by the logic of `os.path.isdir`, and `load_from_disk` was called to handle it.
However, `load_from_disk` can only handle model folders saved by `datasets.Dataset.save_to_disk`, leading to errors.
Therefore, in this PR, try-except logic has been added. If an error occurs, `load_dataset` is used instead.

这里之前的bug是，如果用户载入的是下载的模型文件夹（这种情况非常经常），也被`os.path.isdir`的逻辑认为是文件，从而调用`load_from_disk`来处理。
但是`load_from_disk`只能处理`datasets.Dataset.save_to_disk`保存的模型文件夹，从而造成报错。
所以在本PR中增加了try except逻辑，如果报错则使用`load_dataset`。