### PR TITLE
fix: pass ring_attn_group to reward model forward in rm_trainer

### DIFF
--- a/openrlhf/trainer/rm_trainer.py
+++ b/openrlhf/trainer/rm_trainer.py
@@ -307,7 +307,9 @@ class RewardModelTrainer(ABC):
         We do this to avoid doing two forward passes, because it's faster for FSDP.
         """
         input_ids, att_masks = self.concatenated_inputs(chosen_ids, c_mask, reject_ids, r_mask)
-        all_values, output = model(input_ids, attention_mask=att_masks, return_output=True)
+        all_values, output = model(
+            input_ids, attention_mask=att_masks, return_output=True, ring_attn_group=self.strategy.ring_attn_group
+        )
         chosen_rewards = all_values[: chosen_ids.shape[0]]
         rejected_rewards = all_values[chosen_ids.shape[0] :]
         aux_loss = output.aux_loss if "aux_loss" in output else []


### PR DESCRIPTION
## Summary

- Pass `ring_attn_group=self.strategy.ring_attn_group` to the model forward call in `RewardModelTrainer.concatenated_forward()`, fixing ring attention support for reward model training (`train_rm`)

## Problem

`rm_trainer.py` does not pass `ring_attn_group` to the reward model's forward pass in `concatenated_forward()`. This causes errors when using ring attention with reward model training, as the model expects this parameter to correctly handle ring attention distributed computation.

**Current code (broken):**
```python
all_values, output = model(input_ids, attention_mask=att_masks, return_output=True)
```

## Fix

**Updated code:**
```python
all_values, output = model(
    input_ids, attention_mask=att_masks, return_output=True, ring_attn_group=self.strategy.ring_attn_group
)
```

This aligns `rm_trainer.py` with the pattern already used in `dpo_trainer.py` (line 301), which correctly passes the ring attention group.

## References

- Fixes #1168
- Consistent with `dpo_trainer.py` implementation
- `strategy.ring_attn_group` is a property defined in `deepspeed.py` (line 131) that returns the ring attention process group
- The model's `forward()` method already accepts `ring_attn_group` as a parameter (`model.py` line 198)