### PR TITLE
Support soft overlong punishment from DAPO

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -384,6 +384,8 @@ if __name__ == "__main__":
         default=False,
         help="disable dividing by std for advantages while keeping mean normalization",
     )
+    parser.add_argument("--overlong_buffer_len", type=float, default=None, help="reward with optional overlong penalty")
+    parser.add_argument("--overlong_penalty_factor", type=float, default=1, help="overlong penalty factor")
 
     # Context Parallel
     parser.add_argument("--ring_attn_size", type=int, default=1, help="Ring attention group size")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -384,7 +384,9 @@ if __name__ == "__main__":
         default=False,
         help="disable dividing by std for advantages while keeping mean normalization",
     )
-    parser.add_argument("--overlong_buffer_len", type=float, default=None, help="reward with optional overlong penalty")
+    parser.add_argument(
+        "--overlong_buffer_len", type=float, default=None, help="reward with optional overlong penalty"
+    )
     parser.add_argument("--overlong_penalty_factor", type=float, default=1, help="overlong penalty factor")
 
     # Context Parallel

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -675,7 +675,8 @@ class RemoteExperienceMaker(ABC):
                 batch_size = len(response_lengths)
                 for j in range(batch_size):
                     valid_response_length = response_lengths[j].item()
-                    exceed_len = valid_response_length - expected_len
+                    # Cap the exceed_len to overlong_buffer_len to prevent excessive penalty
+                    exceed_len = min(valid_response_length - expected_len, overlong_buffer_len)
                     if exceed_len > 0:
                         overlong_penalty = -exceed_len / overlong_buffer_len * overlong_penalty_factor
                         # Apply penalty to the j-th reward in this experience

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -670,8 +670,9 @@ class RemoteExperienceMaker(ABC):
 
         # DAPO reward shaping with optional overlong penalty
         if args.overlong_buffer_len is not None:
-            assert args.generate_max_len >= args.overlong_buffer_len, (
-                "max_resp_len must be larger than overlong_buffer_len")
+            assert (
+                args.generate_max_len >= args.overlong_buffer_len
+            ), "max_resp_len must be larger than overlong_buffer_len"
             overlong_buffer_len = args.overlong_buffer_len
             expected_len = args.generate_max_len - overlong_buffer_len
             overlong_penalty_factor = args.overlong_penalty_factor

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -662,12 +662,13 @@ class RemoteExperienceMaker(ABC):
 
         # DAPO reward shaping with optional overlong penalty - Apply BEFORE dynamic indices processing
         if args.overlong_buffer_len is not None:
-            assert args.generate_max_len >= args.overlong_buffer_len, (
-                "generate_max_len must be larger than overlong_buffer_len")
+            assert (
+                args.generate_max_len >= args.overlong_buffer_len
+            ), "generate_max_len must be larger than overlong_buffer_len"
             overlong_buffer_len = args.overlong_buffer_len
             expected_len = args.generate_max_len - overlong_buffer_len
             overlong_penalty_factor = args.overlong_penalty_factor
-            
+
             # Apply penalty to each experience's rewards based on response length
             for experience in experiences:
                 response_lengths = experience.info["response_length"]

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -660,6 +660,26 @@ class RemoteExperienceMaker(ABC):
         """
         args = self.strategy.args
 
+        # DAPO reward shaping with optional overlong penalty - Apply BEFORE dynamic indices processing
+        if args.overlong_buffer_len is not None:
+            assert args.generate_max_len >= args.overlong_buffer_len, (
+                "generate_max_len must be larger than overlong_buffer_len")
+            overlong_buffer_len = args.overlong_buffer_len
+            expected_len = args.generate_max_len - overlong_buffer_len
+            overlong_penalty_factor = args.overlong_penalty_factor
+            
+            # Apply penalty to each experience's rewards based on response length
+            for experience in experiences:
+                response_lengths = experience.info["response_length"]
+                batch_size = len(response_lengths)
+                for j in range(batch_size):
+                    valid_response_length = response_lengths[j].item()
+                    exceed_len = valid_response_length - expected_len
+                    if exceed_len > 0:
+                        overlong_penalty = -exceed_len / overlong_buffer_len * overlong_penalty_factor
+                        # Apply penalty to the j-th reward in this experience
+                        experience.rewards[j] += overlong_penalty
+
         # get rewards from experiences
         exp_len = [len(experience.index) for experience in experiences]
         # indices is an identity mapping when not using dynamic batch; otherwise, it maps back to the original indices after rearange samples
@@ -667,28 +687,6 @@ class RemoteExperienceMaker(ABC):
         raw_rewards = torch.cat([experience.rewards for experience in experiences], dim=0)
         rewards = torch.empty_like(raw_rewards)
         rewards[indices] = raw_rewards  # sorted
-
-        # DAPO reward shaping with optional overlong penalty
-        if args.overlong_buffer_len is not None:
-            assert (
-                args.generate_max_len >= args.overlong_buffer_len
-            ), "generate_max_len must be larger than overlong_buffer_len"
-            overlong_buffer_len = args.overlong_buffer_len
-            expected_len = args.generate_max_len - overlong_buffer_len
-            overlong_penalty_factor = args.overlong_penalty_factor
-            # Apply penalty to each reward based on response length
-            reward_idx = 0
-            for experience in experiences:
-                response_lengths = experience.info["response_length"]
-                batch_size = len(response_lengths)
-                for j in range(batch_size):
-                    if reward_idx < len(rewards):
-                        valid_response_length = response_lengths[j]
-                        exceed_len = valid_response_length - expected_len
-                        overlong_reward = torch.min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
-                        # Apply penalty to the corresponding reward in flat tensor
-                        rewards[reward_idx] += overlong_reward
-                        reward_idx += 1
 
         rewards = rewards.reshape(-1, args.n_samples_per_prompt)
 

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -668,6 +668,27 @@ class RemoteExperienceMaker(ABC):
         rewards = torch.empty_like(raw_rewards)
         rewards[indices] = raw_rewards  # sorted
 
+        # DAPO reward shaping with optional overlong penalty
+        if args.overlong_buffer_len is not None:
+            assert args.generate_max_len >= args.overlong_buffer_len, (
+                "max_resp_len must be larger than overlong_buffer_len")
+            overlong_buffer_len = args.overlong_buffer_len
+            expected_len = args.generate_max_len - overlong_buffer_len
+            overlong_penalty_factor = args.overlong_penalty_factor
+            # Apply penalty to each reward based on response length
+            reward_idx = 0
+            for experience in experiences:
+                response_lengths = experience.info["response_length"]
+                batch_size = len(response_lengths)
+                for j in range(batch_size):
+                    if reward_idx < len(rewards):
+                        valid_response_length = response_lengths[j]
+                        exceed_len = valid_response_length - expected_len
+                        overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
+                        # Apply penalty to the corresponding reward in flat tensor
+                        rewards[reward_idx] += overlong_reward
+                        reward_idx += 1
+
         rewards = rewards.reshape(-1, args.n_samples_per_prompt)
 
         # log group reward std

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -670,8 +670,9 @@ class RemoteExperienceMaker(ABC):
 
         # DAPO reward shaping with optional overlong penalty
         if args.overlong_buffer_len is not None:
-            assert args.generate_max_len >= args.overlong_buffer_len, (
-                "generate_max_len must be larger than overlong_buffer_len")
+            assert (
+                args.generate_max_len >= args.overlong_buffer_len
+            ), "generate_max_len must be larger than overlong_buffer_len"
             overlong_buffer_len = args.overlong_buffer_len
             expected_len = args.generate_max_len - overlong_buffer_len
             overlong_penalty_factor = args.overlong_penalty_factor

--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -670,9 +670,8 @@ class RemoteExperienceMaker(ABC):
 
         # DAPO reward shaping with optional overlong penalty
         if args.overlong_buffer_len is not None:
-            assert (
-                args.generate_max_len >= args.overlong_buffer_len
-            ), "max_resp_len must be larger than overlong_buffer_len"
+            assert args.generate_max_len >= args.overlong_buffer_len, (
+                "generate_max_len must be larger than overlong_buffer_len")
             overlong_buffer_len = args.overlong_buffer_len
             expected_len = args.generate_max_len - overlong_buffer_len
             overlong_penalty_factor = args.overlong_penalty_factor
@@ -685,7 +684,7 @@ class RemoteExperienceMaker(ABC):
                     if reward_idx < len(rewards):
                         valid_response_length = response_lengths[j]
                         exceed_len = valid_response_length - expected_len
-                        overlong_reward = min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
+                        overlong_reward = torch.min(-exceed_len / overlong_buffer_len * overlong_penalty_factor, 0)
                         # Apply penalty to the corresponding reward in flat tensor
                         rewards[reward_idx] += overlong_reward
                         reward_idx += 1


### PR DESCRIPTION

This PR adds the **overlong response penalty feature**, completing the implementation of **full DAPO support.**

### Key Differences from GRPO

Compared to GRPO, DAPO includes the following four main modifications:

✅ **Clip-Higher Strategy**: Already supported via the `--eps_clip_low_high` parameter, enabling asymmetric clipping.
✅ **Dynamic Filtering**: Enabled through `--dynamic_filtering` and `--dynamic_filtering_reward_range`, allowing adaptive sample filtering based on reward distribution.
✅ **Token-Level Loss**: Already supported; `PolicyLoss` uses `token_level_loss = True` by default for finer-grained optimization.
⭐️ **Soft Overlong Punishment**: Newly supported in this PR via `--overlong_buffer_len` and `--overlong_penalty_factor`.

### Overlong Response Penalty

To address the issue of excessively long responses, we introduce a **length-based penalty** that is smoothly applied based on how far the response exceeds a cache-safe length threshold. Specifically, if the response length \$|y|\$ exceeds a given safety buffer, the reward is adjusted as:

$$
R_{\text{length}}(y) =
\begin{cases}
0, & |y| \leq L_{\text{max}} - L_{\text{cache}} \\\\
\frac{(L_{\text{max}} - L_{\text{cache}}) - |y|}{L_{\text{cache}}}, & L_{\text{max}} - L_{\text{cache}} < |y| \leq L_{\text{max}} \\\\
-1, & |y| > L_{\text{max}}
\end{cases}
$$

This penalty is **added to the accuracy-based reward** during training to create a more balanced and stable learning signal. It discourages overly verbose outputs, improves training stability, and enhances overall model performance.

Our implementation is inspired by [verl/recipe/dapo](https://github.com/volcengine/verl/tree/main/recipe/dapo).
