### PR TITLE
adding `--tokenizer_chat_template` in argument parser for DPO trainer

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -267,6 +267,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--apply_chat_template", action="store_true", default=False, help="Use HF tokenizer chat template"
     )
+    parser.add_argument("--tokenizer_chat_template", type=str, default=None)
     parser.add_argument("--max_len", type=int, default=512)
 
     # wandb parameters


### PR DESCRIPTION
This PR adds the `--tokenizer_chat_template` argument to DPO trainer. 

This argument is already part of reward model training and since DPO and reward model trainer both share the same dataset creating utility - `reward_dataset.py` which already handles correctly how to apply a custom chat template, its trivial to apply that to DPO trainer as well since it also expects a preference dataset like reward modelling.

DPO trainer uses the RewardDataset class which already checks for tokenizer_chat_template - `getattr(self.strategy.args, "tokenizer_chat_template", None)` so once we expose this argument in the `strategy.args` object it just works!