### PR TITLE
Fix typo in README_zh.md

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -171,7 +171,7 @@ data
 
 > [!NOTE]
 >默认情况下我们使用 `train` 和 `test` 作为 split 区分 Huggingface 的训练/测试数据。
->`JSON key` 选项取决于具体的数据集。请参阅 [Reward Dataset](https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/datasets/reward_dataset.py#L10) 和 [SFT Dataset](https://github.com/OpenRLHF/OpenRLHF/blob/mai
+>`JSON key` 选项取决于具体的数据集。请参阅 [Reward Dataset](https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/datasets/reward_dataset.py#L10) 和 [SFT Dataset](https://github.com/OpenRLHF/OpenRLHF/blob/main/openrlhf/datasets/sft_dataset.py#L9)
 
 
 ### Supervised Fine-tuning


### PR DESCRIPTION
SFT Dataset link error in https://github.com/OpenRLHF/OpenRLHF/blob/main/README_zh.md#准备数据集