### PR TITLE
Add SFT tools field support for chat templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ OpenRLHF provides flexible data processing methods:
 - `--data.prompt_probs` / `--data.dataset_probs`: Mix multiple datasets (e.g., `0.1,0.4,0.5`)
 - `--eval.dataset`: Specify evaluation dataset path
 
+For SFT datasets with `--data.apply_chat_template`, each row may also include a `tools` field. OpenRLHF forwards it to HuggingFace chat templates so tool-calling templates can render the available tool schemas.
+
 **Chat Template Example**:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ OpenRLHF provides flexible data processing methods:
 - `--data.prompt_probs` / `--data.dataset_probs`: Mix multiple datasets (e.g., `0.1,0.4,0.5`)
 - `--eval.dataset`: Specify evaluation dataset path
 
-For SFT datasets with `--data.apply_chat_template`, each row may also include a `tools` field. OpenRLHF forwards it to HuggingFace chat templates so tool-calling templates can render the available tool schemas.
+For SFT datasets with `--data.apply_chat_template`, each row may also include a `tools` field (a list of dictionaries following the HuggingFace tool-use format). OpenRLHF forwards it to HuggingFace chat templates so tool-calling templates can render the available tool schemas.
 
 **Chat Template Example**:
 

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,10 +6,17 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
+def _get_chat_template_kwargs(data):
+    if "tools" not in data or data["tools"] is None:
+        return {}
+    return {"tools": data["tools"]}
+
+
 def preprocess_data(
     data, input_template=None, input_key="input", output_key=None, apply_chat_template=None, multiturn=False
 ):
     if apply_chat_template:
+        chat_template_kwargs = _get_chat_template_kwargs(data)
         if output_key:
             prompt_message = data[input_key]
             response_message = data[output_key]
@@ -18,11 +25,17 @@ def preprocess_data(
                 prompt_message = [{"role": "user", "content": prompt_message}]
                 response_message = [{"role": "assistant", "content": response_message}]
 
-            prompt = apply_chat_template(prompt_message, tokenize=False, add_generation_prompt=True)
-            response = apply_chat_template(prompt_message + response_message, tokenize=False)[len(prompt) :]
+            prompt = apply_chat_template(
+                prompt_message, tokenize=False, add_generation_prompt=True, **chat_template_kwargs
+            )
+            response = apply_chat_template(prompt_message + response_message, tokenize=False, **chat_template_kwargs)[
+                len(prompt) :
+            ]
         else:
-            prompt = apply_chat_template(data[input_key][:-1], tokenize=False, add_generation_prompt=True)
-            response = apply_chat_template(data[input_key], tokenize=False)[len(prompt) :]
+            prompt = apply_chat_template(
+                data[input_key][:-1], tokenize=False, add_generation_prompt=True, **chat_template_kwargs
+            )
+            response = apply_chat_template(data[input_key], tokenize=False, **chat_template_kwargs)[len(prompt) :]
     else:
         prompt = data[input_key]
         if input_template:
@@ -97,11 +110,16 @@ class SFTDataset(Dataset):
             ), "You should put the whole trajectory into data[input_key] and do not set output_key"
             input_key = self.input_key
             apply_chat_template = self.apply_chat_template
+            chat_template_kwargs = _get_chat_template_kwargs(data)
             response_ranges = []
             for idx, message in enumerate(data[input_key]):
                 if message["role"] == "assistant":
-                    prompt = apply_chat_template(data[input_key][:idx], tokenize=False, add_generation_prompt=True)
-                    response = apply_chat_template(data[input_key][: idx + 1], tokenize=False)[len(prompt) :]
+                    prompt = apply_chat_template(
+                        data[input_key][:idx], tokenize=False, add_generation_prompt=True, **chat_template_kwargs
+                    )
+                    response = apply_chat_template(data[input_key][: idx + 1], tokenize=False, **chat_template_kwargs)[
+                        len(prompt) :
+                    ]
 
                     start_idx = (
                         self.tokenizer(

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -7,9 +7,8 @@ from openrlhf.utils.utils import zero_pad_sequences
 
 
 def _get_chat_template_kwargs(data):
-    if "tools" not in data or data["tools"] is None:
-        return {}
-    return {"tools": data["tools"]}
+    tools = data.get("tools")
+    return {"tools": tools} if tools is not None else {}
 
 
 def preprocess_data(

--- a/tests/test_sft_dataset_tools.py
+++ b/tests/test_sft_dataset_tools.py
@@ -1,0 +1,200 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+
+def _load_sft_dataset_module():
+    # Keep these unit tests focused on sft_dataset instead of package-level imports.
+    module_path = Path(__file__).parents[1] / "openrlhf" / "datasets" / "sft_dataset.py"
+    module_name = "_sft_dataset_under_test"
+    stubbed_module_names = ("openrlhf.utils", "openrlhf.utils.utils")
+    sentinel = object()
+    previous_modules = {name: sys.modules.get(name, sentinel) for name in stubbed_module_names}
+
+    utils_package = types.ModuleType("openrlhf.utils")
+    utils_package.__path__ = []
+    utils_module = types.ModuleType("openrlhf.utils.utils")
+
+    def zero_pad_sequences(*_args, **_kwargs):
+        raise AssertionError("zero_pad_sequences is not exercised by these tests")
+
+    utils_module.zero_pad_sequences = zero_pad_sequences
+
+    sys.modules["openrlhf.utils"] = utils_package
+    sys.modules["openrlhf.utils.utils"] = utils_module
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is sentinel:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+    return module
+
+
+sft_dataset = _load_sft_dataset_module()
+SFTDataset = sft_dataset.SFTDataset
+_get_chat_template_kwargs = sft_dataset._get_chat_template_kwargs
+preprocess_data = sft_dataset.preprocess_data
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup_weather",
+            "description": "Look up weather by city.",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+        },
+    }
+]
+
+
+class RecordingTemplate:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, messages, **kwargs):
+        self.calls.append((messages, kwargs))
+
+        rendered_parts = []
+        if "tools" in kwargs:
+            rendered_parts.append("<tools>")
+        for message in messages:
+            rendered_parts.append(f"<{message['role']}>{message.get('content', '')}")
+        if kwargs.get("add_generation_prompt"):
+            rendered_parts.append("<assistant>")
+        return "".join(rendered_parts)
+
+
+class NoToolsTemplate:
+    def __call__(self, messages, **kwargs):
+        assert "tools" not in kwargs
+        rendered = "".join(f"<{message['role']}>{message.get('content', '')}" for message in messages)
+        if kwargs.get("add_generation_prompt"):
+            rendered += "<assistant>"
+        return rendered
+
+
+class FakeTokenizer:
+    eos_token = "<eos>"
+    eos_token_id = 0
+    pad_token_id = 0
+
+    def __init__(self, apply_chat_template):
+        self.apply_chat_template = apply_chat_template
+
+    def __call__(self, text, **kwargs):
+        return {"attention_mask": torch.ones((1, len(text)), dtype=torch.long)}
+
+
+def test_get_chat_template_kwargs_omits_missing_and_none_tools():
+    assert _get_chat_template_kwargs({}) == {}
+    assert _get_chat_template_kwargs({"tools": None}) == {}
+
+
+def test_get_chat_template_kwargs_passes_empty_and_populated_tools():
+    empty_tools = []
+    assert _get_chat_template_kwargs({"tools": empty_tools})["tools"] is empty_tools
+    assert _get_chat_template_kwargs({"tools": TOOLS})["tools"] is TOOLS
+
+
+def test_preprocess_data_passes_tools_for_split_prompt_response():
+    template = RecordingTemplate()
+
+    prompt, response = preprocess_data(
+        {"input": "What is the weather?", "output": "Sunny.", "tools": TOOLS},
+        input_key="input",
+        output_key="output",
+        apply_chat_template=template,
+    )
+
+    assert prompt == "<tools><user>What is the weather?<assistant>"
+    assert response == "Sunny."
+    assert len(template.calls) == 2
+    assert all(call_kwargs["tools"] is TOOLS for _, call_kwargs in template.calls)
+
+
+def test_preprocess_data_passes_tools_for_full_conversation():
+    template = RecordingTemplate()
+    row = {
+        "input": [
+            {"role": "user", "content": "What is the weather?"},
+            {"role": "assistant", "content": "Sunny."},
+        ],
+        "tools": TOOLS,
+    }
+
+    prompt, response = preprocess_data(row, input_key="input", apply_chat_template=template)
+
+    assert prompt == "<tools><user>What is the weather?<assistant>"
+    assert response == "Sunny."
+    assert len(template.calls) == 2
+    assert all(call_kwargs["tools"] is TOOLS for _, call_kwargs in template.calls)
+
+
+def test_preprocess_data_does_not_pass_tools_when_field_is_absent():
+    prompt, response = preprocess_data(
+        {"input": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}]},
+        input_key="input",
+        apply_chat_template=NoToolsTemplate(),
+    )
+
+    assert prompt == "<user>Hi<assistant>"
+    assert response == "Hello"
+
+
+def test_preprocess_data_passes_empty_tools_list():
+    template = RecordingTemplate()
+
+    prompt, response = preprocess_data(
+        {"input": [{"role": "user", "content": "Hi"}, {"role": "assistant", "content": "Hello"}], "tools": []},
+        input_key="input",
+        apply_chat_template=template,
+    )
+
+    assert prompt == "<tools><user>Hi<assistant>"
+    assert response == "Hello"
+    assert len(template.calls) == 2
+    assert all(call_kwargs["tools"] == [] for _, call_kwargs in template.calls)
+
+
+def test_process_data_multiturn_passes_tools_for_response_ranges():
+    template = RecordingTemplate()
+    dataset = SFTDataset.__new__(SFTDataset)
+    dataset.tokenizer = FakeTokenizer(template)
+    dataset.pretrain_mode = False
+    dataset.max_length = 1024
+    dataset.multiturn = True
+    dataset.input_template = None
+    dataset.input_key = "input"
+    dataset.output_key = None
+    dataset.apply_chat_template = template
+
+    processed = dataset.process_data(
+        {
+            "input": [
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "One"},
+                {"role": "user", "content": "Second"},
+                {"role": "assistant", "content": "Two"},
+            ],
+            "tools": TOOLS,
+        }
+    )
+
+    assert len(processed["response_ranges"]) == 2
+    assert len(template.calls) == 6
+    assert all(call_kwargs["tools"] is TOOLS for _, call_kwargs in template.calls)
+
+    dataset.response_ranges = [processed["response_ranges"]]
+    input_ids = torch.ones((1, len(processed["prompt"] + processed["response"])), dtype=torch.long)
+    loss_mask = dataset.get_loss_mask(input_ids, 0)
+    assert loss_mask.sum().item() > 0


### PR DESCRIPTION
## Summary

- Forward an optional row-level `tools` field into SFT chat-template rendering when `--data.apply_chat_template` is enabled.
- Apply the same forwarding in split `input`/`output`, full-conversation, and multiturn response-range preprocessing paths.
- Document the supported `tools` field and add focused tests for tool-calling SFT dataset behavior.

## Motivation

Fixes #1079.

SFT preprocessing previously passed only the conversation messages to `apply_chat_template(...)`. Tool-calling chat templates in HuggingFace tokenizers can also use `tools=...`, but OpenRLHF dropped that row-level dataset field before rendering. As a result, datasets that already contained tool schemas could not render tool-aware SFT prompts through the built-in chat-template path.

## Design

- Add a small helper that returns `{"tools": data["tools"]}` only when the row contains a non-`None` `tools` value.
- Preserve existing behavior for rows without `tools` or with `tools=None`.
- Preserve empty tool lists by forwarding `tools=[]`, which lets the tokenizer/template decide how to render an explicitly empty tool set.
- Keep the change scoped to SFT preprocessing, matching the issue request without adding a new CLI flag or changing reward/prompt dataset behavior.

## Validation

- `python3.10 -m py_compile openrlhf/datasets/sft_dataset.py tests/test_sft_dataset_tools.py`
- `python3.10 -m pytest tests/test_sft_dataset_tools.py -q`
- `python3.10 -m pytest tests/test_ray_env_vars.py tests/test_sft_dataset_tools.py -q`
- `git diff --check`
- Repo pre-commit hooks on commit: `autoflake`, import formatting, and Black formatting passed.
