### PR TITLE
fix: resolve UnboundLocalError when training without packed samples

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -420,11 +420,11 @@ class RemoteExperienceMaker(BaseExperienceMaker):
             else:
                 kl = torch.zeros_like(action_log_probs, dtype=action_log_probs.dtype, device=device)
 
+            sequences = samples.sequences
+            attention_mask = samples.attention_mask
             if not self.packing_samples:
                 kl_mean = masked_mean(kl, samples.action_mask, dim=-1)
             else:
-                sequences = samples.sequences
-                attention_mask = samples.attention_mask
                 num_actions = samples.num_actions
                 packed_seq_lens = samples.packed_seq_lens
                 if self.strategy.ring_attn_group is not None:


### PR DESCRIPTION
There's probably a better way to handle this in the experience maker implementation, to avoid the possibility of unbound variables in general. For now, wanted to file a quick patch, so training without packed samples can proceed.

Tested locally.