### PR TITLE
Add PromptDataset collate_fn wiring

### DIFF
--- a/openrlhf/cli/batch_inference.py
+++ b/openrlhf/cli/batch_inference.py
@@ -137,7 +137,7 @@ def batch_generate(args):
 
     prompts_dataset = PromptDataset(prompts_data, tokenizer, strategy, input_template=args.input_template)
     prompts_dataloader = strategy.setup_dataloader(
-        prompts_dataset, args.micro_batch_size, True, False, drop_last=False
+        prompts_dataset, args.micro_batch_size, True, False, collate_fn=prompts_dataset.collate_fn, drop_last=False
     )
     pbar = tqdm(
         prompts_dataloader,

--- a/openrlhf/datasets/prompts_dataset.py
+++ b/openrlhf/datasets/prompts_dataset.py
@@ -63,3 +63,14 @@ class PromptDataset(Dataset):
 
     def __getitem__(self, idx):
         return self.datasources[idx], self.prompts[idx], self.labels[idx]
+
+    def collate_fn(self, item_list):
+        datasources = []
+        prompts = []
+        labels = []
+        for datasource, prompt, label in item_list:
+            datasources.append(datasource)
+            prompts.append(prompt)
+            labels.append(label)
+
+        return datasources, prompts, labels

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -38,7 +38,7 @@ def prepare_datasets(strategy, tokenizer):
     # Create train dataset
     train_data = train_data.select(range(min(args.max_samples, len(train_data))))
     prompts_dataset = PromptDataset(train_data, tokenizer, strategy, input_template=args.input_template)
-    prompts_dataloader = strategy.setup_dataloader(prompts_dataset, 1, True, True)
+    prompts_dataloader = strategy.setup_dataloader(prompts_dataset, 1, True, True, prompts_dataset.collate_fn)
 
     # Create eval dataset if eval data exists
     if getattr(args, "eval_dataset", None):
@@ -50,7 +50,7 @@ def prepare_datasets(strategy, tokenizer):
         )
         eval_data = eval_data.select(range(min(args.max_samples, len(eval_data))))
         eval_dataset = PromptDataset(eval_data, tokenizer, strategy, input_template=args.input_template)
-        eval_dataloader = strategy.setup_dataloader(eval_dataset, 1, True, False)
+        eval_dataloader = strategy.setup_dataloader(eval_dataset, 1, True, False, eval_dataset.collate_fn)
     else:
         eval_dataloader = None
 

--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -17,7 +17,7 @@ class AgentExecutorBase(ABC):
 
 class AgentInstanceBase(ABC):
     @abstractmethod
-    async def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         pass
 
     async def reset(self, states: dict, **kwargs):


### PR DESCRIPTION
PyTorch’s default collate_fn recursively merges batch items. If label is a list, it gets unpacked and rearranged instead of staying intact. That breaks the expected batch structure.

So I add a custom collate_fn that simply collects datasources, prompts, and labels into lists, keeping each label as-is and preventing unwanted expansion.