### PR TITLE
Offload lp_grads and lp_params as well for deepspeed >= 0.16.5

### DIFF
--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -123,17 +123,25 @@ def offload_deepspeed_states(model, pin_memory=True, non_blocking=True):
         raise NotImplementedError("Only Zero stage 3 is currently supported")
 
     # if zero_stage == 3 and not adam_offload:
+    import deepspeed
     import torch
     from deepspeed.runtime.zero.offload_config import OffloadDeviceEnum, OffloadStateTypeEnum
 
+    offload_state_types = [
+        OffloadStateTypeEnum.optim_states,
+        OffloadStateTypeEnum.contiguous_grad_buffer,
+        OffloadStateTypeEnum.hp_params,
+    ]
+
+    if deepspeed.__version__ >= "0.16.5":
+        # These offload types are fixed in https://github.com/deepspeedai/DeepSpeed/pull/7050
+        offload_state_types += [
+            OffloadStateTypeEnum.lp_grads,
+            OffloadStateTypeEnum.lp_params,
+        ]
+
     model.optimizer.offload_states(
-        include=[
-            OffloadStateTypeEnum.optim_states,
-            OffloadStateTypeEnum.contiguous_grad_buffer,
-            OffloadStateTypeEnum.hp_params,
-            # OffloadStateTypeEnum.lp_grads,
-            # OffloadStateTypeEnum.lp_params, # Not released yet, fixed in https://github.com/deepspeedai/DeepSpeed/pull/7050
-        ],
+        include=offload_state_types,
         device=OffloadDeviceEnum.cpu,
         pin_memory=pin_memory,
         non_blocking=non_blocking,


### PR DESCRIPTION
Those offload types are fixed in https://github.com/deepspeedai/DeepSpeed/pull/7050, and they have already been released in 0.16.5.