### PR TITLE
fix: wrap grad_norm with float() for Ray serialization in colocate mode

### DIFF
--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -299,7 +299,7 @@ class ActorPPOTrainer(ABC):
         status = {
             "policy_loss": actor_loss.detach().item(),
             "actor_lr": self.actor_scheduler.get_last_lr()[0],
-            "actor_grad_norm": self.strategy.get_grad_norm(self.actor),
+            "actor_grad_norm": float(self.strategy.get_grad_norm(self.actor)),
         }
         if self.args.entropy_loss_coef is not None:
             status["entropy_loss"] = entropy_loss.detach().item()

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -156,7 +156,7 @@ class CriticPPOTrainer(ABC):
             "critic_loss": critic_loss.detach().item(),
             "values": masked_mean(values, experience.action_mask).detach().item(),
             "critic_lr": self.critic_scheduler.get_last_lr()[0],
-            "critic_grad_norm": self.strategy.get_grad_norm(self.critic),
+            "critic_grad_norm": float(self.strategy.get_grad_norm(self.critic)),
         }
         return status
 


### PR DESCRIPTION
DeepSpeed's `get_global_grad_norm()` may return a non-plain-float value that fails Ray's pickle serialization when sent from GPU actor to CPU PPOTrainer in colocate mode. This causes:

  RuntimeError: Attempting to deserialize object on a CUDA device
  but `torch.cuda.is_available()` is False.

Wrapping with float() ensures the value is a plain Python float before being serialized by Ray.

Fixes the grad_norm logging added in 4908e6e.

Verified on 2x H100 with Qwen2.5-1.5B-Instruct + GSM8K (PPO training)

<img width="2386" height="148" alt="image" src="https://github.com/user-attachments/assets/0b2f54bc-f365-41ab-b5ac-245e14cf9d7f" />

<img width="509" height="168" alt="image" src="https://github.com/user-attachments/assets/14ec8f1e-34a2-47b0-96f5-03674500b258" />