### PR TITLE
optimize logpros from logits temperary memory

### DIFF
--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -88,16 +88,37 @@ def compute_reward(
     return reward
 
 
+def _logsumexp_by_chunk(logits: torch.Tensor, chunk_size: int = 1024) -> torch.Tensor:
+    seq_len = logits.shape[0]
+    logsumexp_values = torch.zeros(
+        (seq_len), device=logits.device, dtype=logits.dtype
+    )
+    for s_idx in range(0, seq_len, chunk_size):
+        end_idx = min(s_idx + chunk_size, seq_len)
+        logsumexp_values[s_idx:end_idx] = torch.logsumexp(
+            logits[s_idx:end_idx], dim=-1
+        )
+
+    return logsumexp_values
+
+
 def log_probs_from_logits(logits: torch.Tensor, labels: torch.Tensor, temperature: float = 1.0) -> torch.Tensor:
     if temperature != 1.0:
         logits.div_(temperature)
     # https://github.com/OpenRLHF/OpenRLHF/pull/718#issuecomment-2641081881
     if logits.dtype in [torch.float32, torch.float64]:
-        logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
-        logsumexp_values = torch.stack(
-            [torch.logsumexp(l, dim=-1) for l in logits]  # loop to reduce peak mem consumption
-        )
-        log_probs_labels = logits_labels - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
+        batch_dim = logits.shape[:-1]
+        last_dim = logits.shape[-1]
+        try:
+            from flash_attn.ops.triton.cross_entropy import cross_entropy_loss
+
+            output = cross_entropy_loss(logits.reshape(-1, last_dim), labels.reshape(-1))
+            log_probs_labels = -output[0].view(*batch_dim)
+        except ImportError:
+            logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
+            logsumexp_values = _logsumexp_by_chunk(logits.reshape(-1, last_dim))
+            logsumexp_values = logsumexp_values.view(*batch_dim)
+            log_probs_labels = logits_labels - logsumexp_values  # log_softmax(x_i) = x_i - logsumexp(x)
     else:
         log_probs_labels = []
         for row_logits, row_labels in zip(logits, labels):  # loop to reduce peak mem consumption

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -90,14 +90,10 @@ def compute_reward(
 
 def _logsumexp_by_chunk(logits: torch.Tensor, chunk_size: int = 1024) -> torch.Tensor:
     seq_len = logits.shape[0]
-    logsumexp_values = torch.zeros(
-        (seq_len), device=logits.device, dtype=logits.dtype
-    )
+    logsumexp_values = torch.zeros((seq_len), device=logits.device, dtype=logits.dtype)
     for s_idx in range(0, seq_len, chunk_size):
         end_idx = min(s_idx + chunk_size, seq_len)
-        logsumexp_values[s_idx:end_idx] = torch.logsumexp(
-            logits[s_idx:end_idx], dim=-1
-        )
+        logsumexp_values[s_idx:end_idx] = torch.logsumexp(logits[s_idx:end_idx], dim=-1)
 
     return logsumexp_values
 


### PR DESCRIPTION
验证脚本：
'''python
import gc
import time

import torch
from openrlhf.models.utils import _logsumexp_by_chunk


def report_memory(name):
    """简单的GPU内存报告"""
    mega_bytes = 1024.0 * 1024.0
    string = name + " 显存 (MB)"
    string += f" | 已分配: {torch.cuda.memory_allocated() / mega_bytes:.2f}"
    string += f" | 最大已分配: {torch.cuda.max_memory_allocated() / mega_bytes:.2f}"
    string += f" | 已保留: {torch.cuda.memory_reserved() / mega_bytes:.2f}"
    string += f" | 最大已保留: {torch.cuda.max_memory_reserved() / mega_bytes:.2f}"
    print(string)


def base_method(logits, labels):
    """基础方法"""
    logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
    logsumexp_values = torch.logsumexp(logits, dim=-1)
    log_probs_labels = logits_labels - logsumexp_values
    return log_probs_labels


def current_method(logits, labels):
    """当前方法"""
    logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
    logsumexp_values = torch.stack(
        [torch.logsumexp(l, dim=-1) for l in logits]  # 循环以减少峰值内存消耗
    )
    log_probs_labels = logits_labels - logsumexp_values
    return log_probs_labels


def optimized_method_1(logits, labels):
    """优化方法1：flash attn cross_entropy_loss"""
    from flash_attn.ops.triton.cross_entropy import cross_entropy_loss

    batch_dim = logits.shape[:-1]
    last_dim = logits.shape[-1]
    output = cross_entropy_loss(logits.reshape(-1, last_dim), labels.reshape(-1))
    log_probs_labels = -output[0].view(*batch_dim)
    return log_probs_labels


def optimized_method_2(logits, labels):
    """优化方法2：按序列分块处理"""
    batch_dim = logits.shape[:-1]
    last_dim = logits.shape[-1]
    logits_labels = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
    logsumexp_values = _logsumexp_by_chunk(logits.reshape(-1, last_dim))
    logsumexp_values = logsumexp_values.view(*batch_dim)
    log_probs_labels = logits_labels - logsumexp_values
    return log_probs_labels


def run_test(
    method, logits, labels, method_name, warmup_iterations=3, test_iterations=10
):
    """运行测试并报告显存使用，包含预热和多次测试取平均

    Args:
        method: 要测试的函数
        logits: 输入logits
        labels: 输入labels
        method_name: 方法名称，用于打印
        warmup_iterations: 预热迭代次数
        test_iterations: 测试迭代次数

    Returns:
        result: 函数返回结果
    """
    # 清理显存
    torch.cuda.empty_cache()
    gc.collect()
    torch.cuda.reset_peak_memory_stats()

    report_memory(f"[{method_name}] 开始前")

    # 测试阶段
    print(f"[{method_name}] 开始测试 ({test_iterations}次)...")
    times = []

    # 第一次运行，获取结果并测量显存
    start_time = time.time()
    result = method(logits, labels)
    torch.cuda.synchronize()
    end_time = time.time()
    times.append(end_time - start_time)

    # 报告第一次运行的显存使用
    report_memory(f"[{method_name}] 第一次运行后")

    # 预热阶段
    print(f"[{method_name}] 开始预热 ({warmup_iterations}次)...")
    for _ in range(warmup_iterations):
        _ = method(logits, labels)
        torch.cuda.synchronize()  # 确保GPU操作完成

    print(f"[{method_name}] 预热结束...")

    # 额外的测试运行，只测量时间
    for _ in range(1, test_iterations):
        start_time = time.time()
        _ = method(logits, labels)
        torch.cuda.synchronize()
        end_time = time.time()
        times.append(end_time - start_time)

    # 打印每次运行的时间
    print(f"[{method_name}] 各次运行时间:")
    for i, t in enumerate(times):
        print(f"  - 运行 {i+1}: {t:.4f} 秒")

    # 计算平均时间和标准差
    avg_time = sum(times) / len(times)
    std_time = (sum((t - avg_time) ** 2 for t in times) / len(times)) ** 0.5

    # 计算吞吐量
    batch_size, seq_len = labels.shape
    tokens_per_second = (batch_size * seq_len) / avg_time

    # 报告性能指标
    print(f"[{method_name}] 平均运行时间: {avg_time:.4f} ± {std_time:.4f} 秒")
    print(f"[{method_name}] 吞吐量: {tokens_per_second:.2f} tokens/秒")
    print("-" * 80)

    return result


def main():
    # 设置随机种子以确保可重复性
    torch.manual_seed(42)

    # 使用较小的尺寸进行测试，以避免直接OOM
    # 实际测试中可以根据GPU容量调整这些参数
    b = 1
    s = 12 * 1024 * 4  # 使用较小的序列长度进行测试
    v = 152064  # 使用较小的词汇表大小进行测试

    print(f"测试参数: batch_size={b}, seq_len={s}, vocab_size={v}")
    print(f"总token数: {b * s}")
    print("-" * 80)

    # 创建测试数据
    logits = torch.randn(b, s, v, dtype=torch.float32, device="cuda")
    labels = torch.randint(0, v, (b, s), dtype=torch.long, device="cuda")

    report_memory("数据加载后")
    print("-" * 80)

    # 测试基础方法
    try:
        result_base = run_test(base_method, logits, labels, "基础方法")
    except RuntimeError as e:
        print(f"[基础方法] 出错: {e}")

    # 测试当前方法
    try:
        result_current = run_test(current_method, logits, labels, "当前方法")
    except RuntimeError as e:
        print(f"[当前方法] 出错: {e}")

    # 测试优化方法1
    try:
        result_opt1 = run_test(
            optimized_method_1,
            logits,
            labels,
            "优化方法1(flash attn cross_entropy_loss)",
        )
    except RuntimeError as e:
        print(f"[优化方法1] 出错: {e}")

    # 测试优化方法2
    try:
        result_opt2 = run_test(
            optimized_method_2, logits, labels, "优化方法2(按序列分块处理)"
        )
    except RuntimeError as e:
        print(f"[优化方法2] 出错: {e}")

    # 验证结果一致性
    try:
        if "result_base" in locals() and "result_current" in locals():
            print(
                f"基础方法与当前方法结果差异: {torch.max(torch.abs(result_base - result_current))}"
            )
        if "result_base" in locals() and "result_opt1" in locals():
            print(
                f"基础方法与优化方法1结果差异: {torch.max(torch.abs(result_base - result_opt1))}"
            )
        if "result_base" in locals() and "result_opt2" in locals():
            print(
                f"基础方法与优化方法2结果差异: {torch.max(torch.abs(result_base - result_opt2))}"
            )
    except Exception as e:
        print(f"比较结果时出错: {e}")


if __name__ == "__main__":
    main()
'''
运行结果：
![image](https://github.com/user-attachments/assets/9e93bb62-47e6-459c-9b24-09a256d0f28b)

