### PR TITLE
Support full determinism option

### DIFF
--- a/openrlhf/cli/batch_inference.py
+++ b/openrlhf/cli/batch_inference.py
@@ -301,6 +301,12 @@ if __name__ == "__main__":
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
     parser.add_argument("--micro_batch_size", type=int, default=16)
     parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
 
     # Models
     parser.add_argument("--pretrain", type=str, default=None, help="HF pretrain model name or path")

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -176,6 +176,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -157,6 +157,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -149,6 +149,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")

--- a/openrlhf/cli/train_ppo.py
+++ b/openrlhf/cli/train_ppo.py
@@ -349,6 +349,12 @@ if __name__ == "__main__":
 
     # DeepSpeed
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -317,6 +317,12 @@ if __name__ == "__main__":
     parser.add_argument("--top_p", type=float, default=1.0)
     parser.add_argument("--temperature", type=float, default=1.0)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--freezing_actor_steps", type=int, default=-1, help="Used for critic initialization")
     parser.add_argument(
         "--n_samples_per_prompt", type=int, default=1, help="number of responses for each prompt in generation"

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -136,6 +136,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -161,6 +161,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -161,6 +161,12 @@ if __name__ == "__main__":
     parser.add_argument("--gradient_checkpointing", action="store_true", default=False)
     parser.add_argument("--torch_compile", action="store_true", default=False)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--full_determinism",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument("--bf16", action="store_true", default=False, help="Enable bfloat16")

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -1,5 +1,4 @@
 import os
-import random
 import shutil
 from abc import ABC
 from collections import defaultdict
@@ -7,10 +6,11 @@ from datetime import timedelta
 from typing import List, Tuple, Union
 
 import deepspeed
-import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
+import transformers
+import transformers.modeling_flash_attention_utils
 from deepspeed.ops.adam import DeepSpeedCPUAdam, FusedAdam
 from peft import PeftModel, get_peft_model_state_dict
 from torch import distributed as dist
@@ -40,6 +40,7 @@ class DeepspeedStrategy(ABC):
     def __init__(
         self,
         seed: int = 42,
+        full_determinism: bool = False,
         max_norm: float = 0.0,
         micro_train_batch_size=1,
         train_batch_size=1,
@@ -55,6 +56,7 @@ class DeepspeedStrategy(ABC):
         self.micro_train_batch_size = micro_train_batch_size
         self.bf16 = bf16
         self.seed = seed
+        self.full_determinism = full_determinism
         self.max_norm = max_norm
         self.adam_offload = getattr(args, "adam_offload", False)
         self.zpg = getattr(args, "zpg", 1)
@@ -66,14 +68,14 @@ class DeepspeedStrategy(ABC):
         self.is_rlhf = False
         self.time_steps = defaultdict(int)
 
-    def set_seed(self, seed: int) -> None:
-        random.seed(seed)
-        np.random.seed(seed)
-        torch.manual_seed(seed)
-        torch.cuda.manual_seed_all(seed)
-
     def setup_distributed(self, timeout=timedelta(minutes=60)) -> None:
-        self.set_seed(self.seed)
+        if self.full_determinism:
+            transformers.enable_full_determinism(self.seed)
+            # Use deterministic backward in flash attention as, by default, flash attention uses atomic adds
+            # https://github.com/Dao-AILab/flash-attention/commit/732654583c2e640adc012ecb60e460bf19dcd9e3
+            transformers.modeling_flash_attention_utils.deterministic_g = True
+        else:
+            transformers.set_seed(self.seed)
 
         # Take the local rank from args as first priority
         if self.args.local_rank != -1:

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -22,6 +22,7 @@ def get_strategy(args):
 
     strategy = DeepspeedStrategy(
         seed=getattr(args, "seed", 42),
+        full_determinism=getattr(args, "full_determinism", False),
         max_norm=getattr(args, "max_norm", 1.0),
         micro_train_batch_size=getattr(args, "micro_train_batch_size", 1),
         train_batch_size=getattr(args, "train_batch_size", 128),


### PR DESCRIPTION
Fix #745 and #834

The non-determinism mainly comes from the flash attention, as in the backward pass, by default, flash attention uses atomic adds for performance. Deterministic backward is implemented in v2.4.1 but not enabled by default, as it's slightly slower and uses more memory:
https://github.com/Dao-AILab/flash-attention/commit/732654583c2e640adc012ecb60e460bf19dcd9e3

In addition, we switch the set_seed to transformers' helper function, to remove code duplication.