### PR TITLE
Fix Tokenizer Behavior for Special Placeholder Token

### DIFF
--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -128,6 +128,7 @@ def blending_datasets(
 
 
 def convert_token_to_id(token, tokenizer):
+    tokenizer.add_tokens([token], special_tokens=True)
     if isinstance(token, str):
         token = tokenizer.encode(token, add_special_tokens=False)
         assert len(token) == 1


### PR DESCRIPTION
#### **Problem Description**
When using the `Qwen2.5-Math-PRM-7B` model, the placeholder token `<extra_0>` is split into multiple sub-tokens by the tokenizer. This behavior disrupts the intended functionality of the placeholder token, which is designed to remain as a single, intact token during tokenization.

For example:
```python
tokenizer.tokenize("<extra_0>")
# Output: ['<', 'extra', '_', '0', '>']
```
This issue occurs because the tokenizer does not recognize `<extra_0>` as a special token by default. As a result, it treats the token as a regular string and applies its standard tokenization rules, breaking it into smaller components.

#### **Solution**
To ensure that the placeholder token is preserved as a single token, we explicitly add it to the tokenizer's vocabulary as a special token. This is achieved by using the `tokenizer.add_tokens()` method with the `special_tokens=True` parameter.

The following code snippet was added to address this issue:
```python
# Add the placeholder token as a special token to the tokenizer
tokenizer.add_tokens([token], special_tokens=True)
```

This ensures that:
1. The tokenizer recognizes the token as a single, indivisible token.
2. The token remains intact during tokenization, preserving its intended functionality.