### PR TITLE
CUDA synchronize before empty cache when make experience

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -714,6 +714,7 @@ class RemoteExperienceMaker(NaiveExperienceMaker):
             ray.get([self.reward_model[0].empty_cache.remote()])
 
         if args.colocate_actor_ref or args.colocate_all_models:
+            torch.cuda.synchronize()
             torch.cuda.empty_cache()
 
         if (self.initial_model is not None) and (not args.use_kl_loss):

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -105,6 +105,7 @@ class ReferenceModelRayActor(BasePPORole):
         return log_probs.to("cpu")
 
     def empty_cache(self) -> None:
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
 
@@ -152,6 +153,7 @@ class RewardModelRayActor(BasePPORole):
         return reward.to("cpu")
 
     def empty_cache(self) -> None:
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
 

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -188,6 +188,7 @@ class CriticModelRayActor(BasePPORole):
         return status
 
     def empty_cache(self) -> None:
+        torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
     def save_model(self):


### PR DESCRIPTION
On AMD clusters, sometimes it will stuck in the forward pass when we make experience, which seems to be caused by the previous empty cache call. This PR implement the fix by doing the CUDA (HIP) sunchronize first before we empty cache.