### PR TITLE
Remove implicit import of deepspeed in vLLM to avoid early CUDA calls

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import RewardDataset
 from openrlhf.models import Actor
-from openrlhf.trainer import DPOTrainer
+from openrlhf.trainer.dpo_trainer import DPOTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import SFTDataset
 from openrlhf.models import Actor
-from openrlhf.trainer import KDTrainer
+from openrlhf.trainer.kd_trainer import KDTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import UnpairedPreferenceDataset
 from openrlhf.models import Actor
-from openrlhf.trainer import KTOTrainer
+from openrlhf.trainer.kto_trainer import KTOTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -4,11 +4,11 @@ from datetime import datetime
 import ray
 from ray.util.placement_group import placement_group
 
-from openrlhf.trainer.ray import (
+from openrlhf.trainer.ray import create_vllm_engines
+from openrlhf.trainer.ray.launcher import (
     PPORayActorGroup,
     ReferenceModelRayActor,
     RewardModelRayActor,
-    create_vllm_engines,
 )
 from openrlhf.trainer.ray.ppo_actor import ActorModelRayActor
 from openrlhf.trainer.ray.ppo_critic import CriticModelRayActor

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import ProcessRewardDataset
 from openrlhf.models import Actor
-from openrlhf.trainer import ProcessRewardModelTrainer
+from openrlhf.trainer.prm_trainer import ProcessRewardModelTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import RewardDataset
 from openrlhf.models import get_llm_for_sequence_regression
-from openrlhf.trainer import RewardModelTrainer
+from openrlhf.trainer.rm_trainer import RewardModelTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -7,7 +7,7 @@ from transformers.trainer import get_scheduler
 
 from openrlhf.datasets import SFTDataset
 from openrlhf.models import Actor
-from openrlhf.trainer import SFTTrainer
+from openrlhf.trainer.sft_trainer import SFTTrainer
 from openrlhf.utils import blending_datasets, get_strategy, get_tokenizer
 
 

--- a/openrlhf/trainer/__init__.py
+++ b/openrlhf/trainer/__init__.py
@@ -1,17 +1,1 @@
-from .dpo_trainer import DPOTrainer
-from .kd_trainer import KDTrainer
-from .kto_trainer import KTOTrainer
-from .ppo_trainer import PPOTrainer
-from .prm_trainer import ProcessRewardModelTrainer
-from .rm_trainer import RewardModelTrainer
-from .sft_trainer import SFTTrainer
-
-__all__ = [
-    "DPOTrainer",
-    "KDTrainer",
-    "KTOTrainer",
-    "PPOTrainer",
-    "ProcessRewardModelTrainer",
-    "RewardModelTrainer",
-    "SFTTrainer",
-]
+# No implicit imports of deepspeed here to avoid vllm environment gets comtaminated

--- a/openrlhf/trainer/ray/__init__.py
+++ b/openrlhf/trainer/ray/__init__.py
@@ -1,11 +1,7 @@
-from .launcher import DistributedTorchRayActor, PPORayActorGroup, ReferenceModelRayActor, RewardModelRayActor
+# No implicit imports of deepspeed here to avoid vllm environment gets comtaminated
 from .vllm_engine import batch_vllm_engine_call, create_vllm_engines
 
 __all__ = [
-    "DistributedTorchRayActor",
-    "PPORayActorGroup",
-    "ReferenceModelRayActor",
-    "RewardModelRayActor",
     "create_vllm_engines",
     "batch_vllm_engine_call",
 ]

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -23,7 +23,7 @@ def get_all_env_variables():
 class BaseLLMRayActor:
     def __init__(self, *args, bundle_indices: list = None, **kwargs):
         kwargs.pop("agent_func_path", None)
-        noset_visible_devices = kwargs.pop("noset_visible_devices")
+        noset_visible_devices = ray_noset_visible_devices()
         if kwargs.get("distributed_executor_backend") == "ray":
             # a hack to make the script work.
             # stop ray from manipulating *_VISIBLE_DEVICES
@@ -123,7 +123,6 @@ def create_vllm_engines(
     assert vllm.__version__ > "0.8.2", "OpenRLHF only supports vllm > 0.8.2"
 
     vllm_engines = []
-    noset_visible_devices = ray_noset_visible_devices(ray.get(get_all_env_variables.remote()))
     distributed_executor_backend = "uni" if tensor_parallel_size == 1 else "ray"
     use_hybrid_engine = shared_pg is not None
     num_gpus = int(tensor_parallel_size == 1)
@@ -170,7 +169,6 @@ def create_vllm_engines(
                 bundle_indices=bundle_indices,
                 num_gpus=0.2 if use_hybrid_engine else 1,
                 enable_sleep_mode=vllm_enable_sleep,
-                noset_visible_devices=noset_visible_devices,
                 agent_func_path=agent_func_path,
             )
         )


### PR DESCRIPTION
Now the new version for the synchronous training mode is broken, as now `LLMRayActor` inherits `BaseLLMRayActor`, which make it import all the dependencies in the file as well all the up level `__init__.py`, and introduces early CUDA calls that's caused by the import of deepspeed.

Similar to:
- https://github.com/OpenRLHF/OpenRLHF/pull/524#issuecomment-2501505023
- https://github.com/OpenRLHF/OpenRLHF/pull/537

So this PR clean up such responsible `__init__.py` files (similar to #537) to give a ultimate fix.

There are also some alternatives to this PR, such as forcing the users to set `RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES`. Another alternative is to set `PYTORCH_NVML_BASED_CUDA_CHECK=1`, but I don't think this is a good practice as explained in
https://github.com/deepspeedai/DeepSpeed/pull/6810#issuecomment-2528676331