### PR TITLE
Update sft_dataset.py

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -223,7 +223,7 @@ class SFTDataset(Dataset):
             attention_masks.append(attention_mask)
             loss_masks.append(loss_mask)
 
-        input_ids = zero_pad_sequences(input_ids, "right", self.tokenizer.pad_token_id)
+        input_ids = zero_pad_sequences(input_ids, "right")
         attention_masks = zero_pad_sequences(attention_masks, "right")
         loss_masks = zero_pad_sequences(loss_masks, "right")
         return input_ids, attention_masks, loss_masks


### PR DESCRIPTION
Got this error
```
[rank0]:   File "<frozen runpy>", line 198, in _run_module_as_main
[rank0]:   File "<frozen runpy>", line 88, in _run_code
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/openrlhf/cli/train_sft.py", line 285, in <module>
[rank0]:     train(args)
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/openrlhf/cli/train_sft.py", line 142, in train
[rank0]:     trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/openrlhf/trainer/sft_trainer.py", line 135, in fit
[rank0]:     for inputs, attention_masks, loss_masks in self.train_dataloader:
[rank0]:                                                ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/torchdata/stateful_dataloader/stateful_dataloader.py", line 450, in __next__
[rank0]:     return super().__next__()
[rank0]:            ^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/torch/utils/data/dataloader.py", line 708, in __next__
[rank0]:     data = self._next_data()
[rank0]:            ^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/torchdata/stateful_dataloader/stateful_dataloader.py", line 491, in _next_data
[rank0]:     data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/torch/utils/data/_utils/fetch.py", line 55, in fetch
[rank0]:     return self.collate_fn(data)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/home/lsutawik/miniconda3/envs/edit/lib/python3.12/site-packages/openrlhf/datasets/sft_dataset.py", line 226, in collate_fn
[rank0]:     input_ids = zero_pad_sequences(input_ids, "right", self.tokenizer.pad_token_id)
[rank0]:                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: TypeError: zero_pad_sequences() takes from 1 to 2 positional arguments but 3 were given
```

Which seems to be due to changes in `zero_pad_sequences` that only accepts 2 args now.