### PR TITLE
adding num processors in args

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -77,6 +77,7 @@ def train(args):
         strategy,
         input_template=args.input_template,
         is_dpo=True,
+        num_processors=args.num_processors,
     )
 
     # prepare dataloader
@@ -269,6 +270,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--tokenizer_chat_template", type=str, default=None)
     parser.add_argument("--max_len", type=int, default=512)
+    parser.add_argument("--num_processors", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/cli/train_kd.py
+++ b/openrlhf/cli/train_kd.py
@@ -69,6 +69,7 @@ def train(args):
         strategy,
         pretrain_mode=args.pretrain_mode,
         input_template=args.input_template,
+        num_processors=args.num_processors,
     )
 
     # prepare dataloader
@@ -234,6 +235,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
+    parser.add_argument("--num_processors", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/cli/train_kto.py
+++ b/openrlhf/cli/train_kto.py
@@ -69,7 +69,12 @@ def train(args):
 
     train_data = train_data.select(range(min(args.max_samples, len(train_data))))
     train_dataset = UnpairedPreferenceDataset(
-        train_data, tokenizer, args.max_len, strategy, input_template=args.input_template
+        train_data,
+        tokenizer,
+        args.max_len,
+        strategy,
+        input_template=args.input_template,
+        num_processors=args.num_processors,
     )
 
     # prepare dataloader
@@ -223,6 +228,7 @@ if __name__ == "__main__":
         "--apply_chat_template", action="store_true", default=False, help="Use HF tokenizer chat template"
     )
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
+    parser.add_argument("--num_processors", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -60,6 +60,7 @@ def train(args):
         args.max_len,
         strategy,
         input_template=args.input_template,
+        num_processors=args.num_processors,
     )
 
     # prepare dataloader
@@ -254,6 +255,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--tokenizer_chat_template", type=str, default=None)
     parser.add_argument("--max_len", type=int, default=512)
+    parser.add_argument("--num_processors", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -62,6 +62,7 @@ def train(args):
         strategy,
         pretrain_mode=args.pretrain_mode,
         input_template=args.input_template,
+        num_processors=args.num_workers,
         multiturn=args.multiturn,
     )
     # prepare dataloader
@@ -241,6 +242,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--tokenizer_chat_template", type=str, default=None)
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
+    parser.add_argument("--num_workers", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -62,7 +62,7 @@ def train(args):
         strategy,
         pretrain_mode=args.pretrain_mode,
         input_template=args.input_template,
-        num_processors=args.num_workers,
+        num_processors=args.num_processors,
         multiturn=args.multiturn,
     )
     # prepare dataloader
@@ -242,7 +242,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--tokenizer_chat_template", type=str, default=None)
     parser.add_argument("--max_len", type=int, default=2048, help="Max tokens for the samples")
-    parser.add_argument("--num_workers", type=int, default=8, help="Number of processes for dataset processing")
+    parser.add_argument("--num_processors", type=int, default=8, help="Number of processes for dataset processing")
 
     # wandb parameters
     parser.add_argument("--use_wandb", type=str, default=None)

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -50,7 +50,7 @@ class SFTDataset(Dataset):
         strategy,
         input_template=None,
         pretrain_mode=False,
-        num_processors=8,  # Specify the number of processors you want to use
+        num_processors=8,
         multiturn=False,
     ) -> None:
         super().__init__()


### PR DESCRIPTION
Small change- enabling num_processors to be configured in CLI arguments such that users can configure data processing workers based on available compute.  Users can update dynamically and run the same script with different dataset sizes/compute resources.

**Changes Made**
**CLI Argument**: Added --num_processors with a default value of 8.
**Train Function**: Passed num_processors to the train function for parallel dataset processing.