### PR TITLE
fix: graceful fallback when checkpoint directory has no valid checkpoint

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -131,9 +131,10 @@ def train(args):
     # load checkpoint
     consumed_samples = 0
     if args.load_checkpoint and os.path.exists(args.ckpt_path):
-        _, states = strategy.load_ckpt(model.model, args.ckpt_path)
-        consumed_samples = states["consumed_samples"]
-        strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
+        load_path, states = strategy.load_ckpt(model.model, args.ckpt_path)
+        if load_path is not None:
+            consumed_samples = states["consumed_samples"]
+            strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
 
     os.makedirs(args.save_path, exist_ok=True)
 

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -121,9 +121,10 @@ def train(args):
     # load checkpoint
     consumed_samples = 0
     if args.load_checkpoint and os.path.exists(args.ckpt_path):
-        _, states = strategy.load_ckpt(model, args.ckpt_path)
-        consumed_samples = states["consumed_samples"]
-        strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
+        load_path, states = strategy.load_ckpt(model, args.ckpt_path)
+        if load_path is not None:
+            consumed_samples = states["consumed_samples"]
+            strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
 
     os.makedirs(args.save_path, exist_ok=True)
 

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -116,9 +116,10 @@ def train(args):
     # load checkpoint
     consumed_samples = 0
     if args.load_checkpoint and os.path.exists(args.ckpt_path):
-        _, states = strategy.load_ckpt(model.model, args.ckpt_path)
-        consumed_samples = states["consumed_samples"]
-        strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
+        load_path, states = strategy.load_ckpt(model.model, args.ckpt_path)
+        if load_path is not None:
+            consumed_samples = states["consumed_samples"]
+            strategy.print(f"Loaded the checkpoint: {args.ckpt_path}, consumed_samples: {consumed_samples}")
 
     os.makedirs(args.save_path, exist_ok=True)
 

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -1,6 +1,5 @@
 import gc
 import json
-import logging
 import os
 import shutil
 from abc import ABC
@@ -621,6 +620,6 @@ class DeepspeedStrategy(ABC):
             load_module_only=load_module_only,
         )
         if load_path is None:
-            logging.warning(f"[deepspeed] No checkpoint found at {load_dir}, skipping checkpoint loading.")
+            self.print(f"Warning: [deepspeed] No checkpoint found at {load_dir}, skipping checkpoint loading.")
             return None, {}
         return load_path, states

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -1,5 +1,6 @@
 import gc
 import json
+import logging
 import os
 import shutil
 from abc import ABC
@@ -620,5 +621,6 @@ class DeepspeedStrategy(ABC):
             load_module_only=load_module_only,
         )
         if load_path is None:
-            raise Exception(f"[deepspeed] failed to resume from checkpoint {load_dir}")
+            logging.warning(f"[deepspeed] No checkpoint found at {load_dir}, skipping checkpoint loading.")
+            return None, {}
         return load_path, states


### PR DESCRIPTION
## Summary

When `--load_checkpoint` is enabled but the checkpoint directory contains no valid DeepSpeed checkpoint (e.g., first run with an empty `ckpt_path`), the framework previously raised an unhandled exception and crashed.

This PR changes the behavior to log a warning and continue training from scratch instead.

## Changes

| File | Change |
|------|--------|
| `openrlhf/utils/deepspeed/deepspeed.py` | `load_ckpt()` returns `(None, {})` instead of raising `Exception` when no checkpoint found |
| `openrlhf/cli/train_sft.py` | Check `load_path is not None` before accessing checkpoint state |
| `openrlhf/cli/train_dpo.py` | Same |
| `openrlhf/cli/train_rm.py` | Same |

## Motivation

A common scenario: user enables `--load_checkpoint` in their training script for resumability, but on the first run the checkpoint directory is empty. Previously this crashed with:

```
Exception: [deepspeed] failed to resume from checkpoint /path/to/ckpt
```

Now it gracefully falls back to training from the beginning with a warning message.

## Test plan

- [x] Verified with empty checkpoint directory: training starts from scratch with warning
- [x] Verified with valid checkpoint: resumes correctly as before