### PR TITLE
Add `prompt_split` and `eval_split` Support to PPO Trainer

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -133,6 +133,8 @@ def train(args):
         reward_model,
         ref_model,
         vllm_engines,
+        prompt_split=args.prompt_split,
+        eval_split=args.eval_split,
         # generate kwargs
         do_sample=True,
         prompt_max_len=args.prompt_max_len,
@@ -375,7 +377,9 @@ if __name__ == "__main__":
         default=None,
         help="sampling probs for datasets",
     )
+    parser.add_argument("--prompt_split", type=str, default="train")
     parser.add_argument("--eval_dataset", type=str, default=None, help="Path to the evaluation dataset")
+    parser.add_argument("--eval_split", type=str, default="test")
     parser.add_argument("--eval_temperature", type=float, default=0.6, help="Temperature for evaluation")
     parser.add_argument(
         "--eval_n_samples_per_prompt", type=int, default=4, help="Number of samples per prompt for evaluation"

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -37,6 +37,8 @@ class PPOTrainer(ABC):
         vllm_engines=None,
         prompt_max_len: int = 120,
         dataloader_pin_memory: bool = True,
+        prompt_split: str = "train",
+        eval_split: str = "test",
         **generate_kwargs,
     ) -> None:
         super().__init__()
@@ -51,6 +53,9 @@ class PPOTrainer(ABC):
         self.reference_model_group = reference_model_group
         self.dataloader_pin_memory = dataloader_pin_memory
         self.vllm_engines = vllm_engines
+
+        self.prompt_split = prompt_split
+        self.eval_split = eval_split
 
         self.prompt_max_len = prompt_max_len
         self.generate_kwargs = generate_kwargs
@@ -411,6 +416,7 @@ class PPOTrainer(ABC):
             strategy,
             args.seed,
             max_count=args.max_samples,
+            dataset_split=self.prompt_split,
         )
 
         # Create train dataset
@@ -429,6 +435,7 @@ class PPOTrainer(ABC):
                 args.eval_dataset,
                 None,  # No probability sampling for eval datasets
                 strategy,
+                dataset_split=self.eval_split,
             )
             eval_data = eval_data.select(range(min(args.max_samples, len(eval_data))))
             eval_dataset = PromptDataset(eval_data, self.tokenizer, strategy, input_template=args.input_template)


### PR DESCRIPTION
This PR adds support for the `prompt_split` and `eval_split` arguments to the PPO trainer, allowing users to specify which dataset splits should be used for the training and evaluation phases, respectively. This enhancement provides greater flexibility in customizing dataset usage and facilitates more precise control over training workflows.

**Key Changes**:
- Introduced `prompt_split` for selecting the dataset split used as the training set.
- Introduced `eval_split` for selecting the dataset split used as the evaluation set.

Note: `prompt_split` was previously supported in `v0.6.4`