### PR TITLE
Support adustable min_lr from DPO training script

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -209,7 +209,12 @@ if __name__ == "__main__":
     # DPO
     parser.add_argument("--max_epochs", type=int, default=1)
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
-    parser.add_argument("--min_lr_ratio", type=float, default=0.1, help="Ratio of the minimum learning rate to the initial learning rate.")
+    parser.add_argument(
+        "--min_lr_ratio",
+        type=float,
+        default=0.1,
+        help="Ratio of the minimum learning rate to the initial learning rate.",
+    )
     parser.add_argument("--beta", type=float, default=0.1)
     parser.add_argument("--ipo", action="store_true", default=False)  # IPO https://arxiv.org/pdf/2310.12036v2.pdf
     parser.add_argument("--label_smoothing", type=float, default=0.0)  # cDPO https://arxiv.org/pdf/2305.18290.pdf

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     # DPO
     parser.add_argument("--max_epochs", type=int, default=1)
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
-    parser.add_argument("--min_lr_ratio", type=float, default=0.1, help="Amount to reduce LR during training")
+    parser.add_argument("--min_lr_ratio", type=float, default=0.1, help="Ratio of the minimum learning rate to the initial learning rate.")
     parser.add_argument("--beta", type=float, default=0.1)
     parser.add_argument("--ipo", action="store_true", default=False)  # IPO https://arxiv.org/pdf/2310.12036v2.pdf
     parser.add_argument("--label_smoothing", type=float, default=0.0)  # cDPO https://arxiv.org/pdf/2305.18290.pdf

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -122,7 +122,7 @@ def train(args):
         optim,
         num_warmup_steps=math.ceil(max_steps * args.lr_warmup_ratio),
         num_training_steps=max_steps,
-        scheduler_specific_kwargs={"min_lr": args.learning_rate * 0.1},
+        scheduler_specific_kwargs={"min_lr": args.learning_rate * args.min_lr_ratio},
     )
 
     # strategy prepare
@@ -209,6 +209,7 @@ if __name__ == "__main__":
     # DPO
     parser.add_argument("--max_epochs", type=int, default=1)
     parser.add_argument("--l2", type=float, default=0.0, help="weight decay loss")
+    parser.add_argument("--min_lr_ratio", type=float, default=0.1, help="Amount to reduce LR during training")
     parser.add_argument("--beta", type=float, default=0.1)
     parser.add_argument("--ipo", action="store_true", default=False)  # IPO https://arxiv.org/pdf/2310.12036v2.pdf
     parser.add_argument("--label_smoothing", type=float, default=0.0)  # cDPO https://arxiv.org/pdf/2305.18290.pdf


### PR DESCRIPTION
`train_dpo.py` currently hard-codes that the learning rate schedule should go from the initial learning rate until 0.1*initial learning rate. There is often value in adjusting this parameter.

This two-line pull request adds a parameter called "min_lr_ratio" which controls this ratio (instead of hard-coding it to 0.1).