### PR TITLE
Support DeepSpeed universal checkpoints

### DIFF
--- a/examples/scripts/ckpt_ds_zero_to_universal.sh
+++ b/examples/scripts/ckpt_ds_zero_to_universal.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Ensure at least one argument is provided.
+if [ "$#" -lt 1 ]; then
+    echo "This script converts the latest DeepSpeed ZeRO checkpoint to a universal checkpoint."
+    echo "Usage: $0 <CKPT_PATH> [additional arguments for deepspeed.checkpoint.ds_to_universal]"
+    exit 1
+fi
+
+# Set CKPT_PATH to the first argument and shift it out so that "$@" contains the extra arguments.
+CKPT_PATH="$1"
+shift
+EXTRA_ARGS="$@"
+
+# Function to process a given directory.
+process_dir() {
+    local path="$1"
+    echo "Processing checkpoint: $path"
+    
+    # Check if the latest tag exists.
+    if [ ! -f "$path/latest" ]; then
+        echo "latest tag file not found in $path, ensure the directory contains a valid DeepSpeed ZeRO checkpoint."
+        return 1
+    fi
+
+    # Read the latest tag.
+    LATEST_TAG=$(cat "$path/latest")
+    LATEST_UNI_TAG="${LATEST_TAG}_uni"
+    
+    # Write the universal tag.
+    echo "$LATEST_UNI_TAG" > "$path/latest_universal"
+    
+    # Run the python command with any additional arguments.
+    python -m deepspeed.checkpoint.ds_to_universal --inject_missing_state \
+        --input_folder "$path/$LATEST_TAG" \
+        --output_folder "$path/$LATEST_UNI_TAG" \
+        $EXTRA_ARGS
+}
+
+# Flag to check if at least one of the specific subdirectories exists.
+found_subdir=0
+
+## For PPO, checkpoints for each model are stored under "_actor" and "_critic" separately.
+# Check for the subdirectory named exactly "_actor".
+if [ -d "$CKPT_PATH/_actor" ]; then
+    process_dir "$CKPT_PATH/_actor"
+    found_subdir=1
+fi
+
+# Check for the subdirectory named exactly "_critic".
+if [ -d "$CKPT_PATH/_critic" ]; then
+    process_dir "$CKPT_PATH/_critic"
+    found_subdir=1
+fi
+
+# If neither subdirectory exists, process the main CKPT_PATH.
+if [ "$found_subdir" -eq 0 ]; then
+    process_dir "$CKPT_PATH"
+fi

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -167,6 +167,7 @@ if __name__ == "__main__":
     parser.add_argument("--ckpt_path", type=str, default="./ckpt/checkpoints_dpo")
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--micro_train_batch_size", type=int, default=8, help="batch size per GPU")

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -149,6 +149,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--micro_train_batch_size", type=int, default=8, help="batch size per GPU")

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -141,6 +141,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--max_norm", type=float, default=1.0, help="Gradient clipping")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -259,6 +259,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -130,6 +130,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--max_norm", type=float, default=1.0, help="Gradient clipping")

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -155,6 +155,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--max_norm", type=float, default=1.0, help="Gradient clipping")

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -153,6 +153,7 @@ if __name__ == "__main__":
     parser.add_argument("--max_ckpt_num", type=int, default=3)
     parser.add_argument("--max_ckpt_mem", type=int, default=1e8)
     parser.add_argument("--load_checkpoint", action="store_true", default=False)
+    parser.add_argument("--universal_ckpt", action="store_true", default=False)
 
     # DeepSpeed
     parser.add_argument("--micro_train_batch_size", type=int, default=8, help="batch size per GPU")

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -64,6 +64,7 @@ class DeepspeedStrategy(ABC):
         # overlap_comm
         self.overlap_comm = getattr(args, "overlap_comm", False)
         self.torch_compile = getattr(args, "torch_compile", False)
+        self.universal_ckpt = getattr(args, "universal_ckpt", False)
 
         self.is_rlhf = False
         self.time_steps = defaultdict(int)
@@ -238,6 +239,7 @@ class DeepspeedStrategy(ABC):
             zpg=self.zpg,
             grad_accum_dtype=self.grad_accum_dtype,
             overlap_comm=self.overlap_comm,
+            universal_ckpt=self.universal_ckpt,
         )
 
         ds_config["train_micro_batch_size_per_gpu"] = self.micro_train_batch_size

--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -10,6 +10,7 @@ def get_train_ds_config(
     zpg=8,
     grad_accum_dtype=None,
     overlap_comm=False,
+    universal_ckpt=False,
 ):
     device = "cpu" if offload else "none"
     zero_opt_dict = {
@@ -46,6 +47,9 @@ def get_train_ds_config(
         "prescale_gradients": False,
         "wall_clock_breakdown": False,
         "data_types": {"grad_accum_dtype": grad_accum_dtype},
+        "checkpoint": {
+            "load_universal": universal_ckpt,
+        },
     }
 
 


### PR DESCRIPTION
This PR adds support for the DeepSpeed universal checkpoints to OpenRLHF, so that it can support resume training from a different configurations (e.g. ZeRO-stage or DP size)

When users are expected to change training configurations, they can first convert the saved DeepSpeed Zero checkpoint to the universal checkpoint via `examples/scripts/ckpt_ds_zero_to_universal.sh <CKPT_PATH>`, then start the training again, by using `--universal_ckpt` in addition to `--load_checkpoint`, together with the modified configurations.

Reference https://www.deepspeed.ai/tutorials/universal-checkpointing/