### PR TITLE
Detach loss before converting to scalar

### DIFF
--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -476,7 +476,7 @@ class ActorPPOTrainer(BasePPOTrainer):
             self.strategy.moving_average(self.actor, self.ema_model, self.ema_beta, "cuda")
 
         # status
-        status = {"policy_loss": actor_loss.item(), "actor_lr": self.actor_scheduler.get_last_lr()[0]}
+        status = {"policy_loss": actor_loss.detach().item(), "actor_lr": self.actor_scheduler.get_last_lr()[0]}
         if self.pretrain_dataloader is not None:
             status["ptx_loss"] = ptx_loss.item()
         for k, v in experience.info.items():

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -128,7 +128,7 @@ class CriticPPOTrainer(BasePPOTrainer):
 
         # status
         status = {
-            "critic_loss": critic_loss.item(),
+            "critic_loss": critic_loss.detach().item(),
             "values": masked_mean(values, experience.action_mask).item(),
             "critic_lr": self.critic_scheduler.get_last_lr()[0],
         }


### PR DESCRIPTION
Reference: https://github.com/pytorch/pytorch/pull/143261

Now PyTorch dev version will produce warning messages:

```log
UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
Consider using tensor.detach() first. (Triggered internally at /pytorch/aten/src/ATen/native/Scalar.cpp:22.)
status = {"policy_loss": actor_loss.item(), "actor_lr": self.actor_scheduler.get_last_lr()[0]}
```

```log
UserWarning: Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.
Consider using tensor.detach() first. (Triggered internally at /pytorch/aten/src/ATen/native/Scalar.cpp:22.)
"critic_loss": critic_loss.item(),
```