### PR TITLE
Fix --use_ms Parameter Placement

### DIFF
--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -221,10 +221,10 @@ if __name__ == "__main__":
     # TensorBoard parameters
     parser.add_argument("--use_tensorboard", type=str, default=None, help="TensorBoard logging path")
 
-    args = parser.parse_args()
-
     # ModelScope parameters
     parser.add_argument("--use_ms", action="store_true", default=False)
+
+    args = parser.parse_args()
 
     if args.input_template and "{}" not in args.input_template:
         print("[Warning] {} not in args.input_template, set to None")


### PR DESCRIPTION
This PR addresses an issue with the placement of the --use_ms parameter in the openrlhf/cli/train_kto.py script. Previously, the --use_ms parameter was defined after the args were parsed, which caused an AttributeError: 'Namespace' object has no attribute 'use_ms'. To resolve this, I have moved the definition of the --use_ms parameter to before the args are parsed, ensuring that it is correctly recognized and processed.