### PR TITLE
fix display bugs when loading checkpoint for ppo

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -459,6 +459,7 @@ class PPOTrainer(BasePPOTrainer):
                 range(self.prompts_dataloader.__len__()),
                 desc=f"Episode [{episode + 1}/{args.num_episodes}]",
                 disable=False,
+                initial=steps,
             )
 
             filtered_samples = []


### PR DESCRIPTION
Hi, thanks for this great work! Recently, when I ran PPO, I found a bug that occurs when enabling `load_checkpoint` for PPO training. If I continue training from a checkpoint, the PPO trainer can successfully load the model and update `checkpoint_states`. However, the progress display always starts from the beginning.

This happens because `ppo_trainer` uses `self.prompts_dataloader.__len__()` as the tqdm range, with the default `initial` set to 0. I have checked other trainers (including DPO, KD, KTO, PRM, RM, and SFT), and none of them have this issue, since they use `(start_epoch, self.epochs)` as the range.

Although this does not affect the functionality of the PPO trainer, I still hope this bug can be fixed to make the package more robust.



Reference code: https://github.com/OpenRLHF/OpenRLHF/blob/f8ec7ca6b5424f6d637d84a461477748e2cb2e03/openrlhf/trainer/ppo_trainer.py#L450C9-L462C14

