### PR TITLE
Fix: inconsistent vllm performance when tp > 1

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -764,12 +764,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
             )
         ray.get(refs)
 
-        # Make sure all requests are sent.
-        if self.strategy.ring_attn_group is None:
-            torch.distributed.barrier()
-        else:
-            time.sleep(3)
-
         # Retrieve and combine results from all outputs
         all_output_refs = []
         for i, llm in enumerate(llms):

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -1,5 +1,6 @@
 import os
 import queue
+import time
 from collections import defaultdict
 from typing import Any, List
 
@@ -108,6 +109,8 @@ class LLMRayActor:
         """
         Return the responses for the actor with the given rank
         """
+        while self.requests:
+            time.sleep(1)
         return self.response_queues[actor_rank].get()
 
 


### PR DESCRIPTION
During training with vllm tp > 1, inconsistent performance among vLLM engines was observed. Some engines ran significantly slower than others (x2~x4 slower). Looks like the barrier operations in ppo_actor affects the tp communication of vllm engines.
This can be fixed by moving barrier from ppo_actor to vllm_engine.