### PR TITLE
Pop ROCR_VISIBLE_DEVICES as well when starting LLMRayActor

### DIFF
--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -29,9 +29,10 @@ class LLMRayActor:
         noset_visible_devices = kwargs.pop("noset_visible_devices")
         if kwargs.get("distributed_executor_backend") == "ray":
             # a hack to make the script work.
-            # stop ray from manipulating CUDA_VISIBLE_DEVICES
+            # stop ray from manipulating *_VISIBLE_DEVICES
             # at the top-level when the distributed_executor_backend is ray.
             os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            os.environ.pop("ROCR_VISIBLE_DEVICES", None)
         elif noset_visible_devices:
             # We need to set CUDA_VISIBLE_DEVICES to the ray assigned GPU
             # when the distributed_executor_backend is not ray and


### PR DESCRIPTION
From v2.6.0, torch respects ROCR_VISIBLE_DEVICES on AMD GPU device discovery: https://github.com/pytorch/pytorch/pull/144026 So we no longer need to set `RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES` when we run OpenRLHF on AMD nodes with ray, when this PR is merged together with https://github.com/vllm-project/vllm/pull/15246 at the vLLM side.