### PR TITLE
Fix full determinism mode when using vLLM V1

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -88,6 +88,7 @@ def train(args):
             args.vllm_tensor_parallel_size,
             args.pretrain,
             args.seed,
+            args.full_determinism,
             args.enable_prefix_caching,
             args.enforce_eager,
             max_len,

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -27,6 +27,10 @@ class LLMRayActor:
 
     def __init__(self, *args, bundle_indices: list = None, **kwargs):
         noset_visible_devices = kwargs.pop("noset_visible_devices")
+        full_determinism = kwargs.pop("full_determinism", False)
+        if full_determinism:
+            # https://github.com/vllm-project/vllm/blob/effc5d24fae10b29996256eb7a88668ff7941aed/examples/offline_inference/reproduciblity.py#L11
+            os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
         if kwargs.get("distributed_executor_backend") == "ray":
             # a hack to make the script work.
             # stop ray from manipulating *_VISIBLE_DEVICES
@@ -118,6 +122,7 @@ def create_vllm_engines(
     tensor_parallel_size: int,
     pretrain: str,
     seed: int,
+    full_determinism: bool,
     enable_prefix_caching: bool,
     enforce_eager: bool,
     max_model_len: int,
@@ -177,6 +182,7 @@ def create_vllm_engines(
                 enable_prefix_caching=enable_prefix_caching,
                 dtype="bfloat16",
                 trust_remote_code=True,
+                full_determinism=full_determinism,
                 num_actors=num_actors,
                 gpu_memory_utilization=gpu_memory_utilization,
                 bundle_indices=bundle_indices,


### PR DESCRIPTION
Collective RPC is supported now in vLLM (nightly), so we no longer need to always set `VLLM_ENABLE_V1_MULTIPROCESSING=0` when we use vLLM V1. https://github.com/vllm-project/vllm/pull/15444

But we still need to set that when we enable the full_determinism mode, as vLLM does not guarantee the reproducibility of the results by default, for the sake of performance. We need to turn off multiprocessing to make the scheduling deterministic. This is not needed and will be ignored for V0.