### PR TITLE
feat: add --dataloader_num_workers option for multi-process data loading

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -86,6 +86,7 @@ def train(args):
         True,
         True,
         train_dataset.collate_fn,
+        num_workers=args.dataloader_num_workers,
     )
 
     eval_dataset = None
@@ -111,6 +112,7 @@ def train(args):
             True,
             False,
             eval_dataset.collate_fn,
+            num_workers=args.dataloader_num_workers,
         )
 
     # scheduler
@@ -190,6 +192,7 @@ if __name__ == "__main__":
         help="Enable reproducible behavior during distributed training",
     )
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--dataloader_num_workers", type=int, default=0, help="Number of dataloader workers for IO")
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument(

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -326,7 +326,12 @@ if __name__ == "__main__":
     parser.add_argument("--overlap_comm", action="store_true", default=False)
     parser.add_argument("--gradient_checkpointing_use_reentrant", action="store_true", default=False)
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
-    parser.add_argument("--dataloader_num_workers", type=int, default=0, help="Number of dataloader workers for IO")
+    parser.add_argument(
+        "--dataloader_num_workers",
+        type=int,
+        default=0,
+        help="Number of dataloader workers for IO (for Ray training, ensure sufficient CPU resources per actor)",
+    )
     parser.add_argument(
         "--deepspeed_enable_sleep",
         action="store_true",

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -326,6 +326,7 @@ if __name__ == "__main__":
     parser.add_argument("--overlap_comm", action="store_true", default=False)
     parser.add_argument("--gradient_checkpointing_use_reentrant", action="store_true", default=False)
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--dataloader_num_workers", type=int, default=0, help="Number of dataloader workers for IO")
     parser.add_argument(
         "--deepspeed_enable_sleep",
         action="store_true",

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -69,6 +69,7 @@ def train(args):
         True,
         True,
         train_dataset.collate_fn,
+        num_workers=args.dataloader_num_workers,
     )
 
     if getattr(args, "eval_dataset", None):
@@ -95,6 +96,7 @@ def train(args):
         True,
         False,
         eval_dataset.collate_fn,
+        num_workers=args.dataloader_num_workers,
     )
 
     # scheduler
@@ -203,6 +205,7 @@ if __name__ == "__main__":
     parser.add_argument("--overlap_comm", action="store_true", default=False)
     parser.add_argument("--gradient_checkpointing_use_reentrant", action="store_true", default=False)
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--dataloader_num_workers", type=int, default=0, help="Number of dataloader workers for IO")
     parser.add_argument("--ds_tensor_parallel_size", type=int, default=1, help="DeepSpeed Tensor parallel size")
 
     # Models

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -71,6 +71,7 @@ def train(args):
         True,
         True,
         train_dataset.collate_fn,
+        num_workers=args.dataloader_num_workers,
     )
 
     eval_dataloader = None
@@ -96,6 +97,7 @@ def train(args):
             True,
             False,
             eval_dataset.collate_fn,
+            num_workers=args.dataloader_num_workers,
         )
 
     # scheduler
@@ -195,6 +197,7 @@ if __name__ == "__main__":
     parser.add_argument("--overlap_comm", action="store_true", default=False)
     parser.add_argument("--gradient_checkpointing_use_reentrant", action="store_true", default=False)
     parser.add_argument("--disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--dataloader_num_workers", type=int, default=0, help="Number of dataloader workers for IO")
     parser.add_argument("--ds_tensor_parallel_size", type=int, default=1, help="DeepSpeed Tensor parallel size")
 
     # SFT

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -42,7 +42,10 @@ def prepare_datasets(strategy, tokenizer):
     # Create train dataset
     train_data = train_data.select(range(min(args.max_samples, len(train_data))))
     prompts_dataset = PromptDataset(train_data, tokenizer, strategy, input_template=args.input_template)
-    prompts_dataloader = strategy.setup_dataloader(prompts_dataset, 1, True, True, prompts_dataset.collate_fn)
+    prompts_dataloader = strategy.setup_dataloader(
+        prompts_dataset, 1, True, True, prompts_dataset.collate_fn,
+        num_workers=args.dataloader_num_workers,
+    )
 
     # Create eval dataset if eval data exists
     if getattr(args, "eval_dataset", None):
@@ -54,7 +57,10 @@ def prepare_datasets(strategy, tokenizer):
         )
         eval_data = eval_data.select(range(min(args.max_samples, len(eval_data))))
         eval_dataset = PromptDataset(eval_data, tokenizer, strategy, input_template=args.input_template)
-        eval_dataloader = strategy.setup_dataloader(eval_dataset, 1, True, False, eval_dataset.collate_fn)
+        eval_dataloader = strategy.setup_dataloader(
+            eval_dataset, 1, True, False, eval_dataset.collate_fn,
+            num_workers=args.dataloader_num_workers,
+        )
     else:
         eval_dataloader = None
 

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -43,7 +43,11 @@ def prepare_datasets(strategy, tokenizer):
     train_data = train_data.select(range(min(args.max_samples, len(train_data))))
     prompts_dataset = PromptDataset(train_data, tokenizer, strategy, input_template=args.input_template)
     prompts_dataloader = strategy.setup_dataloader(
-        prompts_dataset, 1, True, True, prompts_dataset.collate_fn,
+        prompts_dataset,
+        1,
+        True,
+        True,
+        prompts_dataset.collate_fn,
         num_workers=args.dataloader_num_workers,
     )
 
@@ -58,7 +62,11 @@ def prepare_datasets(strategy, tokenizer):
         eval_data = eval_data.select(range(min(args.max_samples, len(eval_data))))
         eval_dataset = PromptDataset(eval_data, tokenizer, strategy, input_template=args.input_template)
         eval_dataloader = strategy.setup_dataloader(
-            eval_dataset, 1, True, False, eval_dataset.collate_fn,
+            eval_dataset,
+            1,
+            True,
+            False,
+            eval_dataset.collate_fn,
             num_workers=args.dataloader_num_workers,
         )
     else:

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -182,6 +182,7 @@ class DeepspeedStrategy(ABC):
         drop_last=True,
         sampler=None,
         consumed_samples=0,
+        num_workers: int = 0,
     ):
         # DDP only mode, replay buffers on each rank are different.
         if sampler is None and dist.is_initialized():
@@ -207,6 +208,8 @@ class DeepspeedStrategy(ABC):
             shuffle=shuffle if sampler is None else False,
             collate_fn=collate_fn,
             pin_memory=pin_memory,
+            num_workers=num_workers,
+            persistent_workers=num_workers > 0,
         )
 
     def _unwrap_model(self, model) -> nn.Module:


### PR DESCRIPTION
## Summary

Add `--dataloader_num_workers` argument to all training pipelines (SFT, RM, DPO, PPO) to support multi-process data loading.

- Default is `0` (unchanged behavior, fully backward compatible)
- When set to `> 0`, enables `persistent_workers=True` to avoid repeated worker spawning overhead
- Passed through `DeepspeedStrategy.setup_dataloader()` so all pipelines benefit consistently

## Motivation

When training on cloud instances (e.g., AutoDL) with network-mounted storage, the default single-process data loading (`num_workers=0`) becomes a significant IO bottleneck. Setting `--dataloader_num_workers 4` gave a noticeable training speedup in my SFT runs by overlapping data loading with GPU computation.

## Changes

| File | Change |
|------|--------|
| `openrlhf/utils/deepspeed/deepspeed.py` | `setup_dataloader()` accepts `num_workers` param, enables `persistent_workers` when > 0 |
| `openrlhf/cli/train_sft.py` | Add `--dataloader_num_workers` CLI arg and pass to dataloader |
| `openrlhf/cli/train_rm.py` | Same |
| `openrlhf/cli/train_dpo.py` | Same |
| `openrlhf/cli/train_ppo_ray.py` | Add `--dataloader_num_workers` CLI arg |
| `openrlhf/trainer/ppo_trainer.py` | Pass `num_workers` to dataloader setup |

## Test plan

- [x] Verified with `--dataloader_num_workers 0` (default, same behavior as before)
- [x] Verified with `--dataloader_num_workers 4` on SFT training with network-mounted storage, significant IO speedup observed