### PR TITLE
Fix PPO evaluation: incorrect batch decoding for queries_list

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -324,8 +324,10 @@ class PPOTrainer(ABC):
             generate_kwargs = self.generate_kwargs.copy()
             generate_kwargs["temperature"] = temperature
             generate_kwargs["n_samples_per_prompt"] = n_samples_per_prompt
-            samples = self.experience_maker.generate_samples(all_prompts, all_labels, **generate_kwargs)
-            queries_list = self.tokenizer.batch_decode(samples.sequences, skip_special_tokens=False)
+            samples_list = self.experience_maker.generate_samples(all_prompts, all_labels, **generate_kwargs)
+            queries_list = sum(
+                [self.tokenizer.batch_decode(s.sequences, skip_special_tokens=False) for s in samples_list], []
+            )
 
             # duplicate prompts and labels for each sample
             all_prompts = sum([[prompt] * n_samples_per_prompt for prompt in all_prompts], [])

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -622,7 +622,7 @@ class RemoteExperienceMaker(ABC):
         return returns
 
     @torch.no_grad()
-    def generate_samples(self, all_prompts: List[str], all_labels, **generate_kwargs) -> Samples:
+    def generate_samples(self, all_prompts: List[str], all_labels, **generate_kwargs) -> List[Samples]:
         """
         Generate samples and return in batches.
 


### PR DESCRIPTION
This pull request fixes the PPO evaluation batch decoding issue caused by the change introduced in commit `ccb58df`, where the return type of `generate_samples` was modified to a list of `Samples` objects.

### Updates:

- `openrlhf/trainer/ppo_utils/experience_maker.py`: Changed the return type of the `generate_samples` method from a single `Samples` object to `List[Samples]`.
- `openrlhf/trainer/ppo_trainer.py`: Updated the tokenizer decoding logic to handle a list of `Samples` objects correctly.