### PR TITLE
Fix generation without vLLM

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -317,6 +317,7 @@ class NaiveExperienceMaker(ABC):
                 total_length=attention_mask.float().sum(dim=-1),
                 prompts=prompts,
                 labels=labels,
+                pad_len=None,
             )
             samples_list.append(samples)
         return samples_list


### PR DESCRIPTION
`pad_len` is missing when initializing `Samples` in `generate_samples` of `NaiveExperienceMaker`.