### PR TITLE
Clarify reward normalization behavior for custom reward sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ ray job submit --address="http://127.0.0.1:8265" \
 
 # Advanced Options:
 # --algo.kl.init_coef 0                                    # No reference model
-# --reward.remote_url http://host:5000/get_reward         # HTTP reward model
+# --reward.remote_url http://host:5000/get_reward         # HTTP reward model; normalize on the server if needed
 # --rollout.n_samples_per_prompt 4                            # Multiple samples per prompt
 # --rollout.vllm_generate_batch_size 2048                     # Oversample at generation (> rollout_batch_size); requires --train.async_enable
 # --algo.advantage.is_correction_enable                         # vLLM importance sampling correction for off-policy rollouts
@@ -578,6 +578,15 @@ ray job submit --address="http://127.0.0.1:8265" \
 ```
 
 **Key Parameter**: `--data.label_key answer` passes the "answer" field from your dataset to `reward_func` as `labels`.
+
+> [!NOTE]
+> `--reward.normalize_enable` normalizes local reward-model and critic
+> value-head outputs. It does not normalize rewards returned by custom
+> `reward_func`, `agent_func`, or HTTP reward APIs in the PPO client. Return
+> custom training rewards on the scale you want PPO to use, and keep `scores`
+> on the scale you want for dynamic filtering. If you serve a reward model with
+> `openrlhf.cli.serve_rm`, pass `--reward.normalize_enable` to the server
+> command to normalize that server's outputs.
 
 > [!TIP]
 > **Use Cases**: Code generation (execute tests), Math (verify solutions), Formatting (check structure), Multi-objective (combine multiple signals)

--- a/examples/scripts/train_ppo_with_reward_fn.sh
+++ b/examples/scripts/train_ppo_with_reward_fn.sh
@@ -7,6 +7,8 @@
 #     print(queries)
 #     return torch.randn(len(queries))
 
+# Custom reward_func outputs are used directly. Normalize inside reward_func if needed.
+
 set -x 
 
 ray job submit --address="http://127.0.0.1:8265" \
@@ -39,10 +41,8 @@ ray job submit --address="http://127.0.0.1:8265" \
    --data.prompt_dataset OpenRLHF/prompt-collection-v0.1 \
    --data.input_key context_messages \
    --data.apply_chat_template \
-   --reward.normalize_enable \
    --ds.packing_samples \
    --ds.adam_offload \
    --ds.attn_implementation flash_attention_2 \
    --actor.gradient_checkpointing_enable \
    --logger.wandb.key {wandb_token}
-

--- a/openrlhf/cli/reward_normalization.py
+++ b/openrlhf/cli/reward_normalization.py
@@ -1,0 +1,49 @@
+"""Helpers for explaining reward normalization routing in PPO training."""
+
+LOCAL_REWARD_MODEL = "local_reward_model"
+PYTHON_REWARD_FUNC = "python_reward_func"
+HTTP_REWARD_API = "http_reward_api"
+AGENT_FUNC = "agent_func"
+
+
+def as_reward_url_list(remote_url):
+    if remote_url is None:
+        return []
+    if isinstance(remote_url, str):
+        return [remote_url]
+    return list(remote_url)
+
+
+def classify_reward_source(remote_url=None, agent_func_path=None):
+    """Classify the reward source using train_ppo_ray.py routing semantics."""
+    if agent_func_path:
+        return AGENT_FUNC
+
+    urls = as_reward_url_list(remote_url)
+    if not urls:
+        return LOCAL_REWARD_MODEL
+    if str(urls[0]).endswith(".py"):
+        return PYTHON_REWARD_FUNC
+    return HTTP_REWARD_API
+
+
+def reward_normalization_warning(normalize_enable, reward_source):
+    if not normalize_enable or reward_source == LOCAL_REWARD_MODEL:
+        return None
+
+    if reward_source == PYTHON_REWARD_FUNC:
+        source_detail = "Python reward_func files"
+        resolution = "Normalize custom rewards inside reward_func when that behavior is desired."
+    elif reward_source == AGENT_FUNC:
+        source_detail = "custom agent_func executors"
+        resolution = "Normalize custom rewards inside the agent executor when that behavior is desired."
+    else:
+        source_detail = "remote reward APIs"
+        resolution = "If the server is openrlhf.cli.serve_rm, pass --reward.normalize_enable to that server command."
+
+    return (
+        "[Warning] --reward.normalize_enable does not transform rewards returned by "
+        f"{source_detail}. It only configures local reward/critic model heads. "
+        "If a critic is active, critic values may still use this setting. "
+        f"{resolution}"
+    )

--- a/openrlhf/cli/reward_normalization.py
+++ b/openrlhf/cli/reward_normalization.py
@@ -9,9 +9,16 @@ AGENT_FUNC = "agent_func"
 def as_reward_url_list(remote_url):
     if remote_url is None:
         return []
-    if isinstance(remote_url, str):
-        return [remote_url]
-    return list(remote_url)
+
+    urls = [remote_url] if isinstance(remote_url, str) else remote_url
+    normalized_urls = []
+    for url in urls:
+        if url is None:
+            continue
+        normalized_url = str(url).strip()
+        if normalized_url:
+            normalized_urls.append(normalized_url)
+    return normalized_urls
 
 
 def classify_reward_source(remote_url=None, agent_func_path=None):

--- a/openrlhf/cli/serve_rm.py
+++ b/openrlhf/cli/serve_rm.py
@@ -76,7 +76,10 @@ if __name__ == "__main__":
     # Reward Model
     parser.add_argument("--reward.model_name_or_path", type=str, default=None, help="HF model name or path")
     parser.add_argument(
-        "--reward.normalize_enable", action="store_true", default=False, help="Enable Reward Normalization"
+        "--reward.normalize_enable",
+        action="store_true",
+        default=False,
+        help="Enable normalization for this served reward model's outputs",
     )
     parser.add_argument("--ds.value_head_prefix", type=str, default="score")
     parser.add_argument("--data.max_len", type=int, default=2048)

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import ray
 from ray.util.placement_group import placement_group
 
-from openrlhf.cli.reward_normalization import classify_reward_source, reward_normalization_warning
+from openrlhf.cli.reward_normalization import as_reward_url_list, classify_reward_source, reward_normalization_warning
 from openrlhf.trainer.ray import create_vllm_engines
 from openrlhf.trainer.ray.launcher import (
     RayActorGroup,
@@ -604,6 +604,12 @@ if __name__ == "__main__":
     if args.train.agent_func_path:
         args.reward.remote_url = "agent"
 
+    if args.reward.remote_url:
+        remote_url = (
+            args.reward.remote_url.split(",") if isinstance(args.reward.remote_url, str) else args.reward.remote_url
+        )
+        args.reward.remote_url = as_reward_url_list(remote_url)
+
     if args.algo.advantage.estimator not in ["gae"]:
         args.critic.model_name_or_path = None
     elif args.critic.model_name_or_path is None:
@@ -628,9 +634,6 @@ if __name__ == "__main__":
             "Packing collapses the batch dimension, breaking alignment between image tokens and pixel_values. "
             "VLM models also require model-computed position_ids (e.g., M-RoPE) which is incompatible with packing."
         )
-
-    if args.reward.remote_url:
-        args.reward.remote_url = args.reward.remote_url.split(",")
 
     warning = reward_normalization_warning(
         args.reward.normalize_enable,

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import ray
 from ray.util.placement_group import placement_group
 
+from openrlhf.cli.reward_normalization import classify_reward_source, reward_normalization_warning
 from openrlhf.trainer.ray import create_vllm_engines
 from openrlhf.trainer.ray.launcher import (
     RayActorGroup,
@@ -393,7 +394,13 @@ if __name__ == "__main__":
     parser.add_argument("--train.micro_batch_size", type=int, default=1, help="batch size per GPU")
     parser.add_argument("--train.batch_size", type=int, default=128, help="Global training batch size")
     parser.add_argument(
-        "--reward.normalize_enable", action="store_true", default=False, help="Enable Reward Normalization"
+        "--reward.normalize_enable",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable normalization for local reward-model and critic value-head outputs. "
+            "Does not normalize rewards returned by reward_func, agent_func, or HTTP reward APIs."
+        ),
     )
     parser.add_argument("--rollout.top_p", type=float, default=1.0)
     parser.add_argument("--rollout.temperature", type=float, default=1.0)
@@ -624,6 +631,13 @@ if __name__ == "__main__":
 
     if args.reward.remote_url:
         args.reward.remote_url = args.reward.remote_url.split(",")
+
+    warning = reward_normalization_warning(
+        args.reward.normalize_enable,
+        classify_reward_source(args.reward.remote_url, args.train.agent_func_path),
+    )
+    if warning:
+        print(warning)
 
     if args.data.input_template and "{}" not in args.data.input_template:
         print("[Warning] '{}' not in args.data.input_template, set to None")

--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 import aiohttp
 
+from openrlhf.cli.reward_normalization import as_reward_url_list
 from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -185,8 +186,7 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
     """Single-turn agent executor with optional reward post-processing."""
 
     def __init__(self, remote_rm_url=None):
-        reward_endpoints = [remote_rm_url] if isinstance(remote_rm_url, str) else remote_rm_url
-        self.reward_endpoints = reward_endpoints or []
+        self.reward_endpoints = as_reward_url_list(remote_rm_url)
 
         # Optional user-provided reward_func from a Python file.
         self.reward_func = None

--- a/tests/test_reward_normalization_semantics.py
+++ b/tests/test_reward_normalization_semantics.py
@@ -1,0 +1,58 @@
+from openrlhf.cli.reward_normalization import (
+    AGENT_FUNC,
+    HTTP_REWARD_API,
+    LOCAL_REWARD_MODEL,
+    PYTHON_REWARD_FUNC,
+    as_reward_url_list,
+    classify_reward_source,
+    reward_normalization_warning,
+)
+
+
+def test_as_reward_url_list_normalizes_supported_shapes():
+    assert as_reward_url_list(None) == []
+    assert as_reward_url_list("http://host:5000/get_reward") == ["http://host:5000/get_reward"]
+    assert as_reward_url_list(["a.py", "http://host"]) == ["a.py", "http://host"]
+
+
+def test_classify_reward_source_local_reward_model():
+    assert classify_reward_source() == LOCAL_REWARD_MODEL
+
+
+def test_classify_reward_source_python_reward_func():
+    assert classify_reward_source("/tmp/reward_func.py") == PYTHON_REWARD_FUNC
+
+
+def test_classify_reward_source_http_reward_api():
+    assert classify_reward_source("http://host:5000/get_reward") == HTTP_REWARD_API
+
+
+def test_classify_reward_source_agent_func_takes_precedence():
+    assert classify_reward_source(["agent"], agent_func_path="/tmp/agent_func.py") == AGENT_FUNC
+
+
+def test_classify_reward_source_uses_first_split_reward_endpoint():
+    assert classify_reward_source(["/tmp/reward_func.py", "http://host:5000/get_reward"]) == PYTHON_REWARD_FUNC
+    assert classify_reward_source(["http://host:5000/get_reward", "/tmp/reward_func.py"]) == HTTP_REWARD_API
+
+
+def test_reward_normalization_warning_is_only_for_enabled_remote_or_custom_rewards():
+    assert reward_normalization_warning(False, PYTHON_REWARD_FUNC) is None
+    assert reward_normalization_warning(True, LOCAL_REWARD_MODEL) is None
+
+    warning = reward_normalization_warning(True, PYTHON_REWARD_FUNC)
+
+    assert "--reward.normalize_enable does not transform rewards" in warning
+    assert "Python reward_func files" in warning
+    assert "local reward/critic model heads" in warning
+    assert "critic values may still use this setting" in warning
+
+
+def test_reward_normalization_warning_describes_agent_and_http_sources():
+    agent_warning = reward_normalization_warning(True, AGENT_FUNC)
+    http_warning = reward_normalization_warning(True, HTTP_REWARD_API)
+
+    assert "custom agent_func executors" in agent_warning
+    assert "inside the agent executor" in agent_warning
+    assert "remote reward APIs" in http_warning
+    assert "pass --reward.normalize_enable to that server command" in http_warning

--- a/tests/test_reward_normalization_semantics.py
+++ b/tests/test_reward_normalization_semantics.py
@@ -12,7 +12,8 @@ from openrlhf.cli.reward_normalization import (
 def test_as_reward_url_list_normalizes_supported_shapes():
     assert as_reward_url_list(None) == []
     assert as_reward_url_list("http://host:5000/get_reward") == ["http://host:5000/get_reward"]
-    assert as_reward_url_list(["a.py", "http://host"]) == ["a.py", "http://host"]
+    assert as_reward_url_list(" http://host:5000/get_reward ") == ["http://host:5000/get_reward"]
+    assert as_reward_url_list([" a.py ", "", "  ", "http://host "]) == ["a.py", "http://host"]
 
 
 def test_classify_reward_source_local_reward_model():
@@ -21,6 +22,11 @@ def test_classify_reward_source_local_reward_model():
 
 def test_classify_reward_source_python_reward_func():
     assert classify_reward_source("/tmp/reward_func.py") == PYTHON_REWARD_FUNC
+    assert classify_reward_source(" /tmp/reward_func.py ") == PYTHON_REWARD_FUNC
+
+
+def test_classify_reward_source_preserves_case_sensitive_python_suffix():
+    assert classify_reward_source("/tmp/reward_func.PY") == HTTP_REWARD_API
 
 
 def test_classify_reward_source_http_reward_api():


### PR DESCRIPTION
## Summary

- Clarify that `--reward.normalize_enable` normalizes local reward-model and critic value-head outputs, not precomputed rewards returned by custom reward sources.
- Add a one-time PPO CLI warning when the flag is used with a Python `reward_func`, custom `agent_func`, or HTTP reward API.
- Update the custom reward README guidance and remove the misleading active flag from `train_ppo_with_reward_fn.sh`.
- Add focused tests for reward-source classification and warning text.

## Root Cause

Issue #1106 reports that reward normalization appears ineffective when rewards come from `agent_func` or `reward_func`. That matches the current routing: those paths return precomputed scalar rewards through rollout generation, so PPO skips the local reward-model actor. The existing flag still matters for local reward-model outputs, served reward-model outputs when passed to `serve_rm.py`, and critic/value-head normalization when a critic is active.

## Behavior

This PR does not change reward math for existing custom reward jobs. It only makes the semantics explicit before users launch training:

- local reward-model jobs keep the same normalization behavior;
- served reward-model normalization remains configured on the reward server;
- Python reward functions, agent executors, and HTTP reward APIs keep returning rewards on their own scale;
- `scores` remain unchanged for dynamic filtering.

## Validation

- `uv run --python /usr/local/bin/python3.10 --with pytest pytest tests/test_reward_normalization_semantics.py tests/test_ray_env_vars.py`
- `uv run --python /usr/local/bin/python3.10 --with ruff ruff check openrlhf/cli/reward_normalization.py tests/test_reward_normalization_semantics.py openrlhf/cli/train_ppo_ray.py openrlhf/cli/serve_rm.py`
- `/usr/local/bin/python3.10 -m py_compile openrlhf/cli/train_ppo_ray.py openrlhf/cli/serve_rm.py openrlhf/cli/reward_normalization.py`
- `git diff --check`
