### PR TITLE
fixes the numerical overflow risk of the k3 estimator in the compute_approx_kl function

### DIFF
--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -35,6 +35,7 @@ def compute_approx_kl(
     if kl_estimator == "k3":
         log_ratio = log_probs.float() - log_probs_base.float()
         log_ratio = -log_ratio
+        log_ratio = log_ratio.clamp(min=-10, max=10)
         log_ratio = log_ratio.exp() - 1 - log_ratio
 
     log_ratio = log_ratio.clamp(min=-10, max=10)


### PR DESCRIPTION
**Background:** 
In the k3 calculation logic, if the input value of the log_ratio.exp() step is too large (e.g., 100), it will generate inf (infinity) due to exceeding the floating-point representation range. Although the final clamp can truncate the result, the intermediate inf may cause hidden issues such as gradient anomalies and dirty numerical data;

**Modify:** Add log_ratio.clamp(min=-10, max=10) before the exp() calculation in the k3 branch to limit the input range of the exponential function in advance, fundamentally preventing exp() from generating inf;