### PR TITLE
Update for recent HIP_VISIBLE_DEVICES changes in ray

### DIFF
--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -5,6 +5,7 @@ def ray_noset_visible_devices(env_vars=os.environ):
     # Refer to
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/amd_gpu.py#L102-L103
+    # https://github.com/ray-project/ray/blob/3b9e729f6a669ffd85190f901f5e262af79771b0/python/ray/_private/accelerators/amd_gpu.py#L114-L115
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/npu.py#L94-L95
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/hpu.py#L116-L117
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/neuron.py#L108-L109
@@ -13,6 +14,7 @@ def ray_noset_visible_devices(env_vars=os.environ):
     NOSET_VISIBLE_DEVICES_ENV_VARS_LIST = [
         "RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES",
         "RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES",
+        "RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES",
         "RAY_EXPERIMENTAL_NOSET_ASCEND_RT_VISIBLE_DEVICES",
         "RAY_EXPERIMENTAL_NOSET_HABANA_VISIBLE_MODULES",
         "RAY_EXPERIMENTAL_NOSET_NEURON_RT_VISIBLE_CORES",


### PR DESCRIPTION
Now ray uses HIP_VISIBLE_DEVICES instead of ROCR_VISIBLE_DEVICES in recent changes for AMD devices.
https://github.com/ray-project/ray/pull/51104

This PR integrates such changes here.