### PR TITLE
feat: add --from_scratch option to initialize model with random weights

### DIFF
--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -31,6 +31,7 @@ def train(args):
         ds_config=strategy.get_ds_train_config(is_actor=True),
         packing_samples=args.packing_samples,
         use_liger_kernel=args.use_liger_kernel,
+        from_scratch=args.from_scratch,
     )
     # configure tokenizer
     tokenizer = get_tokenizer(args.pretrain, model.model, "right", strategy, use_fast=not args.disable_fast_tokenizer)
@@ -204,6 +205,12 @@ if __name__ == "__main__":
     parser.add_argument("--learning_rate", type=float, default=5e-6)
     parser.add_argument("--lr_warmup_ratio", type=float, default=0.03)
     parser.add_argument("--pretrain_mode", action="store_true", default=False, help="Use pretrain loss")
+    parser.add_argument(
+        "--from_scratch",
+        action="store_true",
+        default=False,
+        help="Initialize model from config with random weights instead of loading pretrained weights",
+    )
     parser.add_argument("--lr_scheduler", type=str, default="cosine_with_min_lr")
     parser.add_argument("--l2", type=float, default=0, help="weight decay loss")
     parser.add_argument("--adam_betas", type=float, nargs=2, default=(0.9, 0.95), help="Betas for Adam optimizer")

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -49,6 +49,7 @@ class Actor(nn.Module):
         packing_samples=False,
         temperature=1.0,
         use_liger_kernel=False,
+        from_scratch=False,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -88,14 +89,25 @@ class Actor(nn.Module):
             else:
                 model_class = AutoModelForCausalLM
 
-            self.model = model_class.from_pretrained(
-                pretrain_or_model,
-                trust_remote_code=True,
-                attn_implementation=attn_impl,
-                quantization_config=nf4_config,
-                torch_dtype=torch_dtype,  # default: bf16
-                device_map=device_map,
-            )
+            if from_scratch:
+                from transformers import AutoConfig
+
+                config = AutoConfig.from_pretrained(pretrain_or_model, trust_remote_code=True)
+                self.model = model_class.from_config(
+                    config,
+                    trust_remote_code=True,
+                    attn_implementation=attn_impl,
+                    torch_dtype=torch_dtype,
+                )
+            else:
+                self.model = model_class.from_pretrained(
+                    pretrain_or_model,
+                    trust_remote_code=True,
+                    attn_implementation=attn_impl,
+                    quantization_config=nf4_config,
+                    torch_dtype=torch_dtype,  # default: bf16
+                    device_map=device_map,
+                )
 
             # LoRA
             if lora_rank > 0:

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -92,6 +92,9 @@ class Actor(nn.Module):
             if from_scratch:
                 from transformers import AutoConfig
 
+                if load_in_4bit or device_map is not None:
+                    print("[Warning] 'load_in_4bit' and 'device_map' are ignored when 'from_scratch' is True")
+
                 config = AutoConfig.from_pretrained(pretrain_or_model, trust_remote_code=True)
                 self.model = model_class.from_config(
                     config,


### PR DESCRIPTION
## Summary

Add `--from_scratch` flag to SFT training that initializes a model with random weights from its config, enabling pre-training from scratch using OpenRLHF's SFT pipeline.

## Motivation

OpenRLHF currently only supports fine-tuning from pretrained weights. However, for research purposes (e.g., training small custom models from scratch), it's useful to initialize a model with random weights while reusing the existing SFT training infrastructure (DeepSpeed, packing, logging, etc.).

With `--from_scratch`, users can point `--pretrain` to a model config directory and train from randomly initialized weights using `--pretrain_mode`.

## Changes

| File | Change |
|------|--------|
| `openrlhf/models/actor.py` | Add `from_scratch` param: use `from_config()` instead of `from_pretrained()` when enabled |
| `openrlhf/cli/train_sft.py` | Add `--from_scratch` CLI argument, pass to Actor |

## Usage

```bash
deepspeed --module openrlhf.cli.train_sft \
    --pretrain /path/to/model_config \
    --from_scratch \
    --pretrain_mode \
    ...
```

## Test plan

- [x] Verified `--from_scratch` with a small model config: model initializes with random weights and trains successfully
- [x] Verified without `--from_scratch`: behavior unchanged (loads pretrained weights as before)