### PR TITLE
fix zero_pad_sequences

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -7,7 +7,6 @@ from typing import List, Optional, Tuple, Union
 
 import ray
 import torch
-import torch.nn.functional as F
 
 from openrlhf.models.utils import compute_approx_kl, compute_reward, masked_mean
 from openrlhf.trainer.ray.launcher import PPORayActorGroup

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 from openrlhf.models.utils import compute_approx_kl, compute_reward, masked_mean
 from openrlhf.trainer.ray.launcher import PPORayActorGroup
 from openrlhf.utils.logging_utils import init_logger
+from openrlhf.utils.utils import zero_pad_sequences
 
 logger = init_logger(__name__)
 
@@ -26,17 +27,6 @@ def pin_memory(tensor: Union[torch.Tensor, list[torch.Tensor]]):
     if isinstance(tensor, list):
         return [pin_memory(t) for t in tensor]
     return tensor.pin_memory() if isinstance(tensor, torch.Tensor) else tensor
-
-
-def zero_pad_sequences(sequences, side: str = "left", value=0):
-    assert side in ("left", "right")
-    max_len = max(seq.size(-1) for seq in sequences)
-    padded_sequences = []
-    for seq in sequences:
-        pad_len = max_len - seq.size(-1)
-        padding = (pad_len, 0) if side == "left" else (0, pad_len)
-        padded_sequences.append(F.pad(seq, padding, value=value))
-    return torch.cat(padded_sequences, dim=0)
 
 
 @dataclass

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -44,12 +44,12 @@ def convert_token_to_id(token, tokenizer):
         raise ValueError("token should be int or str")
 
 
-def zero_pad_sequences(sequences: List[torch.Tensor], side: str = "left") -> torch.Tensor:
+def zero_pad_sequences(sequences: List[torch.Tensor], side: str = "left", value: int = 0) -> torch.Tensor:
     assert side in ("left", "right")
-    max_len = max(seq.size(0) for seq in sequences)
+    max_len = max(seq.size(-1) for seq in sequences)
     padded_sequences = []
     for seq in sequences:
-        pad_len = max_len - seq.size(0)
+        pad_len = max_len - seq.size(-1)
         padding = (pad_len, 0) if side == "left" else (0, pad_len)
-        padded_sequences.append(F.pad(seq, padding))
-    return torch.stack(padded_sequences, dim=0)
+        padded_sequences.append(F.pad(seq, padding, value=value))
+    return torch.cat(padded_sequences, dim=0)


### PR DESCRIPTION
Previously, function `zero_pad_sequences` (defined in `openrlhf/utils/utils.py`) only receives `sequences` and `side` as two positional arguments. However, it should also support `value` as a default argument.