### PR TITLE
fix remote reward model init bug in PPOTrainerAsync

### DIFF
--- a/openrlhf/trainer/ppo_trainer_async.py
+++ b/openrlhf/trainer/ppo_trainer_async.py
@@ -266,7 +266,7 @@ class PPOTrainerAsync:
         if self.args.remote_rm_url and not self.args.remote_rm_url[0] == "agent":
             from openrlhf.utils.remote_rm_utils import RemoteRewardModel
 
-            self.remote_reward_model = RemoteRewardModel.remote(self.args, self.remote_rm_url)
+            self.remote_reward_model = RemoteRewardModel.remote(self.args, self.args.remote_rm_url)
         else:
             self.remote_reward_model = None
 


### PR DESCRIPTION
change
self.remote_reward_model = RemoteRewardModel.remote(self.args, self.remote_rm_url)
to
self.remote_reward_model = RemoteRewardModel.remote(self.args, self.args.remote_rm_url)

in PPOTrainerAsync