### PR TITLE
feat: Add 3-stage deferred dispatch for vLLM rollout generation

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -328,7 +328,9 @@ class SamplesGenerator:
             (prompts[q3:], labels[q3:]),
         ]
         # Drop empty trailing stages (e.g. when batch is very small).
-        staged_batches = [(stage_prompts, stage_labels) for stage_prompts, stage_labels in staged_batches if stage_prompts]
+        staged_batches = [
+            (stage_prompts, stage_labels) for stage_prompts, stage_labels in staged_batches if stage_prompts
+        ]
 
         dispatches = self._dispatch_prompts_to_vllm(prompts[:mid], labels[:mid], **generate_kwargs)
         pending_refs = [ref for ref, _ in dispatches]
@@ -374,7 +376,9 @@ class SamplesGenerator:
                     avg_reward = sum(scores) / len(scores)
                     min_r, max_r = self.args.dynamic_filtering_reward_range
                     if not (min_r < avg_reward < max_r):
-                        logger.info(f"Filtered out: avg_reward={avg_reward:.2f}, threshold=({min_r:.2f}, {max_r:.2f}), scores={[f'{s:.2f}' for s in scores]}")
+                        logger.info(
+                            f"Filtered out: avg_reward={avg_reward:.2f}, threshold=({min_r:.2f}, {max_r:.2f}), scores={[f'{s:.2f}' for s in scores]}"
+                        )
                         experiences = []
 
                 # Accept experiences and stop once enough have been gathered.


### PR DESCRIPTION
This PR improves rollout scheduling by replacing single-shot prompt dispatch with a **deferred multi-stage dispatch** strategy in GRPO sampling. The objective is to reduce engine idle time from long-tail generations and improve throughput/load balance across vLLM engines during multi-turn rollouts.

## Motivation

For long rollouts, especially multi-turn tool-calling, generation time varies widely across prompts. With all prompts dispatched upfront, some engines can drain early and wait while other engines are still processing requests, reducing GPU utilization.

We already use heap-based load-aware assignment for newly replaced prompts in DAPO-style filtering, but that does not fix the initial batch imbalance. This PR extends load-aware behavior to the initial rollout batch by deferring part of dispatch until runtime imbalance is observable.

## Changes

### 1) Deferred 3-stage dispatch for initial rollout batch
Updated `SamplesGenerator._generate_vllm()` in `openrlhf/trainer/ppo_utils/experience_maker.py`:

- Stage 1: dispatch first ~50% immediately
- Stage 2: hold ~25%
- Stage 3: hold remaining ~25%

Stages 2 and 3 are dispatched only when an engine becomes nearly idle. Each wave re-evaluates engine load rather than relying on static upfront assignment. 

### 2) Dispatch trigger at `pending <= 1` to prevent engine drain
Added per-engine in-flight tracking (`engine_pending`) and `ref_to_engine` mapping.

When any engine drops to **1 pending request**, we dispatch the next deferred stage.This acts as a one-step lookahead: new work is queued before the engine reaches zero pending, minimizing/no-op idle gaps between waves.

### 3) Load-aware assignment on every dispatch wave
`_dispatch_prompts_to_vllm()` now returns `(ref, engine_idx)` and keeps min-heap assignment by current unfinished request counts. 

## Why not continuous load balancing?

One alternative to **coarse deferred waves** is continuous micro-dispatching. This would be theoretically most optimal, but I'm wary of the overhead this may lead to and actually cause unintended idle time. However, this may be an unfounded assumption, and continuous batching would be a more optimal approach. The only idle time would be from the last engine processing the final prompt.