### PR TITLE
fix generation attn_mask in ppo_train

### DIFF
--- a/openrlhf/models/ring_attn_utils.py
+++ b/openrlhf/models/ring_attn_utils.py
@@ -82,8 +82,9 @@ def pad_sequences(sequences, attention_mask, num_actions, packed_seq_lens, ring_
         pad_len = (ring_attn_size - seqlen % ring_attn_size) % ring_attn_size
         padded = torch.tensor([pad_token_id] * pad_len, device=sequences.device, dtype=sequences.dtype).unsqueeze(0)
         sequences = torch.cat([sequences, padded], dim=1)
+        max_seq_id = attention_mask.max().item()
         attention_mask = torch.cat(
-            [attention_mask, (len(sequences) + 1) * torch.ones(1, pad_len, device="cuda", dtype=torch.float)], dim=-1
+            [attention_mask, (max_seq_id + 1) * torch.ones(1, pad_len, device="cuda", dtype=torch.float)], dim=-1
         )
     elif isinstance(sequences, list):
         seqlen = len(sequences)


### PR DESCRIPTION
fix generation attn_mask in ppo_train when turn on both ring_attn and packing
before:
![image](https://github.com/user-attachments/assets/d06e81b2-894f-43c0-b28f-023d5f87c50d)
after fix:
![image](https://github.com/user-attachments/assets/c20588d7-d39e-4bd0-881c-5d49ff8c438a)

