### PR TITLE
Fix temperature alignment

### DIFF
--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -30,7 +30,7 @@ def train(args):
         target_modules=args.target_modules,
         lora_dropout=args.lora_dropout,
         ds_config=strategy.get_ds_train_config(is_actor=True),
-        temperature=args.temperature, 
+        temperature=args.temperature,
     )
 
     if args.actor_init_on_gpu:
@@ -51,7 +51,7 @@ def train(args):
             ds_config=strategy.get_ds_train_config(is_actor=False),
             value_head_prefix=args.value_head_prefix,
             init_value_head=strategy.args.pretrain == strategy.args.critic_pretrain,
-            temperature=args.temperature, 
+            temperature=args.temperature,
         )
     else:
         critic = None

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -51,7 +51,6 @@ def train(args):
             ds_config=strategy.get_ds_train_config(is_actor=False),
             value_head_prefix=args.value_head_prefix,
             init_value_head=strategy.args.pretrain == strategy.args.critic_pretrain,
-            temperature=args.temperature,
         )
     else:
         critic = None
@@ -87,6 +86,7 @@ def train(args):
         bf16=args.bf16,
         load_in_4bit=args.load_in_4bit,
         ds_config=strategy.get_ds_eval_config(offload=False),
+        temperature=args.temperature,
     )
 
     if args.enable_ema:

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -30,6 +30,7 @@ def train(args):
         target_modules=args.target_modules,
         lora_dropout=args.lora_dropout,
         ds_config=strategy.get_ds_train_config(is_actor=True),
+        temperature=args.temperature, 
     )
 
     if args.actor_init_on_gpu:
@@ -50,6 +51,7 @@ def train(args):
             ds_config=strategy.get_ds_train_config(is_actor=False),
             value_head_prefix=args.value_head_prefix,
             init_value_head=strategy.args.pretrain == strategy.args.critic_pretrain,
+            temperature=args.temperature, 
         )
     else:
         critic = None

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -245,5 +245,5 @@ if __name__ == "__main__":
     # TODO: [packing samples]
     if args.ring_attn_size > 1:
         assert args.packing_samples, "packing_samples must be enabled when using ring attention"
-    
+
     train(args)

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -168,8 +168,10 @@ class SFTDataset(Dataset):
 
         packed_input_ids = torch.cat(packed_input_ids, dim=0).unsqueeze(0)
         packed_attention_masks = torch.cat(packed_attention_masks, dim=0).unsqueeze(0)
-        
-        if self.multiple_of > 1 and packed_input_ids.numel() % self.multiple_of != 0: # not divisible by multiple_of; here we align for grouping
+
+        if (
+            self.multiple_of > 1 and packed_input_ids.numel() % self.multiple_of != 0
+        ):  # not divisible by multiple_of; here we align for grouping
             padding_len = self.multiple_of - (packed_input_ids.numel() % self.multiple_of)
             packed_input_ids = F.pad(packed_input_ids, (0, padding_len), value=self.tokenizer.pad_token_id)
             packed_attention_masks = F.pad(packed_attention_masks, (0, padding_len), value=0)

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -45,6 +45,7 @@ class Actor(nn.Module):
         ds_config=None,
         device_map=None,
         packing_samples=False,
+        temperature=1.,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -117,6 +118,7 @@ class Actor(nn.Module):
             self.packing_samples = packing_samples
         else:
             self.model = pretrain_or_model
+        self.temperature = temperature
 
     @torch.no_grad()
     def generate(self, input_ids: torch.Tensor, **kwargs) -> Union[
@@ -211,7 +213,7 @@ class Actor(nn.Module):
             assert return_output
             return output
 
-        log_probs = log_probs_from_logits(output["logits"][:, :-1, :], sequences[:, 1:])
+        log_probs = log_probs_from_logits(output["logits"][:, :-1, :], sequences[:, 1:], self.temperature)
 
         if not self.packing_samples:
             action_log_probs = log_probs[:, -num_actions:]

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -45,7 +45,7 @@ class Actor(nn.Module):
         ds_config=None,
         device_map=None,
         packing_samples=False,
-        temperature=1.,
+        temperature=1.0,
         **kwargs,
     ) -> None:
         super().__init__()

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -74,7 +74,7 @@ def compute_reward(
     return reward
 
 
-def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
+def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor, temperature: float = 1.0) -> torch.Tensor:
     logits.div_(temperature)
     log_probs = F.log_softmax(logits, dim=-1)
     log_probs_labels = log_probs.gather(dim=-1, index=labels.unsqueeze(-1))

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -74,7 +74,8 @@ def compute_reward(
     return reward
 
 
-def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor, temperature: float = 1.) -> torch.Tensor:
+    logits.div_(temperature)
     log_probs = F.log_softmax(logits, dim=-1)
     log_probs_labels = log_probs.gather(dim=-1, index=labels.unsqueeze(-1))
     return log_probs_labels.squeeze(-1)

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -9,9 +9,9 @@ from ray.util.placement_group import PlacementGroup, placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from openrlhf.models import Actor, get_llm_for_sequence_regression
+from openrlhf.trainer.ray.utils import ray_noset_visible_devices
 from openrlhf.utils.deepspeed import DeepspeedStrategy
 
-from openrlhf.trainer.ray.utils import ray_noset_visible_devices
 
 class DistributedTorchRayActor:
     def __init__(self, world_size, rank, master_addr, master_port):

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -2,10 +2,7 @@ import os
 from abc import ABC
 
 import torch
-import torch.distributed as dist
-from flash_attn.utils.distributed import all_gather
 from torch.optim import Optimizer
-from torch.nn import functional as F
 from tqdm import tqdm
 
 from openrlhf.models import GPTLMLoss
@@ -141,8 +138,8 @@ class SFTTrainer(ABC):
                     output = self.model(inputs, attention_mask=attention_mask, return_output=True)
                 else:
                     output = self.model(
-                        inputs, 
-                        attention_mask=attention_mask, 
+                        inputs,
+                        attention_mask=attention_mask,
                         return_output=True,
                         ring_attn_group=self.strategy.ring_attn_group,
                         packed_seq_lens=infos["input_length"],
@@ -251,13 +248,13 @@ class SFTTrainer(ABC):
                     output = self.model(inputs, attention_mask=attention_mask, return_output=True)
                 else:
                     output = self.model(
-                        inputs, 
-                        attention_mask=attention_mask, 
+                        inputs,
+                        attention_mask=attention_mask,
                         return_output=True,
                         ring_attn_group=self.strategy.ring_attn_group,
                         packed_seq_lens=infos["input_length"],
                     )
-                    
+
                 # loss function
                 labels = torch.where(
                     attention_mask.bool(),
@@ -292,4 +289,3 @@ class SFTTrainer(ABC):
                     for k, v in logs.items():
                         self._tensorboard.add_scalar(f"eval/{k}", v, steps)
         self.model.train()  # reset model state
-        


### PR DESCRIPTION
There exsits a misalignment between the log_probs of rollout sampling and log_probs for kl-div.
When conduct PPO training, the temperature can be specified for rollout sampling.
However, the log_probs used for KL-div calculation are directy calculated based on logits and ignores the temperature, which incurs misalignment.
This PR fix this misalignment.
