### PR TITLE
Fix multi-turn SFT masks for Qwen3 thinking templates

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -201,38 +201,38 @@ class SFTDataset(Dataset):
         return self._mask_to_ranges(assistant_mask)
 
     def _build_marker_assistant_ranges(self, messages, rendered_text):
+        marked_messages = copy.deepcopy(messages)
+        collision_text = rendered_text + "\n" + str(marked_messages)
+        marker_pairs_by_message = []
+        for message_idx, message in enumerate(messages):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+
+            marker_pairs = self._mark_assistant_message(marked_messages, message_idx, collision_text)
+            if not marker_pairs:
+                continue
+            marker_pairs_by_message.append((message_idx, marker_pairs))
+
+        if not marker_pairs_by_message:
+            return []
+
         try:
-            full_rendered_text = self._render_chat(messages).rstrip("\n")
+            marked_render = self._render_chat(marked_messages).rstrip("\n")
         except Exception:
             return []
 
-        if full_rendered_text != rendered_text:
+        all_marker_pairs = [marker_pair for _, marker_pairs in marker_pairs_by_message for marker_pair in marker_pairs]
+        stripped_render, marker_occurrences = self._strip_marker_occurrences(marked_render, all_marker_pairs)
+        if stripped_render != rendered_text:
             warnings.warn(
-                "Skipping multi-turn assistant mask construction because prompt + response does not match the "
-                "full chat-template render.",
+                "Skipping multi-turn assistant mask construction because the marked chat-template render does not "
+                "match the unmarked prompt + response after marker removal.",
                 stacklevel=2,
             )
             return []
 
         char_spans = []
-        for message_idx, message in enumerate(messages):
-            if not isinstance(message, dict) or message.get("role") != "assistant":
-                continue
-
-            marked_messages = copy.deepcopy(messages)
-            marker_pairs = self._mark_assistant_message(marked_messages, message_idx, rendered_text)
-            if not marker_pairs:
-                continue
-
-            try:
-                marked_render = self._render_chat(marked_messages).rstrip("\n")
-            except Exception:
-                continue
-
-            stripped_render, marker_occurrences = self._strip_marker_occurrences(marked_render, marker_pairs)
-            if stripped_render != rendered_text:
-                continue
-
+        for _, marker_pairs in marker_pairs_by_message:
             visible_spans = []
             for start_marker, end_marker in marker_pairs:
                 start_marker_pos = marked_render.find(start_marker)
@@ -256,7 +256,7 @@ class SFTDataset(Dataset):
 
         return self._char_spans_to_token_ranges(rendered_text, self._merge_char_spans(char_spans))
 
-    def _mark_assistant_message(self, messages, message_idx, rendered_text):
+    def _mark_assistant_message(self, messages, message_idx, collision_text):
         message = messages[message_idx]
         marker_pairs = []
         marker_index = 0
@@ -267,12 +267,7 @@ class SFTDataset(Dataset):
                 start_marker = f"__OPENRLHF_ASSISTANT_SPAN_{message_idx}_{marker_index}_START__"
                 end_marker = f"__OPENRLHF_ASSISTANT_SPAN_{message_idx}_{marker_index}_END__"
                 marker_index += 1
-                if (
-                    start_marker not in rendered_text
-                    and end_marker not in rendered_text
-                    and start_marker not in str(messages)
-                    and end_marker not in str(messages)
-                ):
+                if start_marker not in collision_text and end_marker not in collision_text:
                     return start_marker, end_marker
 
         def wrap_segment(text):

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -1,3 +1,6 @@
+import copy
+import warnings
+from collections.abc import Mapping
 from typing import Callable
 
 import torch
@@ -59,6 +62,7 @@ class SFTDataset(Dataset):
         self.pretrain_mode = pretrain_mode
         self.max_length = max_length
         self.multiturn = multiturn
+        self._warned_offset_mapping_unavailable = False
 
         # chat template
         self.input_template = input_template
@@ -86,62 +90,360 @@ class SFTDataset(Dataset):
         self.prompt_ids_lens = processed_dataset["prompt_ids_len"]
         self.response_ranges = processed_dataset["response_ranges"] if self.multiturn else None
 
+    def _normalize_multiturn_messages(self, data):
+        messages = copy.deepcopy(data[self.input_key])
+        if self.output_key and data.get(self.output_key):
+            output_message = copy.deepcopy(data[self.output_key])
+            if isinstance(output_message, list):
+                messages.extend(output_message)
+            else:
+                messages.append(output_message)
+        return messages
+
+    def _render_chat(self, messages, add_generation_prompt=False):
+        return self.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=add_generation_prompt,
+        )
+
+    @staticmethod
+    def _to_flat_list(value):
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+        if isinstance(value, tuple):
+            value = list(value)
+        if isinstance(value, list) and value and isinstance(value[0], (list, tuple)):
+            value = value[0]
+        return list(value)
+
+    @staticmethod
+    def _mask_to_ranges(mask):
+        ranges = []
+        start_idx = None
+        for idx, value in enumerate(mask):
+            if value and start_idx is None:
+                start_idx = idx
+            elif not value and start_idx is not None:
+                ranges.append((start_idx, idx - 1))
+                start_idx = None
+        if start_idx is not None:
+            ranges.append((start_idx, len(mask) - 1))
+        return ranges
+
+    @staticmethod
+    def _merge_char_spans(spans):
+        if not spans:
+            return []
+
+        spans = sorted(spans)
+        merged = [spans[0]]
+        for start, end in spans[1:]:
+            prev_start, prev_end = merged[-1]
+            if start <= prev_end:
+                merged[-1] = (prev_start, max(prev_end, end))
+            else:
+                merged.append((start, end))
+        return merged
+
+    def _tokenize_text(self, text, return_offsets_mapping=False):
+        kwargs = {
+            "max_length": self.max_length,
+            "padding": False,
+            "truncation": True,
+            "return_tensors": None,
+            "add_special_tokens": False,
+        }
+        if return_offsets_mapping:
+            kwargs["return_offsets_mapping"] = True
+        return self.tokenizer(text, **kwargs)
+
+    def _build_multiturn_response_ranges(self, messages, rendered_text):
+        native_ranges = self._try_native_assistant_ranges(messages, rendered_text)
+        if native_ranges is not None:
+            return native_ranges
+        return self._build_marker_assistant_ranges(messages, rendered_text)
+
+    def _try_native_assistant_ranges(self, messages, rendered_text):
+        try:
+            encoded = self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=True,
+                return_dict=True,
+                return_assistant_tokens_mask=True,
+                truncation=True,
+                max_length=self.max_length,
+            )
+        except Exception:
+            return None
+
+        if not isinstance(encoded, Mapping) or "input_ids" not in encoded:
+            return None
+
+        mask = None
+        for key in ("assistant_masks", "assistant_tokens_mask", "assistant_mask"):
+            if key in encoded:
+                mask = encoded[key]
+                break
+        if mask is None:
+            return None
+
+        native_input_ids = self._to_flat_list(encoded["input_ids"])
+        assistant_mask = self._to_flat_list(mask)
+        if len(native_input_ids) != len(assistant_mask) or not any(assistant_mask):
+            return None
+
+        tokenized_render = self._tokenize_text(rendered_text)
+        rendered_input_ids = self._to_flat_list(tokenized_render["input_ids"])
+        if native_input_ids != rendered_input_ids:
+            return None
+
+        return self._mask_to_ranges(assistant_mask)
+
+    def _build_marker_assistant_ranges(self, messages, rendered_text):
+        try:
+            full_rendered_text = self._render_chat(messages).rstrip("\n")
+        except Exception:
+            return []
+
+        if full_rendered_text != rendered_text:
+            warnings.warn(
+                "Skipping multi-turn assistant mask construction because prompt + response does not match the "
+                "full chat-template render.",
+                stacklevel=2,
+            )
+            return []
+
+        char_spans = []
+        for message_idx, message in enumerate(messages):
+            if not isinstance(message, dict) or message.get("role") != "assistant":
+                continue
+
+            marked_messages = copy.deepcopy(messages)
+            marker_pairs = self._mark_assistant_message(marked_messages, message_idx, rendered_text)
+            if not marker_pairs:
+                continue
+
+            try:
+                marked_render = self._render_chat(marked_messages).rstrip("\n")
+            except Exception:
+                continue
+
+            stripped_render, marker_occurrences = self._strip_marker_occurrences(marked_render, marker_pairs)
+            if stripped_render != rendered_text:
+                continue
+
+            visible_spans = []
+            for start_marker, end_marker in marker_pairs:
+                start_marker_pos = marked_render.find(start_marker)
+                if start_marker_pos == -1:
+                    continue
+
+                content_start = start_marker_pos + len(start_marker)
+                end_marker_pos = marked_render.find(end_marker, content_start)
+                if end_marker_pos == -1:
+                    continue
+
+                start_char = self._marked_to_unmarked_pos(content_start, marker_occurrences)
+                end_char = self._marked_to_unmarked_pos(end_marker_pos, marker_occurrences)
+                if start_char < end_char:
+                    visible_spans.append((start_char, end_char))
+
+            if visible_spans:
+                start_char = min(start for start, _ in visible_spans)
+                end_char = max(end for _, end in visible_spans)
+                char_spans.append(self._extend_assistant_span(rendered_text, start_char, end_char))
+
+        return self._char_spans_to_token_ranges(rendered_text, self._merge_char_spans(char_spans))
+
+    def _mark_assistant_message(self, messages, message_idx, rendered_text):
+        message = messages[message_idx]
+        marker_pairs = []
+        marker_index = 0
+
+        def make_marker_pair():
+            nonlocal marker_index
+            while True:
+                start_marker = f"__OPENRLHF_ASSISTANT_SPAN_{message_idx}_{marker_index}_START__"
+                end_marker = f"__OPENRLHF_ASSISTANT_SPAN_{message_idx}_{marker_index}_END__"
+                marker_index += 1
+                if (
+                    start_marker not in rendered_text
+                    and end_marker not in rendered_text
+                    and start_marker not in str(messages)
+                    and end_marker not in str(messages)
+                ):
+                    return start_marker, end_marker
+
+        def wrap_segment(text):
+            start_marker, end_marker = make_marker_pair()
+            marker_pairs.append((start_marker, end_marker))
+            return f"{start_marker}{text}{end_marker}"
+
+        reasoning_content = message.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            message["reasoning_content"] = self._mark_newline_stripped_segment(
+                reasoning_content,
+                wrap_segment,
+                strip_left=True,
+                strip_right=True,
+            )
+
+        content = message.get("content")
+        if isinstance(content, str) and content:
+            message["content"] = self._mark_content_segments(content, wrap_segment)
+
+        return marker_pairs
+
+    @staticmethod
+    def _mark_newline_stripped_segment(text, wrap_segment, strip_left=False, strip_right=False):
+        start = 0
+        end = len(text)
+        if strip_left:
+            while start < end and text[start] == "\n":
+                start += 1
+        if strip_right:
+            while end > start and text[end - 1] == "\n":
+                end -= 1
+        if start >= end:
+            return text
+        return text[:start] + wrap_segment(text[start:end]) + text[end:]
+
+    def _mark_content_segments(self, content, wrap_segment):
+        think_start = "<think>"
+        think_end = "</think>"
+        first_think_start = content.find(think_start)
+        first_think_end = content.find(think_end, first_think_start + len(think_start))
+        if first_think_start == -1 or first_think_end == -1:
+            return self._mark_newline_stripped_segment(content, wrap_segment, strip_left=True)
+
+        reasoning_start = first_think_start + len(think_start)
+        reasoning_text = content[reasoning_start:first_think_end]
+        marked_reasoning = self._mark_newline_stripped_segment(
+            reasoning_text,
+            wrap_segment,
+            strip_left=True,
+            strip_right=True,
+        )
+
+        last_think_end = content.rfind(think_end)
+        answer_start = last_think_end + len(think_end)
+        while answer_start < len(content) and content[answer_start] == "\n":
+            answer_start += 1
+
+        answer_text = content[answer_start:]
+        marked_answer = wrap_segment(answer_text) if answer_text else answer_text
+        return content[:reasoning_start] + marked_reasoning + content[first_think_end:answer_start] + marked_answer
+
+    @staticmethod
+    def _strip_marker_occurrences(marked_render, marker_pairs):
+        markers = {marker for marker_pair in marker_pairs for marker in marker_pair}
+        occurrences = []
+        for marker in markers:
+            search_start = 0
+            while True:
+                marker_pos = marked_render.find(marker, search_start)
+                if marker_pos == -1:
+                    break
+                occurrences.append((marker_pos, marker))
+                search_start = marker_pos + len(marker)
+
+        occurrences.sort(key=lambda item: item[0])
+        stripped_parts = []
+        last_pos = 0
+        for marker_pos, marker in occurrences:
+            stripped_parts.append(marked_render[last_pos:marker_pos])
+            last_pos = marker_pos + len(marker)
+        stripped_parts.append(marked_render[last_pos:])
+        return "".join(stripped_parts), occurrences
+
+    @staticmethod
+    def _marked_to_unmarked_pos(position, marker_occurrences):
+        removed_chars = sum(len(marker) for marker_pos, marker in marker_occurrences if marker_pos < position)
+        return position - removed_chars
+
+    def _extend_assistant_span(self, rendered_text, start_char, end_char):
+        think_prefix = "<think>\n"
+        previous_text = rendered_text[start_char - len(think_prefix) : start_char]
+        if start_char >= len(think_prefix) and previous_text == think_prefix:
+            start_char -= len(think_prefix)
+
+        think_suffix = "\n</think>"
+        if rendered_text.startswith(think_suffix, end_char):
+            end_char += len(think_suffix)
+
+        eos_token = getattr(self.tokenizer, "eos_token", None)
+        if eos_token and rendered_text.startswith(eos_token, end_char):
+            end_char += len(eos_token)
+
+        return start_char, end_char
+
+    def _char_spans_to_token_ranges(self, rendered_text, spans):
+        if not spans:
+            return []
+
+        try:
+            encoded = self._tokenize_text(rendered_text, return_offsets_mapping=True)
+            offsets = encoded["offset_mapping"]
+        except Exception:
+            return self._char_spans_to_token_ranges_without_offsets(rendered_text, spans)
+
+        if hasattr(offsets, "tolist"):
+            offsets = offsets.tolist()
+        if offsets and isinstance(offsets[0], list) and offsets[0] and isinstance(offsets[0][0], (list, tuple)):
+            offsets = offsets[0]
+        ranges = []
+        for start_char, end_char in spans:
+            token_indices = [
+                idx
+                for idx, offset in enumerate(offsets)
+                if len(offset) == 2 and offset[0] != offset[1] and offset[0] < end_char and offset[1] > start_char
+            ]
+            if token_indices:
+                ranges.append((token_indices[0], token_indices[-1]))
+        return self._merge_char_spans(ranges)
+
+    def _char_spans_to_token_ranges_without_offsets(self, rendered_text, spans):
+        if not self._warned_offset_mapping_unavailable:
+            warnings.warn(
+                "Tokenizer does not provide offset mappings; falling back to prefix token counts for multi-turn "
+                "assistant masks.",
+                stacklevel=2,
+            )
+            self._warned_offset_mapping_unavailable = True
+
+        ranges = []
+        for start_char, end_char in spans:
+            start_idx = len(self._to_flat_list(self._tokenize_text(rendered_text[:start_char])["input_ids"]))
+            end_idx = len(self._to_flat_list(self._tokenize_text(rendered_text[:end_char])["input_ids"])) - 1
+            clipped_end_idx = min(end_idx, self.max_length - 1)
+            if start_idx <= clipped_end_idx:
+                ranges.append((start_idx, clipped_end_idx))
+        return self._merge_char_spans(ranges)
+
     def process_data(self, data):
-        if self.multiturn and self.output_key:
-            data[self.input_key].append(data[self.output_key])
-            data[self.output_key] = None
+        response_ranges = []
+        effective_output_key = self.output_key
+        data_for_preprocess = data
 
         if self.multiturn:
-            assert (
-                not self.output_key or not data[self.output_key]
-            ), "You should put the whole trajectory into data[input_key] and do not set output_key"
-            input_key = self.input_key
-            apply_chat_template = self.apply_chat_template
-            response_ranges = []
-            for idx, message in enumerate(data[input_key]):
-                if message["role"] == "assistant":
-                    prompt = apply_chat_template(data[input_key][:idx], tokenize=False, add_generation_prompt=True)
-                    response = apply_chat_template(data[input_key][: idx + 1], tokenize=False)[len(prompt) :]
-
-                    start_idx = (
-                        self.tokenizer(
-                            prompt,
-                            max_length=self.max_length,
-                            padding=False,
-                            truncation=True,
-                            return_tensors="pt",
-                            add_special_tokens=False,
-                        )["attention_mask"]
-                        .int()
-                        .sum()
-                        .item()
-                    )
-
-                    end_idx = (
-                        start_idx
-                        + self.tokenizer(
-                            response,
-                            max_length=self.max_length,
-                            padding=False,
-                            truncation=True,
-                            return_tensors="pt",
-                            add_special_tokens=False,
-                        )["attention_mask"]
-                        .int()
-                        .sum()
-                        .item()
-                        - 1
-                    )
-                    response_ranges.append((start_idx, end_idx))  # left close right close
+            messages = self._normalize_multiturn_messages(data)
+            data_for_preprocess = dict(data)
+            data_for_preprocess[self.input_key] = messages
+            effective_output_key = None
 
         prompt, response = preprocess_data(
-            data,
+            data_for_preprocess,
             None if self.pretrain_mode else self.input_template,
             self.input_key,
-            self.output_key,
+            effective_output_key,
             apply_chat_template=None if self.pretrain_mode else self.apply_chat_template,
             multiturn=self.multiturn,
         )
+
+        if self.multiturn and not self.pretrain_mode:
+            rendered_text = (prompt + response).rstrip("\n")
+            response_ranges = self._build_multiturn_response_ranges(messages, rendered_text)
 
         if not self.pretrain_mode:
             prompt_token = self.tokenizer(

--- a/tests/test_sft_dataset_multiturn_masks.py
+++ b/tests/test_sft_dataset_multiturn_masks.py
@@ -156,6 +156,16 @@ class QwenLikeTokenizer(CharTokenizer):
         return "".join(rendered)
 
 
+class CountingQwenLikeTokenizer(QwenLikeTokenizer):
+    def __init__(self):
+        self.marked_render_calls = 0
+
+    def apply_chat_template(self, messages, *args, **kwargs):
+        if any("__OPENRLHF_ASSISTANT_SPAN_" in str(message) for message in messages):
+            self.marked_render_calls += 1
+        return super().apply_chat_template(messages, *args, **kwargs)
+
+
 class SimpleTemplateTokenizer(CharTokenizer):
     eos_token = "</s>"
     eos_token_id = 0
@@ -415,3 +425,23 @@ def test_marker_fallback_when_native_mask_empty():
     assert tokenizer.native_mask_calls == 1
     assert "answer" in masked_targets
     assert "question" not in masked_targets
+
+
+def test_marker_fallback_marks_all_assistant_turns_in_one_render():
+    tokenizer = CountingQwenLikeTokenizer()
+    dataset = _make_dataset(tokenizer)
+    row = {
+        "input": [
+            {"role": "user", "content": "question one"},
+            {"role": "assistant", "reasoning_content": "hidden first", "content": "answer one"},
+            {"role": "user", "content": "question two"},
+            {"role": "assistant", "reasoning_content": "visible second", "content": "answer two"},
+        ]
+    }
+
+    _, _, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert tokenizer.marked_render_calls == 1
+    assert "answer one" in masked_targets
+    assert "visible second" in masked_targets
+    assert "answer two" in masked_targets

--- a/tests/test_sft_dataset_multiturn_masks.py
+++ b/tests/test_sft_dataset_multiturn_masks.py
@@ -1,0 +1,417 @@
+import copy
+import importlib.util
+import sys
+import types
+from collections import UserDict
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.nn.functional as F
+
+
+def _zero_pad_sequences(sequences, side="left", value=0, stack=False):
+    max_len = max(seq.size(-1) for seq in sequences)
+    padded_sequences = []
+    for seq in sequences:
+        pad_len = max_len - seq.size(-1)
+        padding = (pad_len, 0) if side == "left" else (0, pad_len)
+        padded_sequences.append(F.pad(seq, padding, value=value))
+    return torch.stack(padded_sequences, dim=0) if stack else torch.cat(padded_sequences, dim=0)
+
+
+fake_utils = types.ModuleType("openrlhf.utils")
+fake_utils_utils = types.ModuleType("openrlhf.utils.utils")
+fake_utils_utils.zero_pad_sequences = _zero_pad_sequences
+
+_SFT_DATASET_PATH = Path(__file__).resolve().parents[1] / "openrlhf" / "datasets" / "sft_dataset.py"
+_SFT_SPEC = importlib.util.spec_from_file_location("sft_dataset_under_test", _SFT_DATASET_PATH)
+_SFT_MODULE = importlib.util.module_from_spec(_SFT_SPEC)
+_ORIGINAL_UTILS = sys.modules.get("openrlhf.utils")
+_ORIGINAL_UTILS_UTILS = sys.modules.get("openrlhf.utils.utils")
+try:
+    sys.modules["openrlhf.utils"] = fake_utils
+    sys.modules["openrlhf.utils.utils"] = fake_utils_utils
+    _SFT_SPEC.loader.exec_module(_SFT_MODULE)
+finally:
+    if _ORIGINAL_UTILS is None:
+        sys.modules.pop("openrlhf.utils", None)
+    else:
+        sys.modules["openrlhf.utils"] = _ORIGINAL_UTILS
+
+    if _ORIGINAL_UTILS_UTILS is None:
+        sys.modules.pop("openrlhf.utils.utils", None)
+    else:
+        sys.modules["openrlhf.utils.utils"] = _ORIGINAL_UTILS_UTILS
+SFTDataset = _SFT_MODULE.SFTDataset
+
+
+class CharTokenizer:
+    eos_token = "<|im_end|>"
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def __call__(
+        self,
+        text,
+        max_length=None,
+        padding=False,
+        truncation=False,
+        return_tensors=None,
+        add_special_tokens=False,
+        return_offsets_mapping=False,
+    ):
+        del padding, add_special_tokens
+        ids = [ord(ch) for ch in text]
+        offsets = [(idx, idx + 1) for idx in range(len(text))]
+        if truncation and max_length is not None:
+            ids = ids[:max_length]
+            offsets = offsets[:max_length]
+
+        attention_mask = [1] * len(ids)
+        if return_tensors == "pt":
+            result = {
+                "input_ids": torch.tensor([ids], dtype=torch.long),
+                "attention_mask": torch.tensor([attention_mask], dtype=torch.long),
+            }
+            if return_offsets_mapping:
+                result["offset_mapping"] = torch.tensor([offsets], dtype=torch.long)
+            return result
+
+        result = {"input_ids": ids, "attention_mask": attention_mask}
+        if return_offsets_mapping:
+            result["offset_mapping"] = offsets
+        return result
+
+
+class QwenLikeTokenizer(CharTokenizer):
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=False,
+        add_generation_prompt=False,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+        truncation=False,
+        max_length=None,
+        **kwargs,
+    ):
+        del kwargs, return_assistant_tokens_mask
+        rendered = self._render(messages, add_generation_prompt=add_generation_prompt)
+        if not tokenize:
+            return rendered
+
+        encoded = self(
+            rendered,
+            max_length=max_length,
+            truncation=truncation,
+            return_tensors=None,
+            add_special_tokens=False,
+        )
+        return encoded if return_dict else encoded["input_ids"]
+
+    def _render(self, messages, add_generation_prompt=False):
+        last_query_index = len(messages) - 1
+        for index in range(len(messages) - 1, -1, -1):
+            message = messages[index]
+            content = message.get("content", "")
+            if (
+                message.get("role") == "user"
+                and isinstance(content, str)
+                and not content.startswith("<tool_response>")
+            ):
+                last_query_index = index
+                break
+
+        rendered = []
+        for index, message in enumerate(messages):
+            role = message["role"]
+            content = message.get("content", "")
+            content = content if isinstance(content, str) else ""
+            if role in ("system", "user"):
+                rendered.append(f"<|im_start|>{role}\n{content}<|im_end|>\n")
+            elif role == "assistant":
+                reasoning_content = ""
+                if isinstance(message.get("reasoning_content"), str):
+                    reasoning_content = message["reasoning_content"]
+                elif "</think>" in content:
+                    reasoning_content = content.split("</think>")[0].rstrip("\n").split("<think>")[-1].lstrip("\n")
+                    content = content.split("</think>")[-1].lstrip("\n")
+
+                if index > last_query_index:
+                    if index == len(messages) - 1 or reasoning_content:
+                        rendered.append(
+                            "<|im_start|>assistant\n"
+                            f"<think>\n{reasoning_content.strip(chr(10))}\n</think>\n\n"
+                            f"{content.lstrip(chr(10))}"
+                            "<|im_end|>\n"
+                        )
+                    else:
+                        rendered.append(f"<|im_start|>assistant\n{content}<|im_end|>\n")
+                else:
+                    rendered.append(f"<|im_start|>assistant\n{content}<|im_end|>\n")
+
+        if add_generation_prompt:
+            rendered.append("<|im_start|>assistant\n")
+        return "".join(rendered)
+
+
+class SimpleTemplateTokenizer(CharTokenizer):
+    eos_token = "</s>"
+    eos_token_id = 0
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=False,
+        add_generation_prompt=False,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+        truncation=False,
+        max_length=None,
+        **kwargs,
+    ):
+        del return_assistant_tokens_mask, kwargs
+        rendered = "".join(f"<{message['role']}>\n{message.get('content', '')}</s>\n" for message in messages)
+        if add_generation_prompt:
+            rendered += "<assistant>\n"
+        if not tokenize:
+            return rendered
+
+        encoded = self(
+            rendered,
+            max_length=max_length,
+            truncation=truncation,
+            return_tensors=None,
+            add_special_tokens=False,
+        )
+        return encoded if return_dict else encoded["input_ids"]
+
+
+class NativeMaskTokenizer(SimpleTemplateTokenizer):
+    def __init__(self):
+        self.native_mask_calls = 0
+
+    def apply_chat_template(
+        self,
+        messages,
+        tokenize=False,
+        add_generation_prompt=False,
+        return_dict=False,
+        return_assistant_tokens_mask=False,
+        truncation=False,
+        max_length=None,
+        **kwargs,
+    ):
+        del kwargs
+        rendered = []
+        assistant_mask = []
+        for message in messages:
+            prefix = f"<{message['role']}>\n"
+            content = message.get("content", "")
+            suffix = "</s>\n"
+            rendered.append(prefix + content + suffix)
+            if message["role"] == "assistant":
+                assistant_mask.extend([0] * len(prefix))
+                assistant_mask.extend([1] * (len(content) + len(suffix.rstrip("\n"))))
+                assistant_mask.extend([0])
+            else:
+                assistant_mask.extend([0] * len(prefix + content + suffix))
+
+        if add_generation_prompt:
+            rendered.append("<assistant>\n")
+            assistant_mask.extend([0] * len("<assistant>\n"))
+
+        rendered = "".join(rendered)
+        if not tokenize:
+            return rendered
+
+        encoded = self(
+            rendered,
+            max_length=max_length,
+            truncation=truncation,
+            return_tensors=None,
+            add_special_tokens=False,
+        )
+        if return_dict:
+            if return_assistant_tokens_mask:
+                self.native_mask_calls += 1
+                encoded["assistant_masks"] = assistant_mask[: len(encoded["input_ids"])]
+            return UserDict(encoded)
+        return encoded["input_ids"]
+
+
+class EmptyNativeMaskTokenizer(NativeMaskTokenizer):
+    def apply_chat_template(self, *args, **kwargs):
+        encoded = super().apply_chat_template(*args, **kwargs)
+        if kwargs.get("tokenize") and kwargs.get("return_dict") and "assistant_masks" in encoded:
+            encoded["assistant_masks"] = [0] * len(encoded["assistant_masks"])
+        return encoded
+
+
+def _make_dataset(tokenizer, max_length=4096, output_key=None):
+    dataset = SFTDataset.__new__(SFTDataset)
+    dataset.tokenizer = tokenizer
+    dataset.strategy = SimpleNamespace(
+        args=SimpleNamespace(
+            data=SimpleNamespace(
+                input_key="input",
+                output_key=output_key,
+                apply_chat_template=True,
+                tokenizer_chat_template=None,
+            )
+        )
+    )
+    dataset.pretrain_mode = False
+    dataset.max_length = max_length
+    dataset.multiturn = True
+    dataset.input_template = None
+    dataset.input_key = "input"
+    dataset.output_key = output_key
+    dataset.apply_chat_template = tokenizer.apply_chat_template
+    dataset._warned_offset_mapping_unavailable = False
+    return dataset
+
+
+def _process_and_get_masked_targets(dataset, row):
+    processed = dataset.process_data(copy.deepcopy(row))
+    dataset.prompts = [processed["prompt"]]
+    dataset.responses = [processed["response"]]
+    dataset.prompt_ids_lens = [processed["prompt_ids_len"]]
+    dataset.response_ranges = [processed["response_ranges"]]
+
+    _, _, loss_mask = dataset[0]
+    text = (processed["prompt"] + processed["response"]).rstrip("\n")
+    if not text.endswith(dataset.tokenizer.eos_token):
+        text += " " + dataset.tokenizer.eos_token
+
+    mask = loss_mask[0].tolist()
+    masked_targets = "".join(text[idx + 1] for idx, value in enumerate(mask[:-1]) if value and idx + 1 < len(text))
+    return processed, text, masked_targets
+
+
+def test_qwen3_history_think_not_masked():
+    dataset = _make_dataset(QwenLikeTokenizer())
+    row = {
+        "input": [
+            {"role": "user", "content": "question one"},
+            {"role": "assistant", "reasoning_content": "hidden first", "content": "answer one"},
+            {"role": "user", "content": "question two"},
+            {"role": "assistant", "reasoning_content": "visible second", "content": "answer two"},
+        ]
+    }
+
+    _, rendered_text, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert "hidden first" not in rendered_text
+    assert "hidden first" not in masked_targets
+    assert "question one" not in masked_targets
+    assert "question two" not in masked_targets
+    assert "answer one" in masked_targets
+    assert "visible second" in masked_targets
+    assert "answer two" in masked_targets
+
+
+def test_qwen3_in_band_history_think_masks_visible_answer_only():
+    dataset = _make_dataset(QwenLikeTokenizer())
+    row = {
+        "input": [
+            {"role": "user", "content": "question one"},
+            {"role": "assistant", "content": "<think>\nhidden first\n</think>\n\nanswer one"},
+            {"role": "user", "content": "question two"},
+            {"role": "assistant", "content": "<think>\nvisible second\n</think>\n\nanswer two"},
+        ]
+    }
+
+    _, rendered_text, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert "hidden first" not in rendered_text
+    assert "hidden first" not in masked_targets
+    assert "question two" not in masked_targets
+    assert "answer one" in masked_targets
+    assert "<think>\nvisible second" in masked_targets
+    assert "answer two" in masked_targets
+
+
+def test_simple_template_masks_assistant_turns_without_user_text():
+    dataset = _make_dataset(SimpleTemplateTokenizer())
+    row = {
+        "input": [
+            {"role": "user", "content": "question one"},
+            {"role": "assistant", "content": "answer one"},
+            {"role": "user", "content": "question two"},
+            {"role": "assistant", "content": "answer two"},
+        ]
+    }
+
+    _, _, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert "answer one" in masked_targets
+    assert "answer two" in masked_targets
+    assert "question one" not in masked_targets
+    assert "question two" not in masked_targets
+
+
+def test_truncation_clips_response_ranges():
+    dataset = _make_dataset(SimpleTemplateTokenizer(), max_length=80)
+    row = {
+        "input": [
+            {"role": "user", "content": "short question"},
+            {"role": "assistant", "content": "a" * 200},
+        ]
+    }
+
+    processed, _, _ = _process_and_get_masked_targets(dataset, row)
+
+    assert processed["response_ranges"]
+    for start_idx, end_idx in processed["response_ranges"]:
+        assert 0 <= start_idx <= end_idx < dataset.max_length
+
+
+def test_output_key_multiturn_does_not_mutate_input_row():
+    dataset = _make_dataset(SimpleTemplateTokenizer(), output_key="output")
+    row = {
+        "input": [{"role": "user", "content": "question"}],
+        "output": {"role": "assistant", "content": "answer"},
+    }
+    original = copy.deepcopy(row)
+
+    _, _, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert row == original
+    assert "answer" in masked_targets
+    assert "question" not in masked_targets
+
+
+def test_native_assistant_mask_path_when_available():
+    tokenizer = NativeMaskTokenizer()
+    dataset = _make_dataset(tokenizer)
+    row = {
+        "input": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
+    }
+
+    _, _, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert tokenizer.native_mask_calls == 1
+    assert "answer" in masked_targets
+    assert "question" not in masked_targets
+
+
+def test_marker_fallback_when_native_mask_empty():
+    tokenizer = EmptyNativeMaskTokenizer()
+    dataset = _make_dataset(tokenizer)
+    row = {
+        "input": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "answer"},
+        ]
+    }
+
+    _, _, masked_targets = _process_and_get_masked_targets(dataset, row)
+
+    assert tokenizer.native_mask_calls == 1
+    assert "answer" in masked_targets
+    assert "question" not in masked_targets


### PR DESCRIPTION
## Summary

Fixes OpenRLHF/OpenRLHF#1080.

This PR makes multi-turn SFT assistant masking template-aware for Qwen3/DeepSeek-style thinking templates. The previous implementation computed each assistant range from partial conversation prefixes, which can disagree with the final full chat-template render when a template drops historical reasoning content.

## Root Cause

`SFTDataset.process_data` previously rendered each assistant turn as `messages[:idx]` plus `messages[: idx + 1]` and reused those token lengths as ranges in the final training sequence. Qwen3-style templates decide whether reasoning content is visible based on the full conversation context, especially the last user query. That means historical assistant thinking can appear in a prefix render but be absent from the final render, causing loss masks to drift into user/system tokens.

## Changes

- Build multi-turn `response_ranges` from the exact final rendered chat text instead of partial renders.
- Prefer native Hugging Face assistant masks when `apply_chat_template(..., return_assistant_tokens_mask=True)` returns a valid, aligned mask.
- Add a full-context marker fallback for templates without native assistant masks.
- Convert recovered assistant character spans to token ranges with offset mappings, with a conservative prefix-length fallback for tokenizers that do not expose offsets.
- Preserve existing `SFTDataset.__getitem__` output shape and next-token loss-shift behavior.
- Avoid mutating dataset rows when `output_key` is appended into multi-turn trajectories.
- Add focused tests for Qwen3-like historical thinking stripping, in-band `<think>` content, simple templates, truncation, `output_key` mutation safety, native assistant masks, and marker fallback behavior.

## Validation

- `uv run pytest tests/test_sft_dataset_multiturn_masks.py`
- `uv run --python 3.10 python -m compileall openrlhf/datasets/sft_dataset.py tests/test_sft_dataset_multiturn_masks.py`
- `git diff --check`
- Pre-commit hooks during commit:
  - check yaml
  - check for case conflicts
  - detect private key
  - check for added large files
  - autoflake
  - isort
  - black
