### PR TITLE
refactor data packing and fix loss scale.

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -96,7 +96,7 @@ def train(args):
         args.micro_train_batch_size,
         True,
         True,
-        train_dataset.packing_collate_fn if args.packing_samples else train_dataset.collate_fn,
+        train_dataset.collate_fn,
     )
 
     eval_dataloader = strategy.setup_dataloader(
@@ -104,7 +104,7 @@ def train(args):
         args.micro_train_batch_size,
         True,
         False,
-        eval_dataset.packing_collate_fn if args.packing_samples else eval_dataset.collate_fn,
+        eval_dataset.collate_fn,
     )
 
     # scheduler

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -83,14 +83,14 @@ def train(args):
         args.micro_train_batch_size,
         True,
         True,
-        train_dataset.packing_collate_fn if args.packing_samples else train_dataset.collate_fn,
+        train_dataset.collate_fn,
     )
     eval_dataloader = strategy.setup_dataloader(
         eval_dataset,
         args.micro_train_batch_size,
         True,
         False,
-        eval_dataset.packing_collate_fn if args.packing_samples else eval_dataset.collate_fn,
+        eval_dataset.collate_fn,
     )
 
     # scheduler

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -1,7 +1,6 @@
 from typing import Callable
 
 import torch
-import torch.nn.functional as F
 from torch.utils.data import Dataset
 
 from .utils import zero_pad_sequences
@@ -213,7 +212,7 @@ class SFTDataset(Dataset):
         else:
             response_ranges = self.response_ranges[idx]
             for start_idx, end_idx in response_ranges:
-                loss_mask[0, start_idx-1:end_idx] = 1
+                loss_mask[0, start_idx - 1 : end_idx] = 1
         return loss_mask
 
     def collate_fn(self, item_list):

--- a/openrlhf/models/__init__.py
+++ b/openrlhf/models/__init__.py
@@ -1,5 +1,6 @@
 from .actor import Actor
 from .loss import (
+    SFTLoss,
     DPOLoss,
     GPTLMLoss,
     KDLoss,
@@ -15,6 +16,7 @@ from .model import get_llm_for_sequence_regression
 
 __all__ = [
     "Actor",
+    "SFTLoss",
     "DPOLoss",
     "GPTLMLoss",
     "KDLoss",

--- a/openrlhf/models/__init__.py
+++ b/openrlhf/models/__init__.py
@@ -1,6 +1,5 @@
 from .actor import Actor
 from .loss import (
-    SFTLoss,
     DPOLoss,
     GPTLMLoss,
     KDLoss,
@@ -9,6 +8,7 @@ from .loss import (
     PairWiseLoss,
     PolicyLoss,
     PRMLoss,
+    SFTLoss,
     ValueLoss,
     VanillaKTOLoss,
 )

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -181,7 +181,6 @@ class Actor(nn.Module):
         #             break
         #
         eos_indices = seq_length - attention_mask.long().fliplr().argmax(dim=1, keepdim=True).clamp(min=1)
-        sequences.scatter_(dim=1, index=eos_indices, value=eos_token_id)
 
         # For Llama3 and Qwen2 models, there are some eos_tokens in the middle of the prompt.
         first_token_indices = attention_mask.long().argmax(dim=1, keepdim=True)

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -63,7 +63,7 @@ class SFTLoss(nn.Module):
         self.token_level_loss = token_level_loss
 
     def forward(self, per_token_logps: torch.Tensor, loss_mask: torch.Tensor) -> torch.Tensor:
-        loss = masked_mean(per_token_logps, loss_mask, dim=None) if self.token_level_loss else masked_mean(per_token_logps, loss_mask, dim=-1).mean()
+        loss = masked_mean(-per_token_logps, loss_mask, dim=None) if self.token_level_loss else masked_mean(-per_token_logps, loss_mask, dim=-1).mean()
 
         return loss
 

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -63,7 +63,11 @@ class SFTLoss(nn.Module):
         self.token_level_loss = token_level_loss
 
     def forward(self, per_token_logps: torch.Tensor, loss_mask: torch.Tensor) -> torch.Tensor:
-        loss = masked_mean(-per_token_logps, loss_mask, dim=None) if self.token_level_loss else masked_mean(-per_token_logps, loss_mask, dim=-1).mean()
+        loss = (
+            masked_mean(-per_token_logps, loss_mask, dim=None)
+            if self.token_level_loss
+            else masked_mean(-per_token_logps, loss_mask, dim=-1).mean()
+        )
 
         return loss
 
@@ -89,7 +93,11 @@ class PolicyLoss(nn.Module):
         surr1 = ratio * advantages
         surr2 = ratio.clamp(1 - self.clip_eps, 1 + self.clip_eps) * advantages
         loss = -torch.min(surr1, surr2)
-        loss = masked_mean(loss, action_mask, dim=None) if self.token_level_loss else masked_mean(loss, action_mask, dim=-1).mean()
+        loss = (
+            masked_mean(loss, action_mask, dim=None)
+            if self.token_level_loss
+            else masked_mean(loss, action_mask, dim=-1).mean()
+        )
         return loss
 
 
@@ -118,7 +126,11 @@ class ValueLoss(nn.Module):
         else:
             loss = (values - returns) ** 2
 
-        loss = masked_mean(loss, action_mask, dim=None) if self.token_level_loss else masked_mean(loss, action_mask, dim=-1).mean()
+        loss = (
+            masked_mean(loss, action_mask, dim=None)
+            if self.token_level_loss
+            else masked_mean(loss, action_mask, dim=-1).mean()
+        )
         return 0.5 * loss
 
 

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -53,14 +53,30 @@ class GPTLMLoss(nn.Module):
         return loss
 
 
+class SFTLoss(nn.Module):
+    """
+    SFT Loss
+    """
+
+    def __init__(self, token_level_loss: bool = True):
+        super().__init__()
+        self.token_level_loss = token_level_loss
+
+    def forward(self, per_token_logps: torch.Tensor, loss_mask: torch.Tensor) -> torch.Tensor:
+        loss = masked_mean(per_token_logps, loss_mask, dim=None) if self.token_level_loss else masked_mean(per_token_logps, loss_mask, dim=-1).mean()
+
+        return loss
+
+
 class PolicyLoss(nn.Module):
     """
     Policy Loss for PPO
     """
 
-    def __init__(self, clip_eps: float = 0.2) -> None:
+    def __init__(self, clip_eps: float = 0.2, token_level_loss: bool = True) -> None:
         super().__init__()
         self.clip_eps = clip_eps
+        self.token_level_loss = token_level_loss
 
     def forward(
         self,
@@ -73,7 +89,7 @@ class PolicyLoss(nn.Module):
         surr1 = ratio * advantages
         surr2 = ratio.clamp(1 - self.clip_eps, 1 + self.clip_eps) * advantages
         loss = -torch.min(surr1, surr2)
-        loss = masked_mean(loss, action_mask, dim=-1).mean()
+        loss = masked_mean(loss, action_mask, dim=None) if self.token_level_loss else masked_mean(loss, action_mask, dim=-1).mean()
         return loss
 
 

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -98,9 +98,10 @@ class ValueLoss(nn.Module):
     Value Loss for PPO
     """
 
-    def __init__(self, clip_eps: float = None) -> None:
+    def __init__(self, clip_eps: float = None, token_level_loss: bool = True) -> None:
         super().__init__()
         self.clip_eps = clip_eps
+        self.token_level_loss = token_level_loss
 
     def forward(
         self,
@@ -117,7 +118,7 @@ class ValueLoss(nn.Module):
         else:
             loss = (values - returns) ** 2
 
-        loss = masked_mean(loss, action_mask, dim=-1).mean()
+        loss = masked_mean(loss, action_mask, dim=None) if self.token_level_loss else masked_mean(loss, action_mask, dim=-1).mean()
         return 0.5 * loss
 
 

--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -141,32 +141,19 @@ class DPOTrainer(ABC):
             self.ref_model.eval()
             # train
             for data in self.train_dataloader:
-                if not self.packing_samples:
-                    chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens = data
-                    chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
-                    c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
-                    reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
-                    r_mask = r_mask.squeeze(1).to(torch.cuda.current_device())
+                chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens = data
+                chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
+                c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
+                reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
+                r_mask = r_mask.squeeze(1).to(torch.cuda.current_device())
 
-                    chosen_logps, rejected_logps, aux_loss, nll_loss = self.concatenated_forward(
-                        self.model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
+                chosen_logps, rejected_logps, aux_loss, nll_loss = self.concatenated_forward(
+                    self.model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
+                )
+                with torch.no_grad():
+                    reference_chosen_logps, reference_rejected_logps, _, _ = self.concatenated_forward(
+                        self.ref_model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
                     )
-                    with torch.no_grad():
-                        reference_chosen_logps, reference_rejected_logps, _, _ = self.concatenated_forward(
-                            self.ref_model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
-                        )
-                else:
-                    packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens = data
-                    packed_input_ids, packed_attention_masks = packed_input_ids.to(
-                        torch.cuda.current_device()
-                    ), packed_attention_masks.to(torch.cuda.current_device())
-                    chosen_logps, rejected_logps, aux_loss, nll_loss = self.packed_samples_forward(
-                        self.model, packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens
-                    )
-                    with torch.no_grad():
-                        reference_chosen_logps, reference_rejected_logps, _, _ = self.packed_samples_forward(
-                            self.ref_model, packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens
-                        )
 
                 # loss function
                 preference_loss, chosen_reward, reject_reward = self.loss_fn(
@@ -263,32 +250,19 @@ class DPOTrainer(ABC):
             loss_sum = 0
             times = 0
             for data in eval_dataloader:
-                if not self.packing_samples:
-                    chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens = data
-                    chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
-                    c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
-                    reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
-                    r_mask = r_mask.squeeze(1).to(torch.cuda.current_device())
+                chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens = data
+                chosen_ids = chosen_ids.squeeze(1).to(torch.cuda.current_device())
+                c_mask = c_mask.squeeze(1).to(torch.cuda.current_device())
+                reject_ids = reject_ids.squeeze(1).to(torch.cuda.current_device())
+                r_mask = r_mask.squeeze(1).to(torch.cuda.current_device())
 
-                    chosen_logps, rejected_logps, aux_loss, _ = self.concatenated_forward(
-                        self.model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
+                chosen_logps, rejected_logps, aux_loss, _ = self.concatenated_forward(
+                    self.model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
+                )
+                with torch.no_grad():
+                    reference_chosen_logps, reference_rejected_logps, _, _ = self.concatenated_forward(
+                        self.ref_model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
                     )
-                    with torch.no_grad():
-                        reference_chosen_logps, reference_rejected_logps, _, _ = self.concatenated_forward(
-                            self.ref_model, chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
-                        )
-                else:
-                    packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens = data
-                    packed_input_ids, packed_attention_masks = packed_input_ids.to(
-                        torch.cuda.current_device()
-                    ), packed_attention_masks.to(torch.cuda.current_device())
-                    chosen_logps, rejected_logps, aux_loss, _ = self.packed_samples_forward(
-                        self.model, packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens
-                    )
-                    with torch.no_grad():
-                        reference_chosen_logps, reference_rejected_logps, _, _ = self.packed_samples_forward(
-                            self.ref_model, packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens
-                        )
 
                 loss, chosen_reward, reject_reward = self.loss_fn(
                     chosen_logps, rejected_logps, reference_chosen_logps, reference_rejected_logps
@@ -322,10 +296,17 @@ class DPOTrainer(ABC):
         input_ids, att_masks, prompt_id_lens = self.concatenated_inputs(
             chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens
         )
-        output = model(input_ids, attention_mask=att_masks, return_output=True)
-        all_logits = output["logits"]
+
+        log_probs, output = model(
+            input_ids,
+            attention_mask=att_masks,
+            return_output=True,
+            return_logprobs=True,
+            ring_attn_group=self.strategy.ring_attn_group,
+        )
+
         all_logps_sum, all_logps_mean = self._get_batch_logps(
-            all_logits, input_ids, att_masks, prompt_id_lens, average_log_prob=False
+            log_probs, att_masks, prompt_id_lens, average_log_prob=False
         )
         chosen_logps = all_logps_sum[: chosen_ids.shape[0]]
         rejected_logps = all_logps_sum[chosen_ids.shape[0] :]
@@ -366,8 +347,7 @@ class DPOTrainer(ABC):
 
     def _get_batch_logps(
         self,
-        logits: torch.FloatTensor,
-        labels: torch.LongTensor,
+        per_token_logps: torch.LongTensor,
         attention_mask,
         prompt_id_lens,
         average_log_prob: bool = False,
@@ -375,18 +355,13 @@ class DPOTrainer(ABC):
         """Compute the log probabilities of the given labels under the given logits.
 
         Args:
-            logits: Logits of the model (unnormalized). Shape: (batch_size, sequence_length, vocab_size)
-            labels: Labels for which to compute the log probabilities. Label tokens with a value of -100 are ignored. Shape: (batch_size, sequence_length)
+            per_token_logps: Per token log probabilities. Shape: (batch_size, sequence_length)
             average_log_prob: If True, return the average log probability per (non-masked) token. Otherwise, return the sum of the log probabilities of the (non-masked) tokens.
 
         Returns:
             A tensor of shape (batch_size,) containing the average/sum log probabilities of the given labels under the given logits.
         """
         assert average_log_prob == False
-        assert logits.shape[:-1] == labels.shape
-
-        labels = labels[:, 1:].clone()
-        logits = logits[:, :-1, :]
 
         loss_masks = attention_mask.clone().bool()
         # mask prompts
@@ -394,85 +369,6 @@ class DPOTrainer(ABC):
             mask[:source_len] = False
         loss_masks = loss_masks[:, 1:]
 
-        # dummy token; we'll ignore the losses on these tokens later
-        labels[loss_masks == False] = 0
-        per_token_logps = log_probs_from_logits(logits, labels)
-
         logprobs_sums = (per_token_logps * loss_masks).sum(-1)
         logprobs_means = (per_token_logps * loss_masks).sum(-1) / loss_masks.sum(-1)
         return logprobs_sums, logprobs_means
-
-    def packed_samples_forward(self, model, packed_input_ids, packed_attention_masks, packed_seq_lens, prompt_id_lens):
-        output = model(
-            packed_input_ids,
-            attention_mask=packed_attention_masks,
-            return_output=True,
-            ring_attn_group=self.strategy.ring_attn_group,
-            packed_seq_lens=packed_seq_lens,
-        )
-        all_logits = output["logits"]
-        all_logps_sum, all_logps_mean = self._packed_get_batch_logps(
-            all_logits,
-            packed_input_ids,
-            packed_attention_masks,
-            prompt_id_lens * 2,
-            packed_seq_lens,
-            average_log_prob=False,
-        )
-        chosen_logps = all_logps_sum[: len(packed_seq_lens) // 2]
-        rejected_logps = all_logps_sum[len(packed_seq_lens) // 2 :]
-        aux_loss = output.aux_loss if "aux_loss" in output else []
-        return chosen_logps, rejected_logps, aux_loss, -all_logps_mean[: len(packed_seq_lens) // 2].mean()
-
-    def _packed_get_batch_logps(
-        self,
-        logits: torch.FloatTensor,
-        labels: torch.LongTensor,
-        attention_mask,
-        prompt_id_lens,
-        packed_seq_lens,
-        average_log_prob: bool = False,
-    ) -> torch.FloatTensor:
-        assert average_log_prob == False
-
-        if self.strategy.ring_attn_group is None:
-            assert logits.shape[:-1] == labels.shape
-            labels = labels[:, 1:]
-            logits = logits[:, :-1, :]
-            per_token_logps = log_probs_from_logits(logits, labels)
-        else:
-            rank = self.strategy.ring_attn_rank
-            total_seq_len = labels.numel()
-            local_seq_len = total_seq_len // self.strategy.ring_attn_size
-            local_slice = slice(rank * local_seq_len + 1, (rank + 1) * local_seq_len + 1)
-            local_label = labels[:, local_slice]
-            if rank == self.strategy.ring_attn_size - 1:
-                # add a dummy label to the last logit
-                local_label = F.pad(local_label, (0, 1), value=0)
-
-            local_per_token_logps = log_probs_from_logits(logits, local_label)
-            # we may not need to all_gather the entire tensor, but it's easier to implement.
-            # use the flash_attn all_gather so that the all_gather has correct backward.
-            per_token_logps = all_gather(local_per_token_logps, self.strategy.ring_attn_group).reshape((1, -1))
-            per_token_logps = per_token_logps[:, :-1]
-
-        loss_masks = attention_mask.clone().bool()
-
-        index = 0
-        for i, seq_len in enumerate(packed_seq_lens):
-            loss_masks[0, index : index + prompt_id_lens[i]] = False
-            index = index + seq_len
-
-        loss_masks = loss_masks[:, 1:]
-
-        logprobs_sums = []
-        logprobs_means = []
-        index = 0
-        for i, seq_len in enumerate(packed_seq_lens):
-            seq = per_token_logps[0, index : index + seq_len - 1]
-            mask = loss_masks[0, index : index + seq_len - 1]
-            logprobs_sums.append((seq * mask).sum())
-            logprobs_means.append((seq * mask).sum() / mask.sum())
-            index = index + seq_len
-
-        return torch.stack(logprobs_sums), torch.stack(logprobs_means)

--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -2,13 +2,10 @@ import os
 from abc import ABC
 
 import torch
-from flash_attn.utils.distributed import all_gather
-from torch.nn import functional as F
 from torch.optim import Optimizer
 from tqdm import tqdm
 
 from openrlhf.models import DPOLoss
-from openrlhf.models.utils import log_probs_from_logits
 from openrlhf.utils.distributed_sampler import DistributedSampler
 
 

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -548,12 +548,7 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                 raise Exception(f"Unkown advantage_estimator {self.advantage_estimator}")
 
             # calculate the return info.
-            if not getattr(self, "packing_samples", False):
-                return_sums = reward.sum(dim=-1)
-            else:
-                return_sums = torch.tensor(
-                    [each_reward.sum() for each_reward in reward], device=torch.cuda.current_device()
-                )
+            return_sums = reward.sum(dim=-1)
             experience.info["return"] = return_sums
             # remove unnecessary info
             experience.kl = None

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -323,7 +323,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                 sequences=sequences_cpu_list,
                 action_mask=action_mask_list,
                 attention_mask=attention_mask_cpu_list,
-                logps_allgather=[True] * len(samples_list),
             )
 
             if args.colocate_actor_ref or args.colocate_all_models:
@@ -384,7 +383,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                 action_mask,
                 attn_mask.to(device),
                 ring_attn_group=self.strategy.ring_attn_group,
-                logps_allgather=True,
             )
             action_log_probs_list.append(action_log_probs)
 

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -11,7 +11,6 @@ import torch.distributed as dist
 import torch.nn as nn
 
 from openrlhf.models.actor import Actor
-from openrlhf.models.ring_attn_utils import pad_sequences, unpad_sequences
 from openrlhf.models.utils import compute_approx_kl, compute_reward, masked_mean, unpacking_samples
 from openrlhf.utils.logging_utils import init_logger
 from openrlhf.utils.remote_rm_utils import remote_rm_fn_ray
@@ -103,7 +102,6 @@ class Samples:
     attention_mask: (B, S) or (1, total_length), the attention mask for sequences.
     action_mask: (B, A) or None, the action (response) mask to show which part of the
         sequence is the response. When the samples are packed, this is None.
-    num_actions: int or (B,), the number of actions (tokens) in the response.
         When the samples are not packed, we will use action_mask, so this is an int to
         show the size of action_mask. Otherwise, this is a tensor to show the number of
         actions for each sample.
@@ -116,13 +114,45 @@ class Samples:
     sequences: torch.Tensor
     attention_mask: Optional[torch.LongTensor]
     action_mask: Optional[torch.BoolTensor]
-    num_actions: Union[int, torch.Tensor]
-    packed_seq_lens: Optional[torch.Tensor]
     response_length: torch.Tensor
     total_length: torch.Tensor
     prompts: list[str]
     labels: list[str]
-    pad_len: Optional[int]
+
+    def __init__(self,
+                 sequences=None,
+                 attention_mask=None,
+                 action_mask=None,
+                 response_length=None,
+                 total_length=None,
+                 prompts=None,
+                 labels=None,
+                 packed_seq_lens=None):
+        self.sequences = sequences
+        self.attention_mask = attention_mask
+        self.action_mask = action_mask
+        self.response_length = response_length
+        self.total_length = total_length
+        self.prompts = prompts or []
+        self.labels = labels or []
+        self.packed_seq_lens = packed_seq_lens
+
+    def split(self, split_size: int):
+        sequences_list = self.sequences.split(split_size, dim=0)
+        attention_mask_list = self.attention_mask.split(split_size, dim=0)
+        action_mask_list = self.action_mask.split(split_size, dim=0)
+        sample_list = []
+        for i, (seq, mask, action_mask) in enumerate(zip(sequences_list, attention_mask_list, action_mask_list)):
+            sample = Samples()
+            sample.sequences = seq
+            sample.attention_mask = mask
+            sample.action_mask = action_mask
+            sample.response_length = sample.action_mask.float().sum(dim=-1)
+            sample.total_length = sample.attention_mask.float().sum(dim=-1)
+            sample.prompts = self.prompts[i * split_size:(i+1) * split_size]
+            sample.labels = self.labels[i * split_size:(i+1) * split_size]
+            sample_list.append(sample)
+        return sample_list
 
 
 class BaseExperienceMaker(ABC):
@@ -225,19 +255,16 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         if self.strategy.ring_attn_group is not None:
             # Only rank 0 in the ring attention group executes the generation function, and then broadcasts it to all other ranks.
             if self.strategy.ring_attn_rank == 0:
-                samples_list = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
-
-                dist.broadcast_object_list(samples_list, src=dist.get_rank(), group=self.strategy.ring_attn_group)
+                rollout_samples = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
+                dist.broadcast_object_list([rollout_samples], src=dist.get_rank(), group=self.strategy.ring_attn_group)
             else:
-                world_size = torch.distributed.get_world_size() // args.ring_attn_size
-                samples_list = [None] * (
-                    args.rollout_batch_size * args.n_samples_per_prompt // world_size // args.micro_rollout_batch_size
-                )
+                rollout_samples = [None]
                 dist.broadcast_object_list(
-                    samples_list, src=self.strategy.ring_attn_ranks[0], group=self.strategy.ring_attn_group
+                    rollout_samples, src=self.strategy.ring_attn_ranks[0], group=self.strategy.ring_attn_group
                 )
+                rollout_samples = rollout_samples[0]
         else:
-            samples_list = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
+            rollout_samples = self.generate_samples(all_prompts, all_labels, **generate_kwargs)
 
         # vLLM offload when vllm_enable_sleep
         if self.strategy.args.vllm_enable_sleep:
@@ -248,7 +275,7 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         torch.cuda.synchronize()
 
         # Make experiences (models forward: logprobs, values, rewards, and kl divergence)
-        experiences = self.make_experience(samples_list)
+        experiences = self.make_experience(rollout_samples)
 
         # Process experiences (reward shaping, etc.)
         experiences = self.compute_advantages_and_returns(experiences, **generate_kwargs)
@@ -262,25 +289,27 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         return experiences
 
     @torch.no_grad()
-    def make_experience(self, samples_list: List[Samples]) -> List[Experience]:
+    def make_experience(self, rollout_samples: Samples) -> List[Experience]:
         """
         Turn samples into experience by calculating logprobs, values, rewards, and kl divergence.
         """
         start_time = time.time()
         if dist.get_rank() == 0:
-            logger.info(f"🚀 Starting experience making with {len(samples_list) * dist.get_world_size()} batches")
+            logger.info(f"🚀 Starting experience making with {len(rollout_samples.sequences) * dist.get_world_size()} batches")
 
         args = self.strategy.args
         self.actor.eval()
         device = torch.cuda.current_device()
         experiences = []
 
+        # TODO(gzpan): Support dynamic batch later
+        samples_list = rollout_samples.split(args.micro_rollout_batch_size)
+
         # Extract all information from samples in one pass
         # Convert samples into lists of tensors and metadata for batch processing
         sequences_list = [s.sequences for s in samples_list]
         attention_mask_list = [s.attention_mask for s in samples_list]
-        num_actions_list = [s.num_actions for s in samples_list]
-        packed_seq_lens_list = [s.packed_seq_lens for s in samples_list]
+        action_mask_list = [s.action_mask for s in samples_list]
         prompts_list = [p for s in samples_list for p in s.prompts]
         labels_list = [l for s in samples_list for l in s.labels]
 
@@ -292,10 +321,9 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         if self.initial_model is not None:
             base_action_log_probs_ref = self.initial_model.forward_batch.remote(
                 sequences=sequences_cpu_list,
-                num_actions=num_actions_list,
+                action_mask=action_mask_list,
                 attention_mask=attention_mask_cpu_list,
                 logps_allgather=[True] * len(samples_list),
-                packed_seq_lens=packed_seq_lens_list,
             )
 
             if args.colocate_actor_ref or args.colocate_all_models:
@@ -308,9 +336,8 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         if self.critic is not None:
             value_ref = self.critic.forward_batch.remote(
                 sequences=sequences_cpu_list,
-                num_actions=num_actions_list,
+                action_mask=action_mask_list,
                 attention_mask=attention_mask_cpu_list,
-                packed_seq_lens=packed_seq_lens_list,
             )
             if args.colocate_critic_reward or args.colocate_all_models:
                 ray.get([value_ref])
@@ -326,25 +353,12 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                     rm.forward_batch.remote(
                         sequences=sequences_cpu_list,
                         attention_mask=attention_mask_cpu_list,
-                        packed_seq_lens=packed_seq_lens_list,
                         pad_sequence=[True] * len(samples_list),
                     )
                 )
         else:
             if self.strategy.ring_attn_group is None or self.strategy.ring_attn_rank == 0:
-                queries_list = []
-                for i, (seq, packed_lens) in enumerate(zip(sequences_cpu_list, packed_seq_lens_list)):
-                    if not self.packing_samples:
-                        queries = self.tokenizer.batch_decode(seq, skip_special_tokens=False)
-                    else:
-                        sequences_list = []
-                        offset = 0
-                        tokens_list = seq.tolist()[0]
-                        for length in packed_lens:
-                            sequences_list.append(tokens_list[offset : offset + length])
-                            offset += length
-                        queries = self.tokenizer.batch_decode(sequences_list, skip_special_tokens=False)
-                    queries_list.extend(queries)
+                queries_list = sum([self.tokenizer.batch_decode(seq, skip_special_tokens=False) for seq in sequences_cpu_list], [])
 
                 if self.custom_reward_func:
                     r = self.custom_reward_func.remote(queries_list, prompts_list, labels_list)
@@ -362,16 +376,15 @@ class RemoteExperienceMaker(BaseExperienceMaker):
 
         # Batch call actor model
         action_log_probs_list = []
-        for seq, num_acts, attn_mask, packed_lens in zip(
-            sequences_cpu_list, num_actions_list, attention_mask_cpu_list, packed_seq_lens_list
+        for seq, action_mask, attn_mask in zip(
+            sequences_cpu_list, action_mask_list, attention_mask_cpu_list
         ):
             action_log_probs = self.actor(
                 seq.to(device),
-                num_acts,
+                action_mask,
                 attn_mask.to(device),
                 ring_attn_group=self.strategy.ring_attn_group,
                 logps_allgather=True,
-                packed_seq_lens=packed_lens,
             )
             action_log_probs_list.append(action_log_probs)
 
@@ -415,43 +428,15 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                 kl = compute_approx_kl(
                     action_log_probs,
                     base_action_log_probs,
-                    action_mask=samples.action_mask,
                     kl_estimator=self.strategy.args.kl_estimator,
                 )
             else:
                 kl = torch.zeros_like(action_log_probs, dtype=action_log_probs.dtype, device=device)
 
+            kl_mean = masked_mean(kl, None, dim=-1)
+
             sequences = samples.sequences
             attention_mask = samples.attention_mask
-            if not self.packing_samples:
-                kl_mean = masked_mean(kl, samples.action_mask, dim=-1)
-            else:
-                num_actions = samples.num_actions
-                packed_seq_lens = samples.packed_seq_lens
-                if self.strategy.ring_attn_group is not None:
-                    assert samples.pad_len is not None
-                    sequences, attention_mask, num_actions, packed_seq_lens, _, _, kl = unpad_sequences(
-                        pad_len=samples.pad_len,
-                        sequences=sequences,
-                        attention_mask=attention_mask,
-                        num_actions=num_actions,
-                        packed_seq_lens=packed_seq_lens,
-                        ring_attn_group=self.strategy.ring_attn_group,
-                        action_log_probs=action_log_probs,
-                        values=value,
-                        kl=kl,
-                    )
-                # Convert tensor into list of tensors for easier manipulation within dataset
-                sequences = unpacking_samples(sequences, packed_seq_lens)
-                attention_mask = None
-                action_log_probs = unpacking_samples(action_log_probs, num_actions)
-                if value is not None:
-                    value = unpacking_samples(value, num_actions)
-                if base_action_log_probs is not None:
-                    base_action_log_probs = unpacking_samples(base_action_log_probs, num_actions)
-
-                kl = unpacking_samples(kl, num_actions)
-                kl_mean = torch.tensor([each_kl.mean() for each_kl in kl], device=device)
 
             if not args.use_kl_loss:
                 base_action_log_probs = None
@@ -461,7 +446,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
                 "reward": r,
                 "response_length": samples.response_length,
                 "total_length": samples.total_length,
-                "num_actions": samples.num_actions,
             }
 
             if self.strategy.args.perf:
@@ -529,13 +513,11 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         for experience, reward in zip(experiences, rewards):
             experience = experience.to_device("cuda")
             reward = reward.to(device="cuda")
-            num_actions = experience.info["num_actions"]
             reward = compute_reward(
                 reward,
                 self.kl_ctl.value,
                 experience.kl,
                 action_mask=experience.action_mask,
-                num_actions=num_actions,
                 reward_clip_range=args.reward_clip_range,
             )
 
@@ -577,7 +559,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
             experience.info["return"] = return_sums
             # remove unnecessary info
             experience.kl = None
-            del experience.info["num_actions"]
             experience.to_device("cpu")
 
         return experiences
@@ -611,17 +592,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         - advantages: Tensor of shape (batch_size, response_size)
         - returns: Tensor of shape (batch_size, response_size)
         """
-        if isinstance(values, list):
-            # packing samples
-            # TODO: this is slow...
-            advantages = []
-            returns = []
-            for v, r in zip(values, rewards):
-                adv, ret = self.get_advantages_and_returns(v.unsqueeze(0), r.unsqueeze(0), action_mask, gamma, lambd)
-                advantages.append(adv.squeeze(0))
-                returns.append(ret.squeeze(0))
-            return advantages, returns
-
         lastgaelam = 0
         advantages_reversed = []
         response_length = rewards.size(1)
@@ -659,16 +629,6 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         Output:
         - returns: Tensor of shape (batch_size, response_size)
         """
-
-        if isinstance(rewards, list):
-            # packing samples
-            # TODO: this is slow...
-            returns = []
-            for r in rewards:
-                ret = self.get_cumulative_returns(r.unsqueeze(0), action_mask, gamma)
-                returns.append(ret.squeeze(0))
-            return returns
-
         response_length = rewards.size(1)
         returns = torch.zeros_like(rewards)
         cumulative_return = torch.zeros(rewards.size(0), device=rewards.device)
@@ -685,7 +645,7 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         return returns
 
     @torch.no_grad()
-    def generate_samples(self, all_prompts: List[str], all_labels, **generate_kwargs) -> List[Samples]:
+    def generate_samples(self, all_prompts: List[str], all_labels, **generate_kwargs) -> Samples:
         """
         Generate samples and return in batches.
 
@@ -699,7 +659,7 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         return self._generate_vllm(all_prompts, all_labels, **generate_kwargs)
 
     @torch.no_grad()
-    def _generate_with_hf(self, all_prompts: List[str], all_labels, **generate_kwargs) -> List[Samples]:
+    def _generate_with_hf(self, all_prompts: List[str], all_labels, **generate_kwargs) -> Samples:
         """
         Generate samples and return in batches.
         """
@@ -709,28 +669,31 @@ class RemoteExperienceMaker(BaseExperienceMaker):
         # sample multiple response
         all_prompts = sum([[prompt] * args.n_samples_per_prompt for prompt in all_prompts], [])
         all_labels = sum([[label] * args.n_samples_per_prompt for label in all_labels], [])
-        samples_list = []
+        rollout_sequences = []
+        rollout_attention_mask = []
+        rollout_action_mask = []
         for i in range(0, len(all_prompts), args.micro_rollout_batch_size):
             prompts = all_prompts[i : i + args.micro_rollout_batch_size]
-            labels = all_labels[i : i + args.micro_rollout_batch_size]
             inputs = self.tokenize_fn(prompts, self.prompt_max_len, device="cuda")
             sequences, attention_mask, action_mask = self.actor.generate(**inputs, **generate_kwargs)
-            samples = Samples(
-                sequences=sequences,
-                attention_mask=attention_mask,
-                action_mask=action_mask,
-                num_actions=action_mask.size(1),
-                packed_seq_lens=None,
-                response_length=action_mask.float().sum(dim=-1),
-                total_length=attention_mask.float().sum(dim=-1),
-                prompts=prompts,
-                labels=labels,
-                pad_len=None,
-            )
-            samples_list.append(samples)
-        return samples_list
+            rollout_sequences.append(sequences)
+            rollout_attention_mask.append(attention_mask)
+            rollout_action_mask.append(action_mask)
+        rollout_sequences = torch.cat(rollout_sequences, dim=0)
+        rollout_attention_mask = torch.cat(rollout_attention_mask, dim=0)
+        rollout_action_mask = torch.cat(rollout_action_mask, dim=0)
+        rollout_samples = Samples(
+            sequences=rollout_sequences,
+            attention_mask=rollout_attention_mask,
+            action_mask=rollout_action_mask,
+            response_length=rollout_action_mask.float().sum(dim=-1),
+            total_length=rollout_attention_mask.float().sum(dim=-1),
+            prompts=all_prompts,
+            labels=all_labels,
+        )
+        return rollout_samples
 
-    def _generate_vllm(self, all_prompts: List[str], all_labels, **kwargs) -> List[Samples]:
+    def _generate_vllm(self, all_prompts: List[str], all_labels, **kwargs) -> Samples:
         from vllm import SamplingParams
 
         # round-robin load balance
@@ -789,111 +752,55 @@ class RemoteExperienceMaker(BaseExperienceMaker):
             all_output_refs.append(llm.get_responses.remote(rank))
         all_outputs = sum(ray.get(all_output_refs), [])
 
-        samples_list = []
-        for i in range(0, len(all_outputs), args.micro_rollout_batch_size):
-            outputs = all_outputs[i : i + self.strategy.args.micro_rollout_batch_size]
-            prompts = all_prompts[i : i + self.strategy.args.micro_rollout_batch_size]
-            labels = all_labels[i : i + self.strategy.args.micro_rollout_batch_size]
-            if not self.packing_samples:
-                # NOTE: concat all outputs to following format:
-                #
-                # | [PAD] [PAD] token token token | token token [EOS] [PAD] |
-                # | token token token token token | token token [EOS] [PAD] |
-                # | [PAD] [PAD] [PAD] token token | token token token [EOS] |
-                # |<---------- prompt ----------->|<-------- answer ------->|
-                max_input_len, max_output_len = 0, 0
-                for output in outputs:
-                    max_input_len = max(max_input_len, len(output.prompt_token_ids))
-                    max_output_len = max(max_output_len, len(output.outputs[0].token_ids))
+        #
+        # NOTE: concat all outputs to following format:
+        #
+        # | [PAD] [PAD] token token token | token token [EOS] [PAD] |
+        # | token token token token token | token token [EOS] [PAD] |
+        # | [PAD] [PAD] [PAD] token token | token token token [EOS] |
+        # |<---------- prompt ----------->|<-------- answer ------->|
+        max_input_len, max_output_len = 0, 0
+        for output in all_outputs:
+            max_input_len = max(max_input_len, len(output.prompt_token_ids))
+            max_output_len = max(max_output_len, len(output.outputs[0].token_ids))
 
-                pad_token_id, eos_token_id = self.tokenizer.pad_token_id, self.tokenizer.eos_token_id
-                sequences = []
-                for output in outputs:
-                    # left padding input
-                    input_len = len(output.prompt_token_ids)
-                    input_ids = [pad_token_id] * (max_input_len - input_len) + list(output.prompt_token_ids)
+        pad_token_id, eos_token_id = self.tokenizer.pad_token_id, self.tokenizer.eos_token_id
+        sequences = []
+        for output in all_outputs:
+            # left padding input
+            # TODO(gzpan): check if trunc input to max_input_len?
+            input_len = len(output.prompt_token_ids)
+            input_ids = [pad_token_id] * (max_input_len - input_len) + list(output.prompt_token_ids)
 
-                    # right padding output
-                    output_len = len(output.outputs[0].token_ids)
-                    output_ids = list(output.outputs[0].token_ids) + [pad_token_id] * (max_output_len - output_len)
+            # right padding output
+            # TODO(gzpan): check if trunc output to max_output_len?
+            output_len = len(output.outputs[0].token_ids)
+            output_ids = list(output.outputs[0].token_ids) + [pad_token_id] * (max_output_len - output_len)
 
-                    # concat input and output
-                    sequences.append(input_ids + output_ids)
+            # concat input and output
+            sequences.append(input_ids + output_ids)
 
-                sequences = torch.tensor(sequences)
-                sequences, attention_mask, action_mask = self.actor.process_sequences(
-                    sequences, max_input_len, eos_token_id, pad_token_id
-                )
-                sequences = sequences.to("cuda")
-                attention_mask = attention_mask.to("cuda")
-                action_mask = action_mask.to("cuda")
-                samples_list.append(
-                    Samples(
-                        sequences=sequences,
-                        attention_mask=attention_mask,
-                        action_mask=action_mask,
-                        num_actions=action_mask.size(1),
-                        packed_seq_lens=None,
-                        response_length=action_mask.float().sum(dim=-1),
-                        total_length=attention_mask.float().sum(dim=-1),
-                        prompts=prompts,
-                        labels=labels,
-                        pad_len=None,
-                    )
-                )
-            else:
-                # NOTE: concat all outputs to following format:
-                #
-                # | token token token | token token [EOS] | token token token token token | token token [EOS] | token token | token token token [EOS] |
-                # |<---  prompt ----->|<---- answer ----->|<---------- prompt ----------->|<----- answer ---->|<- prompt -->|<-------- answer ------->|
-                pad_token_id, eos_token_id = self.tokenizer.pad_token_id, self.tokenizer.eos_token_id
-                sequences = []
-                packed_seq_lens = []
-                attention_mask = []
-                num_actions = []
-                for i, output in enumerate(outputs):
-                    input_len = len(output.prompt_token_ids)
-                    output_len = len(output.outputs[0].token_ids)
-                    packed_seq_lens.append(input_len + output_len)
-                    sequences.extend(output.prompt_token_ids + list(output.outputs[0].token_ids))
-                    attention_mask.extend([i + 1] * (input_len + output_len))
+        sequences = torch.tensor(sequences)
+        sequences, attention_mask, action_mask = self.actor.process_sequences(
+            sequences, max_input_len, eos_token_id, pad_token_id
+        )
+        sequences = sequences.to("cuda")
+        attention_mask = attention_mask.to("cuda")
+        action_mask = action_mask.to("cuda")
+        response_length = action_mask.float().sum(dim=-1)
+        total_length=attention_mask.float().sum(dim=-1)
 
-                    # current_action_mask = [0] * (input_len - 1) + [1] * output_len + [0]
-                    # num_actions.append(max(1, sum(current_action_mask)))
-                    num_actions.append(max(1, output_len))
+        rollout_samples = Samples(
+            sequences=sequences,
+            attention_mask=attention_mask,
+            action_mask=action_mask,
+            response_length=response_length,
+            total_length=total_length,
+            prompts=all_prompts,
+            labels=all_labels,
+        )
 
-                # pad seq makes the sequence a multiple of ring_attention_size.
-                pad_len = None
-                if self.strategy.ring_attn_group is not None:
-                    pad_len, sequences, attention_mask, num_actions, packed_seq_lens = pad_sequences(
-                        sequences=sequences,
-                        attention_mask=attention_mask,
-                        num_actions=num_actions,
-                        packed_seq_lens=packed_seq_lens,
-                        ring_attn_group=self.strategy.ring_attn_group,
-                        pad_token_id=pad_token_id,
-                    )
-
-                sequences = torch.tensor(sequences, device="cuda").unsqueeze(0)
-                attention_mask = torch.tensor(attention_mask, device="cuda").unsqueeze(0)
-                action_mask = None
-                response_length = torch.tensor(num_actions, device="cuda", dtype=torch.float)
-                total_length = torch.tensor(packed_seq_lens, device="cuda", dtype=torch.float)
-                samples_list.append(
-                    Samples(
-                        sequences=sequences,
-                        attention_mask=attention_mask,
-                        action_mask=None,
-                        num_actions=num_actions,
-                        packed_seq_lens=packed_seq_lens,
-                        response_length=response_length,
-                        total_length=total_length,
-                        prompts=prompts,
-                        labels=labels,
-                        pad_len=pad_len,
-                    )
-                )
-        return samples_list
+        return rollout_samples
 
     def flush(self):
         "Ensure all experience has been send to critic"

--- a/openrlhf/trainer/ppo_utils/replay_buffer.py
+++ b/openrlhf/trainer/ppo_utils/replay_buffer.py
@@ -104,11 +104,8 @@ def make_experience_batch(items: List[BufferItem], packing_samples=False) -> Exp
     )
     for key in keys:
         vals = [getattr(item, key) for item in items]
-        if not packing_samples:
-            batch_data = zero_pad_sequences(vals, "left") if vals[0] is not None else None
-        else:
-            batch_data = vals if vals[0] is not None else None
-        kwargs[key] = batch_data
+        vals = torch.stack(vals, dim=0) if vals[0] is not None else None
+        kwargs[key] = vals
 
     kwargs["info"] = {}
     for key in items[0].info.keys():
@@ -182,9 +179,6 @@ class NaiveReplayBuffer(ABC):
         if self.cpu_offload:
             experience.to_device(torch.device("cpu"))
         items = split_experience_batch(experience)
-        # the packed samples comes with no padding
-        if not self.packing_samples:
-            items = remove_padding_in_sequences(items)
         self.items.extend(items)
         if self.limit > 0:
             samples_to_remove = len(self.items) - self.limit
@@ -222,13 +216,8 @@ class NaiveReplayBuffer(ABC):
 
         items_vector = torch.cat(items).float().flatten()
 
-        if action_masks[0] is None:
-            # packing samples has no action mask
-            action_masks_vector = 1
-            num_actions = items_vector.numel()
-        else:
-            action_masks_vector = torch.cat(action_masks).flatten()
-            num_actions = action_masks_vector.sum()
+        action_masks_vector = torch.cat(action_masks).flatten()
+        num_actions = action_masks_vector.sum()
 
         # for DP
         # mean

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -118,7 +118,7 @@ class ReferenceModelRayActor(BasePPORole):
     def forward(
         self,
         sequences: torch.LongTensor,
-        num_actions: int = None,
+        action_mask: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         return_output=False,
         logps_allgather=False,
@@ -128,7 +128,7 @@ class ReferenceModelRayActor(BasePPORole):
         with torch.no_grad():
             log_probs = self.model(
                 sequences.to(device),
-                num_actions,
+                action_mask.to(device),
                 attention_mask.to(device),
                 return_output=return_output,
                 ring_attn_group=self.strategy.ring_attn_group,

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -121,7 +121,6 @@ class ReferenceModelRayActor(BasePPORole):
         action_mask: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.Tensor] = None,
         return_output=False,
-        logps_allgather=False,
         packed_seq_lens: Optional[list[int]] = None,
     ) -> torch.Tensor:
         device = torch.cuda.current_device()
@@ -130,9 +129,7 @@ class ReferenceModelRayActor(BasePPORole):
                 sequences.to(device),
                 action_mask.to(device),
                 attention_mask.to(device),
-                return_output=return_output,
                 ring_attn_group=self.strategy.ring_attn_group,
-                logps_allgather=logps_allgather,
                 packed_seq_lens=packed_seq_lens,
             )
         return log_probs.to("cpu")

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -14,7 +14,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import PromptDataset, SFTDataset
 from openrlhf.models import Actor
-from openrlhf.models.utils import compute_approx_kl, masked_mean, unpacking_samples
+from openrlhf.models.utils import compute_approx_kl, masked_mean
 from openrlhf.trainer import BasePPOTrainer
 from openrlhf.trainer.ppo_utils import Experience, RemoteExperienceMaker
 from openrlhf.trainer.ray.vllm_engine import batch_vllm_engine_call

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -14,7 +14,6 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import PromptDataset, SFTDataset
 from openrlhf.models import Actor
-from openrlhf.models.ring_attn_utils import pad_sequences, unpad_sequences
 from openrlhf.models.utils import compute_approx_kl, masked_mean, unpacking_samples
 from openrlhf.trainer import BasePPOTrainer
 from openrlhf.trainer.ppo_utils import Experience, RemoteExperienceMaker
@@ -356,55 +355,24 @@ class ActorPPOTrainer(BasePPOTrainer):
     def training_step(self, experience: Experience) -> Dict[str, float]:
         self.actor.train()
 
-        # TODO: this is a bad indicator to say that data is packed...
-        if isinstance(experience.sequences, list):
-            sequences = torch.cat(experience.sequences, dim=0).unsqueeze(0)
-            old_action_log_probs = torch.cat(experience.action_log_probs, dim=0).unsqueeze(0)
-            advantages = torch.cat(experience.advantages, dim=0).unsqueeze(0)
-            num_actions = [v.numel() for v in experience.advantages]
-            packed_seq_lens = [s.numel() for s in experience.sequences]
-            attention_mask = torch.cat(
-                [torch.full_like(s, i + 1) for i, s in enumerate(experience.sequences)], dim=0
-            ).unsqueeze(0)
-            # pad seq makes the sequence a multiple of ring_attention_size.
-            if self.strategy.ring_attn_group is not None:
-                pad_len, sequences, attention_mask, num_actions, packed_seq_lens = pad_sequences(
-                    sequences, attention_mask, num_actions, packed_seq_lens, self.strategy.ring_attn_group
-                )
-            if self.args.use_kl_loss and experience.base_action_log_probs is not None:
-                base_action_log_probs = torch.cat(experience.base_action_log_probs, dim=0).unsqueeze(0)
-        else:
-            sequences = experience.sequences
-            old_action_log_probs = experience.action_log_probs
-            advantages = experience.advantages
-            num_actions = experience.action_mask.size(1)
-            packed_seq_lens = None
-            attention_mask = experience.attention_mask
-            if self.args.use_kl_loss and experience.base_action_log_probs is not None:
-                base_action_log_probs = experience.base_action_log_probs
+        sequences = experience.sequences
+        action_mask = experience.action_mask
+        attention_mask = experience.attention_mask
+        packed_seq_lens = None
+        old_action_log_probs = experience.action_log_probs
+        advantages = experience.advantages
+        base_action_log_probs = experience.base_action_log_probs
 
         # actor loss
         action_log_probs, output = self.actor(
             sequences,
-            num_actions,
+            action_mask,
             attention_mask=attention_mask,
             return_output=True,
             ring_attn_group=self.strategy.ring_attn_group,
             logps_allgather=True,
             packed_seq_lens=packed_seq_lens,
         )
-        # unpad sequence ensures that pad tokens do not contribute to the loss calculation.
-        if self.strategy.ring_attn_group is not None:
-            assert pad_len is not None
-            sequences, attention_mask, num_actions, packed_seq_lens, action_log_probs, _, _ = unpad_sequences(
-                pad_len=pad_len,
-                sequences=sequences,
-                attention_mask=attention_mask,
-                num_actions=num_actions,
-                packed_seq_lens=packed_seq_lens,
-                action_log_probs=action_log_probs,
-                ring_attn_group=self.strategy.ring_attn_group,
-            )
 
         # loss function
         actor_loss = self.actor_loss_fn(
@@ -419,20 +387,11 @@ class ActorPPOTrainer(BasePPOTrainer):
                 kl = compute_approx_kl(
                     action_log_probs,
                     base_action_log_probs,
-                    experience.action_mask,
                     kl_estimator=self.args.kl_estimator,
                 )
             else:
                 kl = torch.zeros_like(action_log_probs, dtype=action_log_probs.dtype, device=action_log_probs.device)
-
-            if not self.args.packing_samples:
-                kl_mean = masked_mean(kl, experience.action_mask, dim=-1)
-            else:
-                # convert tensor into list of tensors so that it's easier to manipulate
-                # within dataset.
-
-                kl = unpacking_samples(kl, num_actions)
-                kl_mean = torch.tensor([each_kl.mean() for each_kl in kl], device=action_log_probs.device)
+            kl_mean = masked_mean(kl, experience.action_mask, dim=-1)
 
             kl_loss = kl_mean.mean()
             experience.info["kl"] = kl_loss.item()

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -370,7 +370,6 @@ class ActorPPOTrainer(BasePPOTrainer):
             attention_mask=attention_mask,
             return_output=True,
             ring_attn_group=self.strategy.ring_attn_group,
-            logps_allgather=True,
             packed_seq_lens=packed_seq_lens,
         )
 

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -5,7 +5,7 @@ import torch
 from torch.optim import Optimizer
 from tqdm import tqdm
 
-from openrlhf.models import GPTLMLoss
+from openrlhf.models import SFTLoss
 from openrlhf.utils.distributed_sampler import DistributedSampler
 
 
@@ -61,7 +61,7 @@ class SFTTrainer(ABC):
         self.save_hf_ckpt = save_hf_ckpt
         self.disable_ds_ckpt = disable_ds_ckpt
 
-        self.loss_fn = GPTLMLoss(ring_attn_group=self.strategy.ring_attn_group)
+        self.loss_fn = SFTLoss()
 
         # Mixtral 8*7b
         self.aux_loss = self.args.aux_loss_coef > 1e-8
@@ -133,57 +133,27 @@ class SFTTrainer(ABC):
             # train
             self.model.train()
             for prompt_id_lens, inputs, attention_masks, infos in self.train_dataloader:
-                if self.packing_samples:
-                    inputs = inputs.to(torch.cuda.current_device())
-                    attention_mask = attention_masks.to(torch.cuda.current_device())
-                else:
-                    inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
-                    attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
-
-                if self.strategy.ring_attn_group is None:
-                    output = self.model(inputs, attention_mask=attention_mask, return_output=True)
-                else:
-                    output = self.model(
-                        inputs,
-                        attention_mask=attention_mask,
-                        return_output=True,
-                        ring_attn_group=self.strategy.ring_attn_group,
-                        packed_seq_lens=infos["input_length"],
-                    )
-
-                # loss function
-                labels = torch.where(
-                    attention_mask.bool(),
+                inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
+                attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
+                per_token_log_probs, output = self.model(
                     inputs,
-                    self.loss_fn.IGNORE_INDEX,
+                    attention_mask=attention_mask,
+                    return_output=True,
+                    return_logprobs=True,
+                    ring_attn_group=self.strategy.ring_attn_group,
                 )
+
                 # mixtral
                 if self.aux_loss:
                     aux_loss = output.aux_loss
                 else:
                     aux_loss = 0
 
+                loss_mask = torch.ones_like(per_token_log_probs, dtype=torch.bool)
                 if not self.pretrain_mode:
-                    if self.packing_samples:
-                        # As response_ranges need to constrain the dataset organization strictly, we handle multiturn feature separately.
-                        if infos["response_ranges"]:
-                            dump_labels = torch.full(labels.size(), self.loss_fn.IGNORE_INDEX).to(labels.device)
-                            for response_ranges in infos["response_ranges"]:
-                                for response_range in response_ranges:
-                                    dump_labels[0][response_range[0] : response_range[1] + 1] = labels[0][
-                                        response_range[0] : response_range[1] + 1
-                                    ]
-                            labels = dump_labels
-                        else:
-                            index = 0
-                            for input_length, source_len in zip(infos["input_length"], prompt_id_lens):
-                                labels[0][index : index + source_len + 1] = self.loss_fn.IGNORE_INDEX
-                                index += input_length
-                    else:
-                        for label, source_len in zip(labels, prompt_id_lens):
-                            label[: source_len + 1] = self.loss_fn.IGNORE_INDEX
-
-                gpt_loss = self.loss_fn(output.logits, labels)
+                    for source_len in prompt_id_lens:
+                        loss_mask[:, :source_len] = False
+                gpt_loss = self.loss_fn(per_token_log_probs, loss_mask)
                 loss = gpt_loss + aux_loss * self.args.aux_loss_coef
                 self.strategy.backward(loss, self.model, self.optimizer)
                 self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler)
@@ -259,51 +229,20 @@ class SFTTrainer(ABC):
             )
 
             for prompt_id_lens, inputs, attention_masks, infos in eval_dataloader:
-                if self.packing_samples:
-                    inputs = inputs.to(torch.cuda.current_device())
-                    attention_mask = attention_masks.to(torch.cuda.current_device())
-                else:
-                    inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
-                    attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
-
-                if self.strategy.ring_attn_group is None:
-                    output = self.model(inputs, attention_mask=attention_mask, return_output=True)
-                else:
-                    output = self.model(
-                        inputs,
-                        attention_mask=attention_mask,
-                        return_output=True,
-                        ring_attn_group=self.strategy.ring_attn_group,
-                        packed_seq_lens=infos["input_length"],
-                    )
-
-                # loss function
-                labels = torch.where(
-                    attention_mask.bool(),
+                inputs = inputs.to(torch.cuda.current_device()).squeeze(1)
+                attention_mask = attention_masks.to(torch.cuda.current_device()).squeeze(1)
+                per_token_log_probs = self.model(
                     inputs,
-                    self.loss_fn.IGNORE_INDEX,
+                    attention_mask=attention_mask,
+                    return_logprobs=True,
+                    ring_attn_group=self.strategy.ring_attn_group,
                 )
 
+                loss_mask = torch.ones_like(per_token_log_probs, dtype=torch.bool)
                 if not self.pretrain_mode:
-                    if self.packing_samples:
-                        if infos["response_ranges"]:
-                            dump_labels = torch.full(labels.size(), self.loss_fn.IGNORE_INDEX).to(labels.device)
-                            for response_ranges in infos["response_ranges"]:
-                                for response_range in response_ranges:
-                                    dump_labels[0][response_range[0] : response_range[1]] = labels[0][
-                                        response_range[0] : response_range[1]
-                                    ]
-                            labels = dump_labels
-                        else:
-                            index = 0
-                            for input_length, source_len in zip(infos["input_length"], prompt_id_lens):
-                                labels[0][index : index + source_len] = self.loss_fn.IGNORE_INDEX
-                                index += input_length
-                    else:
-                        for label, source_len in zip(labels, prompt_id_lens):
-                            label[:source_len] = self.loss_fn.IGNORE_INDEX
-
-                loss = self.loss_fn(output.logits, labels)
+                    for source_len in prompt_id_lens:
+                        loss_mask[:, :source_len] = False
+                loss = self.loss_fn(per_token_log_probs, loss_mask)
 
                 times += 1
                 loss_sum += loss.item()


### PR DESCRIPTION
1. 可读性提升，data packing和ring_attn的相关代码只限制在Actor forward内
2. packing情况下loss计算与非packing一致，既考虑了sample级别的loss（PolicyLoss等forward），也考虑到了action mask的scale（masked_mean）
  a. 之前packing情况下，packing的多个sample的所有token loss统一做一次mean，短序列的重要性会被压制
![image](https://github.com/user-attachments/assets/ba179766-aba6-42e8-af12-f6dcfdedf46b)

  b. 当前packing，传入action_mask不为None，每个sample内所有token单独先mean，sample间再mean，且masked_mean中会对loss做action_mask的scale
![image](https://github.com/user-attachments/assets/e844a651-ccc0-4407-bf13-4238daf29a36)
