### PR TITLE
fix: true loss aggregation across dp ranks

### DIFF
--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -5,7 +5,7 @@ import torch.distributed as dist
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .utils import masked_mean
+from .utils import masked_mean, masked_sum
 
 
 class GPTLMLoss(nn.Module):
@@ -16,7 +16,7 @@ class GPTLMLoss(nn.Module):
     def __init__(self, ring_attn_group=None):
         super().__init__()
         self.IGNORE_INDEX = -100
-        self.loss = nn.CrossEntropyLoss(ignore_index=self.IGNORE_INDEX)
+        self.loss = nn.CrossEntropyLoss(ignore_index=self.IGNORE_INDEX, reduction="sum")
 
         self.ring_attn_group = ring_attn_group
         if self.ring_attn_group:
@@ -38,19 +38,22 @@ class GPTLMLoss(nn.Module):
             # if labels are all IGNORE_INDEX, then nn.CrossEntropyLoss will be nan
             if torch.all(shift_labels == self.IGNORE_INDEX):
                 # Use mean of logits multiplied by 0 to maintain gradient flow
-                loss = shift_logits.mean() * 0
+                loss_sum = shift_logits.mean() * 0
+                num_tokens = torch.zeros(1, device=logits.device)
             else:
-                loss = self.loss(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+                loss_sum = self.loss(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+                num_tokens = (shift_labels != self.IGNORE_INDEX).sum().to(loss_sum.dtype)
 
-            dist.all_reduce(loss, op=dist.ReduceOp.SUM, group=self.ring_attn_group)
-            loss = loss / self.ring_attn_world_size
+            dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM, group=self.ring_attn_group)
+            dist.all_reduce(num_tokens, op=dist.ReduceOp.SUM, group=self.ring_attn_group)
         else:
             shift_logits = logits[..., :-1, :].contiguous()
             shift_labels = labels[..., 1:].contiguous()
 
-            loss = self.loss(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+            loss_sum = self.loss(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+            num_tokens = (shift_labels != self.IGNORE_INDEX).sum().to(loss_sum.dtype)
 
-        return loss
+        return loss_sum, num_tokens
 
 
 class SFTLoss(nn.Module):
@@ -63,13 +66,13 @@ class SFTLoss(nn.Module):
         self.token_level_loss = token_level_loss
 
     def forward(self, per_token_logps: torch.Tensor, loss_mask: torch.Tensor) -> torch.Tensor:
-        loss = (
-            masked_mean(-per_token_logps, loss_mask, dim=None)
-            if self.token_level_loss
-            else masked_mean(-per_token_logps, loss_mask, dim=-1).mean()
-        )
-
-        return loss
+        if self.token_level_loss:
+            loss_sum = masked_sum(-per_token_logps, loss_mask, dim=None)
+            num_items = loss_mask.sum()
+        else:
+            loss_sum = masked_mean(-per_token_logps, loss_mask, dim=-1).sum()
+            num_items = (loss_mask.sum(dim=-1) > 0).sum().to(loss_sum.dtype)
+        return loss_sum, num_items
 
 
 class PolicyLoss(nn.Module):
@@ -172,14 +175,17 @@ class PolicyLoss(nn.Module):
                 loss = vllm_is * loss
             vllm_kl = masked_mean(rollout_log_probs - old_log_probs, action_mask, dim=None)
 
-        loss = (
-            masked_mean(loss, action_mask, dim=None)
-            if self.token_level_loss
-            else masked_mean(loss, action_mask, dim=-1).mean()
-        )
+        # Return sum and count for global normalization
+        if self.token_level_loss:
+            loss_sum = masked_sum(loss, action_mask, dim=None)
+            num_items = action_mask.sum()
+        else:
+            # Sequence-level: mean over tokens per sequence, then sum sequences
+            loss_sum = masked_mean(loss, action_mask, dim=-1).sum()
+            num_items = (action_mask.sum(dim=-1) > 0).sum().to(loss_sum.dtype)
         clip_ratio = masked_mean(torch.lt(surr2, surr1).float(), action_mask, dim=None)
         ppo_kl = masked_mean(-log_ratio.detach(), action_mask, dim=None)
-        return loss, clip_ratio, ppo_kl, vllm_kl
+        return loss_sum, num_items, clip_ratio, ppo_kl, vllm_kl
 
 
 class ValueLoss(nn.Module):
@@ -207,12 +213,13 @@ class ValueLoss(nn.Module):
         else:
             loss = (values - returns) ** 2
 
-        loss = (
-            masked_mean(loss, action_mask, dim=None)
-            if self.token_level_loss
-            else masked_mean(loss, action_mask, dim=-1).mean()
-        )
-        return 0.5 * loss
+        if self.token_level_loss:
+            loss_sum = 0.5 * masked_sum(loss, action_mask, dim=None)
+            num_items = action_mask.sum()
+        else:
+            loss_sum = 0.5 * masked_mean(loss, action_mask, dim=-1).sum()
+            num_items = (action_mask.sum(dim=-1) > 0).sum().to(loss_sum.dtype)
+        return loss_sum, num_items
 
 
 class PairWiseLoss(nn.Module):

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -153,6 +153,12 @@ def masked_mean(tensor: torch.Tensor, mask: Optional[torch.Tensor], dim: int = N
     return (tensor * mask).sum(dim=dim) / mask.sum(dim=dim)
 
 
+def masked_sum(tensor: torch.Tensor, mask: Optional[torch.Tensor], dim: int = None) -> torch.Tensor:
+    if mask is None:
+        return tensor.sum(dim=dim)
+    return (tensor * mask).sum(dim=dim)
+
+
 def masked_normalize(tensor: torch.Tensor, mask: torch.Tensor, dim: int = 1, eps: float = 1e-8) -> torch.Tensor:
     tensor = tensor * mask
     mean = masked_mean(tensor, mask, dim=dim)

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from transformers.trainer import get_scheduler
 
 from openrlhf.models import Actor, PolicyLoss
-from openrlhf.models.utils import compute_approx_kl, masked_mean
+from openrlhf.models.utils import compute_approx_kl, masked_sum
 from openrlhf.trainer.ppo_utils.experience import Experience
 from openrlhf.utils import get_tokenizer
 from openrlhf.utils.deepspeed import DeepspeedStrategy
@@ -266,13 +266,22 @@ class ActorPPOTrainer(ABC):
         )
 
         # loss function
-        actor_loss, clip_ratio, ppo_kl, vllm_kl = self.actor_loss_fn(
+        actor_loss_sum, num_tokens, clip_ratio, ppo_kl, vllm_kl = self.actor_loss_fn(
             action_log_probs,
             old_action_log_probs,
             advantages,
             action_mask=experience.action_mask,
             rollout_log_probs=experience.rollout_log_probs,
         )
+
+        global_num_tokens = num_tokens.clone()
+        torch.distributed.all_reduce(
+            global_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.strategy.dp_group
+        )
+
+        dp_size = self.strategy.dp_size
+        actor_loss = actor_loss_sum / global_num_tokens * dp_size
+
         experience.info["ppo_clip_ratio"] = clip_ratio.detach()
         experience.info["ppo_kl"] = ppo_kl.detach()
         if vllm_kl is not None:
@@ -289,10 +298,15 @@ class ActorPPOTrainer(ABC):
             else:
                 kl = torch.zeros_like(action_log_probs)
                 logprobs_diff = torch.zeros_like(action_log_probs)
-            kl_loss = masked_mean(kl, experience.action_mask)
-            logprobs_diff = masked_mean(logprobs_diff, experience.action_mask)
-            experience.info["kl"] = kl_loss.detach()
-            experience.info["logprobs_diff"] = logprobs_diff.detach()
+
+            kl_loss_sum = masked_sum(kl, experience.action_mask)
+            kl_loss = kl_loss_sum / global_num_tokens * dp_size
+
+            logprobs_diff_sum = masked_sum(logprobs_diff, experience.action_mask)
+            logprobs_diff = logprobs_diff_sum / global_num_tokens * dp_size
+
+            experience.info["kl"] = (kl_loss_sum / num_tokens).detach()
+            experience.info["logprobs_diff"] = (logprobs_diff_sum / num_tokens).detach()
         else:
             kl_loss = 0
 
@@ -302,7 +316,8 @@ class ActorPPOTrainer(ABC):
             loss += output.aux_loss * self.args.aux_loss_coef
         # entropy loss
         if self.args.entropy_loss_coef is not None:
-            entropy_loss = masked_mean(output.entropy[:, -experience.action_mask.shape[1] :], experience.action_mask)
+            entropy_sum = masked_sum(output.entropy[:, -experience.action_mask.shape[1] :], experience.action_mask)
+            entropy_loss = entropy_sum / global_num_tokens * dp_size
             if self.args.entropy_loss_coef != 0:
                 loss -= entropy_loss * self.args.entropy_loss_coef
 
@@ -323,11 +338,14 @@ class ActorPPOTrainer(ABC):
             else:
                 self.strategy.moving_average(self.actor, self.ema_model, self.ema_beta, "cuda")
 
-        # Per-token losses (0-D tensors, shape carries weighting info for ppo_train)
-        metrics = {"policy_loss": actor_loss.detach()}
+        # Log local means so the weighted-reduction pipeline in ppo_train produces
+        # correct global averages even when token counts differ across DP ranks.
+        actor_loss_mean = (actor_loss_sum / num_tokens).detach()
+        metrics = {"policy_loss": actor_loss_mean}
         weights = {"policy_loss": "token"}
         if self.args.entropy_loss_coef is not None:
-            metrics["entropy_loss"] = entropy_loss.detach()
+            entropy_loss_mean = (entropy_sum / num_tokens).detach()
+            metrics["entropy_loss"] = entropy_loss_mean
             weights["entropy_loss"] = "token"
 
         # Non-reducible meta

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -280,7 +280,7 @@ class ActorPPOTrainer(ABC):
         )
 
         dp_size = self.strategy.dp_size
-        actor_loss = actor_loss_sum / global_num_tokens * dp_size
+        actor_loss = actor_loss_sum / global_num_tokens.clamp(min=1.0) * dp_size
 
         experience.info["ppo_clip_ratio"] = clip_ratio.detach()
         experience.info["ppo_kl"] = ppo_kl.detach()
@@ -300,13 +300,13 @@ class ActorPPOTrainer(ABC):
                 logprobs_diff = torch.zeros_like(action_log_probs)
 
             kl_loss_sum = masked_sum(kl, experience.action_mask)
-            kl_loss = kl_loss_sum / global_num_tokens * dp_size
+            kl_loss = kl_loss_sum / global_num_tokens.clamp(min=1.0) * dp_size
 
             logprobs_diff_sum = masked_sum(logprobs_diff, experience.action_mask)
             logprobs_diff = logprobs_diff_sum / global_num_tokens * dp_size
 
-            experience.info["kl"] = (kl_loss_sum / num_tokens).detach()
-            experience.info["logprobs_diff"] = (logprobs_diff_sum / num_tokens).detach()
+            experience.info["kl"] = (kl_loss_sum / num_tokens.clamp(min=1.0)).detach()
+            experience.info["logprobs_diff"] = (logprobs_diff_sum / num_tokens.clamp(min=1.0)).detach()
         else:
             kl_loss = 0
 
@@ -340,7 +340,7 @@ class ActorPPOTrainer(ABC):
 
         # Log local means so the weighted-reduction pipeline in ppo_train produces
         # correct global averages even when token counts differ across DP ranks.
-        actor_loss_mean = (actor_loss_sum / num_tokens).detach()
+        actor_loss_mean = (actor_loss_sum / num_tokens.clamp(min=1.0)).detach()
         metrics = {"policy_loss": actor_loss_mean}
         weights = {"policy_loss": "token"}
         if self.args.entropy_loss_coef is not None:

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -5,13 +5,14 @@ from typing import Dict, Optional, Union
 
 import ray
 import torch
+import torch.distributed as dist
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 from transformers.trainer import get_scheduler
 
 from openrlhf.models import ValueLoss, get_llm_for_sequence_regression
-from openrlhf.models.utils import masked_mean
+from openrlhf.models.utils import masked_sum
 from openrlhf.trainer.ppo_utils.experience import Experience
 from openrlhf.utils import get_tokenizer
 from openrlhf.utils.deepspeed import DeepspeedStrategy
@@ -129,12 +130,19 @@ class CriticPPOTrainer(ABC):
         )
 
         # loss function
-        critic_loss = self.critic_loss_fn(
+        critic_loss_sum, num_tokens = self.critic_loss_fn(
             values,
             old_values,
             returns,
             action_mask=experience.action_mask,
         )
+
+        global_num_tokens = num_tokens.clone()
+        dist.all_reduce(global_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.strategy.dp_group)
+
+        dp_size = self.strategy.dp_size
+        critic_loss = critic_loss_sum / global_num_tokens * dp_size
+
         # mixtral
         if self.aux_loss:
             aux_loss = output.aux_loss
@@ -152,9 +160,13 @@ class CriticPPOTrainer(ABC):
             self.strategy.optimizer_step(self.critic_optim, self.critic, self.critic_scheduler, name="critic")
 
         # status
+        values_sum = masked_sum(values, experience.action_mask)
+        dist.all_reduce(values_sum, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+        values_mean = (values_sum / global_num_tokens).detach().item()
+
         status = {
             "critic_loss": critic_loss.detach().item(),
-            "values": masked_mean(values, experience.action_mask).detach().item(),
+            "values": values_mean,
             "critic_lr": self.critic_scheduler.get_last_lr()[0],
             "critic_grad_norm": self.strategy.get_grad_norm(self.critic),
         }

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -141,7 +141,7 @@ class CriticPPOTrainer(ABC):
         dist.all_reduce(global_num_tokens, op=torch.distributed.ReduceOp.SUM, group=self.strategy.dp_group)
 
         dp_size = self.strategy.dp_size
-        critic_loss = critic_loss_sum / global_num_tokens * dp_size
+        critic_loss = critic_loss_sum / global_num_tokens.clamp(min=1.0) * dp_size
 
         # mixtral
         if self.aux_loss:
@@ -162,7 +162,7 @@ class CriticPPOTrainer(ABC):
         # status
         values_sum = masked_sum(values, experience.action_mask)
         dist.all_reduce(values_sum, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
-        values_mean = (values_sum / global_num_tokens).detach().item()
+        values_mean = (values_sum / global_num_tokens.clamp(min=1.0)).detach().item()
 
         status = {
             "critic_loss": critic_loss.detach().item(),

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -170,7 +170,7 @@ class SFTTrainer(ABC):
                 dist.all_reduce(global_num_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
 
                 dp_size = self.strategy.dp_size
-                gpt_loss = local_loss_sum / global_num_tokens * dp_size
+                gpt_loss = local_loss_sum / global_num_tokens.clamp(min=1.0) * dp_size
 
                 loss = gpt_loss + aux_loss * self.args.aux_loss_coef
                 self.strategy.backward(loss, self.model, self.optimizer)
@@ -196,7 +196,7 @@ class SFTTrainer(ABC):
                     global_accumulated_tokens = torch.tensor([accumulated_num_tokens], device=device)
                     dist.all_reduce(global_accumulated_loss, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
                     dist.all_reduce(global_accumulated_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
-                    logs_dict["loss_mean"] = (global_accumulated_loss / global_accumulated_tokens).item()
+                    logs_dict["loss_mean"] = (global_accumulated_loss / global_accumulated_tokens.clamp(min=1.0)).item()
                     accumulated_loss_sum = 0.0
                     accumulated_num_tokens = 0.0
                     global_step = step // self.strategy.accumulated_gradient

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -196,7 +196,9 @@ class SFTTrainer(ABC):
                     global_accumulated_tokens = torch.tensor([accumulated_num_tokens], device=device)
                     dist.all_reduce(global_accumulated_loss, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
                     dist.all_reduce(global_accumulated_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
-                    logs_dict["loss_mean"] = (global_accumulated_loss / global_accumulated_tokens.clamp(min=1.0)).item()
+                    logs_dict["loss_mean"] = (
+                        global_accumulated_loss / global_accumulated_tokens.clamp(min=1.0)
+                    ).item()
                     accumulated_loss_sum = 0.0
                     accumulated_num_tokens = 0.0
                     global_step = step // self.strategy.accumulated_gradient

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -2,6 +2,7 @@ import os
 from abc import ABC
 
 import torch
+import torch.distributed as dist
 from torch.optim import Optimizer
 from tqdm import tqdm
 
@@ -128,7 +129,6 @@ class SFTTrainer(ABC):
             desc="Train epoch",
             disable=not self.strategy.is_rank_0(),
         )
-        loss_sum = 0
         for epoch in range(start_epoch, self.epochs):
             if isinstance(self.train_dataloader.sampler, DistributedSampler):
                 self.train_dataloader.sampler.set_epoch(
@@ -143,6 +143,8 @@ class SFTTrainer(ABC):
 
             # train
             self.model.train()
+            accumulated_loss_sum = 0.0
+            accumulated_num_tokens = 0.0
             device = next(self.model.parameters()).device
             for inputs, attention_masks, loss_masks in self.train_dataloader:
                 inputs = inputs.to(device).squeeze(1)
@@ -161,12 +163,21 @@ class SFTTrainer(ABC):
                     aux_loss = output.aux_loss
                 else:
                     aux_loss = 0
-                gpt_loss = self.loss_fn(per_token_log_probs, loss_mask[:, :-1])
+
+                local_loss_sum, local_num_tokens = self.loss_fn(per_token_log_probs, loss_mask[:, :-1])
+
+                global_num_tokens = local_num_tokens.clone()
+                dist.all_reduce(global_num_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+
+                dp_size = self.strategy.dp_size
+                gpt_loss = local_loss_sum / global_num_tokens * dp_size
+
                 loss = gpt_loss + aux_loss * self.args.aux_loss_coef
                 self.strategy.backward(loss, self.model, self.optimizer)
                 self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler)
 
-                loss_sum += gpt_loss.item()
+                accumulated_loss_sum += local_loss_sum.item()
+                accumulated_num_tokens += local_num_tokens.item()
                 logs_dict = {
                     "gpt_loss": gpt_loss.item(),
                     "lr": self.scheduler.get_last_lr()[0],
@@ -181,8 +192,13 @@ class SFTTrainer(ABC):
 
                 # logs/checkpoints/evaluation
                 if step % self.strategy.accumulated_gradient == 0:
-                    logs_dict["loss_mean"] = loss_sum / self.strategy.accumulated_gradient
-                    loss_sum = 0
+                    global_accumulated_loss = torch.tensor([accumulated_loss_sum], device=device)
+                    global_accumulated_tokens = torch.tensor([accumulated_num_tokens], device=device)
+                    dist.all_reduce(global_accumulated_loss, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+                    dist.all_reduce(global_accumulated_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+                    logs_dict["loss_mean"] = (global_accumulated_loss / global_accumulated_tokens).item()
+                    accumulated_loss_sum = 0.0
+                    accumulated_num_tokens = 0.0
                     global_step = step // self.strategy.accumulated_gradient
                     client_states = {"consumed_samples": global_step * args.train_batch_size}
                     self.save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
@@ -227,10 +243,10 @@ class SFTTrainer(ABC):
                 self.strategy.save_model(self.model, self.tokenizer, save_path)
 
     def evaluate(self, eval_dataloader, steps=0):
-        times = 0
         self.model.eval()
         with torch.no_grad():
-            loss_sum = 0
+            total_loss_sum = 0.0
+            total_num_tokens = 0.0
             step_bar = tqdm(
                 range(eval_dataloader.__len__()),
                 desc="Eval stage of steps %d" % steps,
@@ -249,14 +265,20 @@ class SFTTrainer(ABC):
                     ring_attn_group=self.strategy.ring_attn_group,
                 )
 
-                loss = self.loss_fn(per_token_log_probs, loss_mask[:, :-1])
+                local_loss_sum, local_num_tokens = self.loss_fn(per_token_log_probs, loss_mask[:, :-1])
 
-                times += 1
-                loss_sum += loss.item()
-                bar_dict = {"eval gpt_loss": loss_sum / times}
+                total_loss_sum += local_loss_sum.item()
+                total_num_tokens += local_num_tokens.item()
                 step_bar.update()
-                logs = self.strategy.all_reduce(bar_dict)
-                step_bar.set_postfix(logs)
+
+            global_loss_sum = torch.tensor([total_loss_sum], device=device)
+            global_num_tokens = torch.tensor([total_num_tokens], device=device)
+            dist.all_reduce(global_loss_sum, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+            dist.all_reduce(global_num_tokens, op=dist.ReduceOp.SUM, group=self.strategy.dp_group)
+            logs = {
+                "eval gpt_loss": (global_loss_sum / global_num_tokens).item() if global_num_tokens.item() > 0 else 0
+            }
+            step_bar.set_postfix(logs)
 
             if self.strategy.is_rank_0():
                 if self._wandb is not None:

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -135,6 +135,14 @@ class DeepspeedStrategy(ABC):
     def ring_attn_group(self):
         return get_ring_attn_group()
 
+    @property
+    def dp_size(self):
+        return self.world_size // self.ring_attn_size // self.ds_tensor_parallel_size
+
+    @property
+    def dp_group(self):
+        return self.ds_device_mesh["dp"].get_group()
+
     def create_optimizer(self, model, **kwargs) -> Optimizer:
         if isinstance(model, Actor):
             model = model.model


### PR DESCRIPTION
This PR fixes an incorrect loss aggregation across data parallel (DP) ranks, where the global loss was previously computed as a “mean of means”, leading to a biased estimate.

The correct approach is to aggregate sum of losses and token counts per DP rank, then all-reduce these totals and compute the true global loss as total_loss / total_tokens.

The plot below shows the difference in loss computation before and after the fix:

<img width="2943" height="1742" alt="loss_variability_comparison" src="https://github.com/user-attachments/assets/3d667b40-63f8-43df-b321-7326d98a5bf8" />

Setup: SFT run with 3 epochs, comparing different DP aggregation implementations.

The corrected version shows significantly reduced loss variability across steps, as seen in the plot, and aligns with the expected stable global loss behavior.