### PR TITLE
Enable logits extraction from vLLM for training

### DIFF
--- a/examples/scripts/train_reinforce_baseline_llama_ray_async_vllm_logits.sh
+++ b/examples/scripts/train_reinforce_baseline_llama_ray_async_vllm_logits.sh
@@ -1,0 +1,49 @@
+set -x
+
+# reinforce++
+
+ray job submit --address="http://127.0.0.1:8265" \
+   --runtime-env-json='{"working_dir": "/openrlhf"}' \
+   -- python3 -m openrlhf.cli.train_ppo_ray \
+   --ref_num_nodes 1 \
+   --ref_num_gpus_per_node 1 \
+   --reward_num_nodes 1 \
+   --reward_num_gpus_per_node 1 \
+   --actor_num_nodes 1 \
+   --actor_num_gpus_per_node 4 \
+   --vllm_num_engines 2 \
+   --vllm_tensor_parallel_size 1 \
+   --pretrain OpenRLHF/Llama-3-8b-sft-mixture \
+   --reward_pretrain OpenRLHF/Llama-3-8b-rm-700k \
+   --save_path /openrlhf/examples/test_scripts/checkpoint/llama3-8b-rlhf \
+   --micro_train_batch_size 8 \
+   --train_batch_size 128 \
+   --micro_rollout_batch_size 16 \
+   --rollout_batch_size 128 \
+   --n_samples_per_prompt 8 \
+   --max_epochs 1 \
+   --prompt_max_len 1024 \
+   --max_samples 12500 \
+   --generate_max_len 1024 \
+   --advantage_estimator reinforce_baseline \
+   --zero_stage 3 \
+   --bf16 \
+   --actor_learning_rate 5e-7 \
+   --init_kl_coef 1e-2 \
+   --use_kl_loss \
+   --kl_estimator k2 \
+   --prompt_data OpenRLHF/prompt-collection-v0.1 \
+   --input_key context_messages \
+   --apply_chat_template \
+   --normalize_reward \
+   --gradient_checkpointing \
+   --packing_samples \
+   --save_steps -1 \
+   --async_train \
+   --ckpt_path /openrlhf/examples/test_scripts/ckpt/llama3-8b-rlhf \
+   --use_vllm_logprobs \
+# You could also try
+#   --use_kl_loss \
+#   --kl_estimator k3 | k2 \
+
+# also supports --advantage_estimator rloo | reinforce_baseline

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -71,6 +71,7 @@ def train(args):
             args.vllm_enable_sleep,
             LLMRayActor,
             args.agent_func_path,
+            args.use_vllm_logprobs
         )
 
     actor_model = RayActorGroup(
@@ -244,6 +245,12 @@ if __name__ == "__main__":
         type=float,
         default=0.95,
         help="vLLM gpu_memory_utilization",
+    )
+    parser.add_argument(
+        "--use_vllm_logprobs",
+        action="store_true",
+        default=False,
+        help="Enable vLLM logprobs computation",
     )
 
     # Async training using ray

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -122,6 +122,7 @@ def create_vllm_engines(
     vllm_enable_sleep=False,
     llm_actor_cls=LLMRayActor,
     agent_func_path=None,
+    use_fp32_logits=False
 ):
     import vllm
 
@@ -175,6 +176,7 @@ def create_vllm_engines(
                 num_gpus=0.2 if use_hybrid_engine else 1,
                 enable_sleep_mode=vllm_enable_sleep,
                 agent_func_path=agent_func_path,
+                use_fp32_logits=use_fp32_logits
             )
         )
 


### PR DESCRIPTION
This PR adds support for directly extracting logits from vLLM during training.
By enabling this feature, we avoid redundant computation of sequence logits during reinforcement learning (RL) fine-tuning, which previously required separate forward passes.

The change introduces a new flag:

```
--use_vllm_logprobs
```

When enabled, the training engine will use logits returned by vLLM instead of computing them again inside the trainer.
