### PR TITLE
 Star Attention topology support with model integration and --attn_topology flag

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -219,6 +219,7 @@ if __name__ == "__main__":
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
 
     # Context Parallel
+    parser.add_argument("--attn_topology", type=str, default="ring", choices=["ring", "star"], help="Context-parallel topology")
     parser.add_argument("--ring_attn_size", type=int, default=1, help="Ring attention group size")
     parser.add_argument(
         "--ring_head_stride",
@@ -295,7 +296,7 @@ if __name__ == "__main__":
         args.flash_attn = True
 
     if args.ring_attn_size > 1:
-        assert args.packing_samples, "packing_samples must be enabled when using ring attention"
+        assert args.packing_samples, "packing_samples must be enabled when using ring/star attention"
 
     if args.use_ms:
         from modelscope.utils.hf_util import patch_hub

--- a/openrlhf/cli/train_prm.py
+++ b/openrlhf/cli/train_prm.py
@@ -166,6 +166,9 @@ if __name__ == "__main__":
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
     parser.add_argument("--ds_tensor_parallel_size", type=int, default=1, help="DeepSpeed Tensor parallel size")
 
+    # Context Parallel
+    parser.add_argument("--attn_topology", type=str, default="ring", choices=["ring", "star"], help="Context-parallel topology")
+
     # LoRA
     parser.add_argument("--load_in_4bit", action="store_true", default=False)
     parser.add_argument("--lora_rank", type=int, default=0)

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -199,6 +199,7 @@ if __name__ == "__main__":
     parser.add_argument("--value_head_prefix", type=str, default="score")
 
     # Context Parallel
+    parser.add_argument("--attn_topology", type=str, default="ring", choices=["ring", "star"], help="Context-parallel topology")
     parser.add_argument("--ring_attn_size", type=int, default=1, help="Ring attention group size")
     parser.add_argument(
         "--ring_head_stride",
@@ -284,7 +285,7 @@ if __name__ == "__main__":
         args.flash_attn = True
 
     if args.ring_attn_size > 1:
-        assert args.packing_samples, "packing_samples must be enabled when using ring attention"
+        assert args.packing_samples, "packing_samples must be enabled when using ring/star attention"
 
     if args.use_ms:
         from modelscope.utils.hf_util import patch_hub

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -197,6 +197,8 @@ if __name__ == "__main__":
     parser.add_argument("--l2", type=float, default=0, help="weight decay loss")
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")
 
+    # context-parallel topology
+    parser.add_argument("--attn_topology", type=str, default="ring", choices=["ring", "star"], help="Context-parallel topology")
     # ring-attention
     parser.add_argument("--ring_attn_size", type=int, default=1, help="Ring attention group size")
     parser.add_argument(
@@ -274,7 +276,7 @@ if __name__ == "__main__":
         args.flash_attn = True
 
     if args.ring_attn_size > 1:
-        assert args.packing_samples, "packing_samples must be enabled when using ring attention"
+        assert args.packing_samples, "packing_samples must be enabled when using ring/star attention"
 
     if args.use_ms:
         from modelscope.utils.hf_util import patch_hub

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -8,7 +8,8 @@ from peft.tuners.lora import LoraLayer
 from transformers import AutoModelForCausalLM, BitsAndBytesConfig
 from transformers.integrations.deepspeed import HfDeepSpeedConfig
 
-from .ring_attn_utils import gather_and_pad_tensor, unpad_and_slice_tensor
+from .ring_attn_utils import gather_and_pad_tensor as ring_gather_and_pad_tensor, unpad_and_slice_tensor as ring_unpad_and_slice_tensor
+from .star_attn_utils import gather_and_pad_tensor as star_gather_and_pad_tensor, unpad_and_slice_tensor as star_unpad_and_slice_tensor
 from .utils import compute_entropy, log_probs_from_logits
 
 
@@ -146,9 +147,20 @@ class Actor(nn.Module):
         batch, seqlen = sequences.size()
         foward_attention_mask = attention_mask
         if self.packing_samples:
-            sequences, position_ids, rolled_sequences, ring_attn_pad_len, indices = unpad_and_slice_tensor(
-                sequences, attention_mask, ring_attn_group
-            )
+            if ring_attn_group is not None:
+                sequences, position_ids, rolled_sequences, ring_attn_pad_len, indices = ring_unpad_and_slice_tensor(
+                    sequences, attention_mask, ring_attn_group
+                )
+                attn_kind = "ring"
+            else:
+                # Assume star if provided via strategy
+                from openrlhf.utils.deepspeed.deepspeed import DeepspeedStrategy  # local import to avoid cycle
+                attn_kind = "star"
+                from .star_attn_utils import get_star_attn_group
+                star_group = get_star_attn_group()
+                sequences, position_ids, rolled_sequences, ring_attn_pad_len, indices = star_unpad_and_slice_tensor(
+                    sequences, attention_mask, star_group
+                )
             foward_attention_mask = None
         else:
             # https://github.com/OpenRLHF/OpenRLHF/issues/217
@@ -171,15 +183,27 @@ class Actor(nn.Module):
         if not return_action_log_probs and not return_logprobs:
             assert return_output
             if allgather_logits and self.packing_samples:
-                output["logits"] = gather_and_pad_tensor(
-                    output["logits"], ring_attn_group, ring_attn_pad_len, indices, batch, seqlen
-                )
+                if 'attn_kind' in locals() and attn_kind == "star":
+                    from .star_attn_utils import get_star_attn_group
+                    star_group = get_star_attn_group()
+                    output["logits"] = star_gather_and_pad_tensor(
+                        output["logits"], star_group, ring_attn_pad_len, indices, batch, seqlen
+                    )
+                else:
+                    output["logits"] = ring_gather_and_pad_tensor(
+                        output["logits"], ring_attn_group, ring_attn_pad_len, indices, batch, seqlen
+                    )
             return output
 
         log_probs = log_probs_from_logits(output["logits"], rolled_sequences, temperature=self.temperature)
 
         if self.packing_samples:
-            log_probs = gather_and_pad_tensor(log_probs, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
+            if 'attn_kind' in locals() and attn_kind == "star":
+                from .star_attn_utils import get_star_attn_group
+                star_group = get_star_attn_group()
+                log_probs = star_gather_and_pad_tensor(log_probs, star_group, ring_attn_pad_len, indices, batch, seqlen)
+            else:
+                log_probs = ring_gather_and_pad_tensor(log_probs, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
 
         log_probs = log_probs[:, :-1]
         if not return_action_log_probs and return_logprobs:

--- a/openrlhf/models/model.py
+++ b/openrlhf/models/model.py
@@ -10,7 +10,8 @@ from transformers.integrations.deepspeed import HfDeepSpeedConfig
 
 from openrlhf.utils.logging_utils import init_logger
 
-from .ring_attn_utils import gather_and_pad_tensor, unpad_and_slice_tensor
+from .ring_attn_utils import gather_and_pad_tensor as ring_gather_and_pad_tensor, unpad_and_slice_tensor as ring_unpad_and_slice_tensor
+from .star_attn_utils import gather_and_pad_tensor as star_gather_and_pad_tensor, unpad_and_slice_tensor as star_unpad_and_slice_tensor
 
 logger = init_logger(__name__)
 
@@ -190,9 +191,18 @@ def _get_reward_model(base_pretrained_model, base_llm_model, value_head_prefix="
             eos_indices = attention_mask.size(1) - 1 - attention_mask.long().fliplr().argmax(dim=1, keepdim=True)
             forward_attention_mask = attention_mask
             if self.packing_samples:
-                input_ids, position_ids, _, ring_attn_pad_len, indices = unpad_and_slice_tensor(
-                    input_ids, attention_mask, ring_attn_group
-                )
+                if ring_attn_group is not None:
+                    input_ids, position_ids, _, ring_attn_pad_len, indices = ring_unpad_and_slice_tensor(
+                        input_ids, attention_mask, ring_attn_group
+                    )
+                    attn_kind = "ring"
+                else:
+                    from .star_attn_utils import get_star_attn_group
+                    star_group = get_star_attn_group()
+                    input_ids, position_ids, _, ring_attn_pad_len, indices = star_unpad_and_slice_tensor(
+                        input_ids, attention_mask, star_group
+                    )
+                    attn_kind = "star"
                 forward_attention_mask = None
             else:
                 # https://github.com/OpenRLHF/OpenRLHF/issues/217
@@ -207,7 +217,12 @@ def _get_reward_model(base_pretrained_model, base_llm_model, value_head_prefix="
             values = getattr(self, self.value_head_prefix)(last_hidden_states).squeeze(-1)
 
             if self.packing_samples:
-                values = gather_and_pad_tensor(values, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
+                if 'attn_kind' in locals() and attn_kind == "star":
+                    from .star_attn_utils import get_star_attn_group
+                    star_group = get_star_attn_group()
+                    values = star_gather_and_pad_tensor(values, star_group, ring_attn_pad_len, indices, batch, seqlen)
+                else:
+                    values = ring_gather_and_pad_tensor(values, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
             reward = values.gather(dim=1, index=eos_indices).squeeze(1)
 
             if not self.training and self.normalize_reward:
@@ -254,9 +269,18 @@ def _get_critic_model(base_pretrained_model, base_llm_model, value_head_prefix="
             batch, seqlen = input_ids.size()
             forward_attention_mask = attention_mask
             if self.packing_samples:
-                input_ids, position_ids, _, ring_attn_pad_len, indices = unpad_and_slice_tensor(
-                    input_ids, attention_mask, ring_attn_group
-                )
+                if ring_attn_group is not None:
+                    input_ids, position_ids, _, ring_attn_pad_len, indices = ring_unpad_and_slice_tensor(
+                        input_ids, attention_mask, ring_attn_group
+                    )
+                    attn_kind = "ring"
+                else:
+                    from .star_attn_utils import get_star_attn_group
+                    star_group = get_star_attn_group()
+                    input_ids, position_ids, _, ring_attn_pad_len, indices = star_unpad_and_slice_tensor(
+                        input_ids, attention_mask, star_group
+                    )
+                    attn_kind = "star"
                 forward_attention_mask = None
             else:
                 # https://github.com/OpenRLHF/OpenRLHF/issues/217
@@ -275,7 +299,12 @@ def _get_critic_model(base_pretrained_model, base_llm_model, value_head_prefix="
             values = getattr(self, self.value_head_prefix)(last_hidden_states).squeeze(-1)  # (1, total_seqs)
 
             if self.packing_samples:
-                values = gather_and_pad_tensor(values, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
+                if 'attn_kind' in locals() and attn_kind == "star":
+                    from .star_attn_utils import get_star_attn_group
+                    star_group = get_star_attn_group()
+                    values = star_gather_and_pad_tensor(values, star_group, ring_attn_pad_len, indices, batch, seqlen)
+                else:
+                    values = ring_gather_and_pad_tensor(values, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)
 
             values = values[:, :-1]
             # normalize reward

--- a/openrlhf/models/star_attn_utils.py
+++ b/openrlhf/models/star_attn_utils.py
@@ -1,0 +1,68 @@
+import torch
+import torch.distributed as dist
+from flash_attn.bert_padding import index_first_axis, pad_input, rearrange, unpad_input
+from flash_attn.utils.distributed import all_gather
+
+STAR_ATTN_GROUP = None
+
+
+def set_star_attn_group(group):
+    global STAR_ATTN_GROUP
+    STAR_ATTN_GROUP = group
+
+
+def get_star_attn_group():
+    return STAR_ATTN_GROUP
+
+
+def _get_tensor_in_current_star_rank(tensors: list[torch.Tensor] | torch.Tensor, star_attn_group, pad_id):
+    if isinstance(tensors, torch.Tensor):
+        tensors = [tensors]
+    star_rank = dist.get_rank(group=star_attn_group)
+    star_size = dist.get_world_size(group=star_attn_group)
+    seqlen = tensors[0].shape[-1]
+    total_seq_len = tensors[0].numel()
+    star_attn_pad_len = (star_size - seqlen % star_size) % star_size
+    output_tensors = []
+    for tensor in tensors:
+        if tensor.numel() != total_seq_len:
+            raise ValueError(f"tensor.numel() {tensor.numel()} != total_seq_len {total_seq_len}")
+        tensor = torch.nn.functional.pad(tensor, (0, star_attn_pad_len), value=pad_id)
+        local_seq_len = tensor.numel() // star_size
+        start, end = star_rank * local_seq_len, (star_rank + 1) * local_seq_len
+        tensor = tensor[:, start:end]
+        output_tensors.append(tensor)
+    if len(output_tensors) == 1:
+        output_tensors = output_tensors[0]
+    return output_tensors, star_attn_pad_len
+
+
+def unpad_and_slice_tensor(sequences, attention_mask, star_attn_group):
+    rolled_sequences = torch.roll(sequences, shifts=-1, dims=1)
+    sequences, indices, cu_seqlens, _, _ = unpad_input(sequences.unsqueeze(-1), attention_mask)
+    sequences = sequences.transpose(0, 1)
+    rolled_sequences = index_first_axis(
+        rearrange(rolled_sequences.unsqueeze(-1), "b s ... -> (b s) ..."), indices
+    ).transpose(0, 1)
+    position_ids = torch.clip(torch.cumsum(attention_mask, dim=-1) - 1, min=0, max=None)
+    position_ids = index_first_axis(rearrange(position_ids.unsqueeze(-1), "b s ... -> (b s) ..."), indices).transpose(
+        0, 1
+    )
+    star_attn_pad_len = 0
+    if star_attn_group is not None:
+        (sequences, position_ids, rolled_sequences), star_attn_pad_len = _get_tensor_in_current_star_rank(
+            [sequences, position_ids, rolled_sequences], star_attn_group, 0
+        )
+        cu_seqlens[-1] += star_attn_pad_len
+    return sequences, position_ids, rolled_sequences, star_attn_pad_len, indices
+
+
+def gather_and_pad_tensor(tensor, star_attn_group, star_attn_pad_len, indices, batch, seqlen):
+    if star_attn_group is not None:
+        tensor = all_gather(tensor.transpose(0, 1), star_attn_group).transpose(0, 1)
+        if star_attn_pad_len > 0:
+            tensor = tensor[:, :-star_attn_pad_len]
+    tensor = pad_input(tensor.transpose(0, 1), indices, batch, seqlen).squeeze(-1)
+    return tensor
+
+

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -20,6 +20,7 @@ from torchdata.stateful_dataloader import StatefulDataLoader
 
 from openrlhf.models import Actor
 from openrlhf.models.ring_attn_utils import get_ring_attn_group, set_ring_attn_group
+from openrlhf.models.star_attn_utils import get_star_attn_group, set_star_attn_group
 from openrlhf.utils.distributed_sampler import DistributedSampler
 from openrlhf.utils.distributed_util import torch_dist_barrier_and_cuda_sync
 from .deepspeed_utils import (
@@ -68,6 +69,7 @@ class DeepspeedStrategy(ABC):
         self.deepcompile = getattr(args, "deepcompile", False)
         self.ds_tensor_parallel_size = getattr(args, "ds_tensor_parallel_size", 1)
         self.ring_attn_size = getattr(self.args, "ring_attn_size", 1)
+        self.attn_topology = getattr(self.args, "attn_topology", "ring")  # ring | star
 
         if self.ds_tensor_parallel_size > 1:
             assert deepspeed.version >= "0.16.4", "DeepSpeed version must be >= 0.16.4 for tensor parallel training"
@@ -102,7 +104,12 @@ class DeepspeedStrategy(ABC):
         self.ds_device_mesh = init_device_mesh(
             "cuda", (dp_size, self.ring_attn_size, self.ds_tensor_parallel_size), mesh_dim_names=("dp", "sp", "tp")
         )
-        self.setup_ring_attn(self.ds_device_mesh)
+        if self.attn_topology == "ring":
+            self.setup_ring_attn(self.ds_device_mesh)
+        elif self.attn_topology == "star":
+            self.setup_star_attn(self.ds_device_mesh)
+        else:
+            raise ValueError(f"Unknown attn_topology: {self.attn_topology}")
 
         self.accumulated_gradient = (
             self.train_batch_size
@@ -130,6 +137,18 @@ class DeepspeedStrategy(ABC):
     @property
     def ring_attn_group(self):
         return get_ring_attn_group()
+
+    def setup_star_attn(self, ds_device_mesh):
+        if self.ring_attn_size == 1:
+            self.ring_attn_rank = 0
+            return
+        group = ds_device_mesh["sp"].get_group()
+        self.ring_attn_rank = dist.get_rank(group=group)
+        set_star_attn_group(group)
+
+    @property
+    def star_attn_group(self):
+        return get_star_attn_group()
 
     def create_optimizer(self, model, **kwargs) -> Optimizer:
         if isinstance(model, Actor):


### PR DESCRIPTION
- Introduces Star Attention scaffolding: `openrlhf/models/star_attn_utils.py` (unpad/slice/gather helpers).
- Adds `--attn_topology {ring,star}` to SFT/DPO/RM/PRM; Ring remains default.
- Integrates topology selection in `DeepspeedStrategy` (sets star process group).
- Updates `Actor` and reward/critic models to dispatch between Ring/Star for packed samples.
- No behavior change unless `--attn_topology star` is specified.

## Why
Enables experimentation with alternative context-parallel topologies; groundwork for kernel-optimized Star and potential throughput gains.
