### PR TITLE
Sort ray placement group bundle indices for vLLM engines

### DIFF
--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -1,6 +1,22 @@
 import os
 
 
+# Address https://github.com/ray-project/ray/issues/51117
+# This function is used to get the bundle indices of a placement group
+# and ensure that the bundles placed on the same node are grouped together.
+def get_bundle_indices(placement_group, index, length):
+    import ray
+
+    pg_infos = ray.util.placement_group_table(placement_group)
+
+    node_id_to_bundles = {}
+    for bundle, node_id in pg_infos["bundles_to_node_id"].items():
+        node_id_to_bundles.setdefault(node_id, []).append(bundle)
+
+    sorted_bundle_indices = sum(node_id_to_bundles.values(), [])
+    return sorted_bundle_indices[index * length : (index + 1) * length]
+
+
 def ray_noset_visible_devices(env_vars=os.environ):
     # Refer to
     # https://github.com/ray-project/ray/blob/161849364a784442cc659fb9780f1a6adee85fce/python/ray/_private/accelerators/nvidia_gpu.py#L95-L96

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -10,7 +10,7 @@ from vllm.inputs import TokensPrompt
 
 from openrlhf.utils.logging_utils import init_logger
 
-from .utils import ray_noset_visible_devices
+from .utils import get_bundle_indices, ray_noset_visible_devices
 
 logger = init_logger(__name__)
 
@@ -156,12 +156,12 @@ def create_vllm_engines(
     for i in range(num_engines):
         bundle_indices = None
         if tensor_parallel_size > 1:
-            bundle_indices = list(range(i * tensor_parallel_size, (i + 1) * tensor_parallel_size))
+            bundle_indices = get_bundle_indices(shared_pg, i, tensor_parallel_size)
 
         scheduling_strategy = PlacementGroupSchedulingStrategy(
             placement_group=shared_pg,
             placement_group_capture_child_tasks=True,
-            placement_group_bundle_index=i * tensor_parallel_size,
+            placement_group_bundle_index=bundle_indices[0] if bundle_indices else i,
         )
 
         if num_engines >= num_total_actors:


### PR DESCRIPTION
To ensure that the bundles placed on the same node are grouped together.

Fixes #958 and #889

Related to https://github.com/ray-project/ray/issues/51117