### PR TITLE
Correctly enable DeepCompile for DeepSpeed

### DIFF
--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -223,6 +223,8 @@ class DeepspeedStrategy(ABC):
             args={"local_rank": int(os.environ.get("LOCAL_RANK", "-1"))},
             dist_init_required=True,
         )
+        if self.deepcompile:
+            engine.compile()
         if is_actor:
             model.model = engine
         else:

--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -63,6 +63,10 @@ def get_eval_ds_config(
     bf16=True,
     deepcompile=False,
 ):
+    # At least for 0.16.6, DeepCompile hasn't support pure inference mode
+    # https://github.com/deepspeedai/DeepSpeed/pull/7225
+    deepcompile = False
+
     zero_opt_dict = {
         "stage": stage,
         "stage3_max_live_parameters": "auto",


### PR DESCRIPTION
We should still call `engine.compile()` in `_ds_init_train_model`.

For now, Zero inference is not supported by DeepCompile, so we disable it for `get_eval_ds_config`.

Note that even though after this PR gets merged, we can still have issues with actually getting DeepCompile working:
- https://github.com/deepspeedai/DeepSpeed/issues/7229
- https://github.com/deepspeedai/DeepSpeed/issues/7228

In addition, we need https://github.com/deepspeedai/DeepSpeed/pull/7227 to get it compatible with offloading states.