### PR TITLE
Add Trackio logger backend

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -328,6 +328,12 @@ if __name__ == "__main__":
         default="exp_%s" % datetime.now().strftime("%m%dT%H:%M"),
     )
 
+    # trackio parameters
+    parser.add_argument("--logger.trackio.project", type=str, default=None)
+    parser.add_argument("--logger.trackio.name", type=str, default=None)
+    parser.add_argument("--logger.trackio.group", type=str, default=None)
+    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")
 

--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -329,10 +329,19 @@ if __name__ == "__main__":
     )
 
     # trackio parameters
-    parser.add_argument("--logger.trackio.project", type=str, default=None)
-    parser.add_argument("--logger.trackio.name", type=str, default=None)
-    parser.add_argument("--logger.trackio.group", type=str, default=None)
-    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+    parser.add_argument(
+        "--logger.trackio.project", type=str, default=None, help="Trackio project name (set to enable Trackio logging)"
+    )
+    parser.add_argument("--logger.trackio.name", type=str, default=None, help="Trackio run name")
+    parser.add_argument(
+        "--logger.trackio.group", type=str, default=None, help="Trackio group name for organizing related runs"
+    )
+    parser.add_argument(
+        "--logger.trackio.space_id",
+        type=str,
+        default=None,
+        help="Optional Hugging Face Space id (username/space) to host the dashboard",
+    )
 
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -578,10 +578,19 @@ if __name__ == "__main__":
     )
 
     # trackio parameters
-    parser.add_argument("--logger.trackio.project", type=str, default=None)
-    parser.add_argument("--logger.trackio.name", type=str, default=None)
-    parser.add_argument("--logger.trackio.group", type=str, default=None)
-    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+    parser.add_argument(
+        "--logger.trackio.project", type=str, default=None, help="Trackio project name (set to enable Trackio logging)"
+    )
+    parser.add_argument("--logger.trackio.name", type=str, default=None, help="Trackio run name")
+    parser.add_argument(
+        "--logger.trackio.group", type=str, default=None, help="Trackio group name for organizing related runs"
+    )
+    parser.add_argument(
+        "--logger.trackio.space_id",
+        type=str,
+        default=None,
+        help="Optional Hugging Face Space id (username/space) to host the dashboard",
+    )
 
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -577,6 +577,12 @@ if __name__ == "__main__":
         help="Freeze vision encoder weights (only train language model). Reduces memory and weight sync overhead.",
     )
 
+    # trackio parameters
+    parser.add_argument("--logger.trackio.project", type=str, default=None)
+    parser.add_argument("--logger.trackio.name", type=str, default=None)
+    parser.add_argument("--logger.trackio.group", type=str, default=None)
+    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")
 

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -308,6 +308,12 @@ if __name__ == "__main__":
         default="rm_%s" % datetime.now().strftime("%m%dT%H:%M"),
     )
 
+    # trackio parameters
+    parser.add_argument("--logger.trackio.project", type=str, default=None)
+    parser.add_argument("--logger.trackio.name", type=str, default=None)
+    parser.add_argument("--logger.trackio.group", type=str, default=None)
+    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")
 

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -309,10 +309,19 @@ if __name__ == "__main__":
     )
 
     # trackio parameters
-    parser.add_argument("--logger.trackio.project", type=str, default=None)
-    parser.add_argument("--logger.trackio.name", type=str, default=None)
-    parser.add_argument("--logger.trackio.group", type=str, default=None)
-    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+    parser.add_argument(
+        "--logger.trackio.project", type=str, default=None, help="Trackio project name (set to enable Trackio logging)"
+    )
+    parser.add_argument("--logger.trackio.name", type=str, default=None, help="Trackio run name")
+    parser.add_argument(
+        "--logger.trackio.group", type=str, default=None, help="Trackio group name for organizing related runs"
+    )
+    parser.add_argument(
+        "--logger.trackio.space_id",
+        type=str,
+        default=None,
+        help="Optional Hugging Face Space id (username/space) to host the dashboard",
+    )
 
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -294,6 +294,12 @@ if __name__ == "__main__":
         default="sft_%s" % datetime.now().strftime("%m%dT%H:%M"),
     )
 
+    # trackio parameters
+    parser.add_argument("--logger.trackio.project", type=str, default=None)
+    parser.add_argument("--logger.trackio.name", type=str, default=None)
+    parser.add_argument("--logger.trackio.group", type=str, default=None)
+    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")
 

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -295,10 +295,19 @@ if __name__ == "__main__":
     )
 
     # trackio parameters
-    parser.add_argument("--logger.trackio.project", type=str, default=None)
-    parser.add_argument("--logger.trackio.name", type=str, default=None)
-    parser.add_argument("--logger.trackio.group", type=str, default=None)
-    parser.add_argument("--logger.trackio.space_id", type=str, default=None)
+    parser.add_argument(
+        "--logger.trackio.project", type=str, default=None, help="Trackio project name (set to enable Trackio logging)"
+    )
+    parser.add_argument("--logger.trackio.name", type=str, default=None, help="Trackio run name")
+    parser.add_argument(
+        "--logger.trackio.group", type=str, default=None, help="Trackio group name for organizing related runs"
+    )
+    parser.add_argument(
+        "--logger.trackio.space_id",
+        type=str,
+        default=None,
+        help="Optional Hugging Face Space id (username/space) to host the dashboard",
+    )
 
     # TensorBoard parameters
     parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")

--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -72,8 +72,9 @@ class DPOTrainer(ABC):
         # packing samples
         self.packing_samples = strategy.args.ds.packing_samples
 
-        # wandb/tensorboard setting
+        # wandb/trackio/tensorboard setting
         self._wandb = None
+        self._trackio = None
         self._tensorboard = None
         if self.strategy.args.logger.wandb.key and self.strategy.is_rank_0():
             import wandb
@@ -94,6 +95,16 @@ class DPOTrainer(ABC):
             wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
             wandb.define_metric("eval/global_step")
             wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
+
+        # Initialize Trackio if configured
+        if (
+            getattr(self.strategy.args.logger, "trackio", None) is not None
+            and self.strategy.args.logger.trackio.project
+            and self.strategy.is_rank_0()
+        ):
+            from openrlhf.utils.logging_utils import TrackioLogger
+
+            self._trackio = TrackioLogger(strategy.args)
 
         # Initialize TensorBoard writer if wandb is not available
         if self.strategy.args.logger.tensorboard_dir and self._wandb is None and self.strategy.is_rank_0():
@@ -216,6 +227,8 @@ class DPOTrainer(ABC):
 
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()
+        if self._trackio is not None and self.strategy.is_rank_0():
+            self._trackio.close()
         if self._tensorboard is not None and self.strategy.is_rank_0():
             self._tensorboard.close()
 
@@ -228,8 +241,11 @@ class DPOTrainer(ABC):
             if self._wandb is not None and self.strategy.is_rank_0():
                 logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
                 self._wandb.log(logs)
+            # Trackio
+            if self._trackio is not None and self.strategy.is_rank_0():
+                self._trackio.log_train(global_step, logs_dict)
             # TensorBoard
-            elif self._tensorboard is not None and self.strategy.is_rank_0():
+            if self._wandb is None and self._tensorboard is not None and self.strategy.is_rank_0():
                 for k, v in logs_dict.items():
                     self._tensorboard.add_scalar(f"train/{k}", v, global_step)
 
@@ -295,9 +311,11 @@ class DPOTrainer(ABC):
 
             if self.strategy.is_rank_0():
                 if self._wandb is not None:
-                    logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
-                    self._wandb.log(logs)
-                elif self._tensorboard is not None:
+                    wandb_logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
+                    self._wandb.log(wandb_logs)
+                if self._trackio is not None:
+                    self._trackio.log_eval(steps, logs)
+                if self._wandb is None and self._tensorboard is not None:
                     for k, v in logs.items():
                         self._tensorboard.add_scalar(f"eval/{k}", v, steps)
         self.model.train()  # reset model state

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -17,7 +17,7 @@ from openrlhf.trainer.ppo_utils.samples_generator import SamplesGenerator
 from openrlhf.trainer.ray.launcher import RayActorGroup
 from openrlhf.trainer.ray.vllm_engine import batch_vllm_engine_call
 from openrlhf.utils.deepspeed import DeepspeedStrategy
-from openrlhf.utils.logging_utils import TensorboardLogger, WandbLogger, init_logger
+from openrlhf.utils.logging_utils import TensorboardLogger, TrackioLogger, WandbLogger, init_logger
 from openrlhf.utils.utils import get_tokenizer
 
 logger = init_logger(__name__)
@@ -187,6 +187,12 @@ class BasePPOTrainer(ABC):
 
         # Tracking backends
         self.wandb_logger = WandbLogger(self.args) if self.args.logger.wandb.key else None
+        self.trackio_logger = (
+            TrackioLogger(self.args)
+            if getattr(self.args.logger, "trackio", None) is not None
+            and self.args.logger.trackio.project
+            else None
+        )
         self.tensorboard_logger = TensorboardLogger(self.args) if self.args.logger.tensorboard_dir else None
 
         # Best eval metric tracking
@@ -385,6 +391,8 @@ class BasePPOTrainer(ABC):
         if global_step % self.args.logger.logging_steps == 0:
             if self.wandb_logger:
                 self.wandb_logger.log_train(global_step, logs_dict)
+            if self.trackio_logger:
+                self.trackio_logger.log_train(global_step, logs_dict)
             if self.tensorboard_logger:
                 self.tensorboard_logger.log_train(global_step, logs_dict)
 
@@ -566,6 +574,8 @@ class PPOTrainer(BasePPOTrainer):
         # Close trackers
         if self.wandb_logger:
             self.wandb_logger.close()
+        if self.trackio_logger:
+            self.trackio_logger.close()
         if self.tensorboard_logger:
             self.tensorboard_logger.close()
 
@@ -580,6 +590,8 @@ class PPOTrainer(BasePPOTrainer):
 
         if self.wandb_logger:
             self.wandb_logger.log_eval(global_step, logs)
+        if self.trackio_logger:
+            self.trackio_logger.log_eval(global_step, logs)
         if self.tensorboard_logger:
             self.tensorboard_logger.log_eval(global_step, logs)
 

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -189,8 +189,7 @@ class BasePPOTrainer(ABC):
         self.wandb_logger = WandbLogger(self.args) if self.args.logger.wandb.key else None
         self.trackio_logger = (
             TrackioLogger(self.args)
-            if getattr(self.args.logger, "trackio", None) is not None
-            and self.args.logger.trackio.project
+            if getattr(self.args.logger, "trackio", None) is not None and self.args.logger.trackio.project
             else None
         )
         self.tensorboard_logger = TensorboardLogger(self.args) if self.args.logger.tensorboard_dir else None

--- a/openrlhf/trainer/ppo_trainer_async.py
+++ b/openrlhf/trainer/ppo_trainer_async.py
@@ -214,6 +214,8 @@ class TrainingActor(BasePPOTrainer):
                 logger.info(f"Eval at step {eval_step}: {eval_metrics}")
                 if self.wandb_logger:
                     self.wandb_logger.log_eval(eval_step, eval_metrics)
+                if self.trackio_logger:
+                    self.trackio_logger.log_eval(eval_step, eval_metrics)
                 if self.tensorboard_logger:
                     self.tensorboard_logger.log_eval(eval_step, eval_metrics)
                 # Save best checkpoint if this eval metric is the best so far
@@ -249,6 +251,8 @@ class TrainingActor(BasePPOTrainer):
 
         if self.wandb_logger:
             self.wandb_logger.close()
+        if self.trackio_logger:
+            self.trackio_logger.close()
         if self.tensorboard_logger:
             self.tensorboard_logger.close()
 

--- a/openrlhf/trainer/rm_trainer.py
+++ b/openrlhf/trainer/rm_trainer.py
@@ -71,8 +71,9 @@ class RewardModelTrainer(ABC):
         self.margin_loss = self.strategy.args.model.margin_loss_enable
         self.compute_fp32_loss = self.strategy.args.model.compute_fp32_loss_enable
 
-        # wandb/tensorboard setting
+        # wandb/trackio/tensorboard setting
         self._wandb = None
+        self._trackio = None
         self._tensorboard = None
         if self.strategy.args.logger.wandb.key and self.strategy.is_rank_0():
             import wandb
@@ -93,6 +94,16 @@ class RewardModelTrainer(ABC):
             wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
             wandb.define_metric("eval/global_step")
             wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
+
+        # Initialize Trackio if configured
+        if (
+            getattr(self.strategy.args.logger, "trackio", None) is not None
+            and self.strategy.args.logger.trackio.project
+            and self.strategy.is_rank_0()
+        ):
+            from openrlhf.utils.logging_utils import TrackioLogger
+
+            self._trackio = TrackioLogger(strategy.args)
 
         # Initialize TensorBoard writer if wandb is not available
         if self.strategy.args.logger.tensorboard_dir and self._wandb is None and self.strategy.is_rank_0():
@@ -207,6 +218,8 @@ class RewardModelTrainer(ABC):
 
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()
+        if self._trackio is not None and self.strategy.is_rank_0():
+            self._trackio.close()
         if self._tensorboard is not None and self.strategy.is_rank_0():
             self._tensorboard.close()
 
@@ -217,8 +230,11 @@ class RewardModelTrainer(ABC):
             if self._wandb is not None and self.strategy.is_rank_0():
                 logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
                 self._wandb.log(logs)
+            # Trackio
+            if self._trackio is not None and self.strategy.is_rank_0():
+                self._trackio.log_train(global_step, logs_dict)
             # TensorBoard
-            elif self._tensorboard is not None and self.strategy.is_rank_0():
+            if self._wandb is None and self._tensorboard is not None and self.strategy.is_rank_0():
                 for k, v in logs_dict.items():
                     self._tensorboard.add_scalar(f"train/{k}", v, global_step)
 
@@ -306,9 +322,11 @@ class RewardModelTrainer(ABC):
 
             if self.strategy.is_rank_0():
                 if self._wandb is not None:
-                    logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
-                    self._wandb.log(logs)
-                elif self._tensorboard is not None:
+                    wandb_logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
+                    self._wandb.log(wandb_logs)
+                if self._trackio is not None:
+                    self._trackio.log_eval(steps, logs)
+                if self._wandb is None and self._tensorboard is not None:
                     for k, v in logs.items():
                         self._tensorboard.add_scalar(f"eval/{k}", v, steps)
         self.model.train()  # reset model state

--- a/openrlhf/trainer/sft_trainer.py
+++ b/openrlhf/trainer/sft_trainer.py
@@ -69,8 +69,9 @@ class SFTTrainer(ABC):
         # packing samples
         self.packing_samples = strategy.args.ds.packing_samples
 
-        # wandb/tensorboard setting
+        # wandb/trackio/tensorboard setting
         self._wandb = None
+        self._trackio = None
         self._tensorboard = None
         if self.strategy.args.logger.wandb.key and self.strategy.is_rank_0():
             import wandb
@@ -91,6 +92,16 @@ class SFTTrainer(ABC):
             wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
             wandb.define_metric("eval/global_step")
             wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
+
+        # Initialize Trackio if configured
+        if (
+            getattr(self.strategy.args.logger, "trackio", None) is not None
+            and self.strategy.args.logger.trackio.project
+            and self.strategy.is_rank_0()
+        ):
+            from openrlhf.utils.logging_utils import TrackioLogger
+
+            self._trackio = TrackioLogger(strategy.args)
 
         # Initialize TensorBoard writer if wandb is not available
         if self.strategy.args.logger.tensorboard_dir and self._wandb is None and self.strategy.is_rank_0():
@@ -193,6 +204,8 @@ class SFTTrainer(ABC):
 
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()
+        if self._trackio is not None and self.strategy.is_rank_0():
+            self._trackio.close()
         if self._tensorboard is not None and self.strategy.is_rank_0():
             self._tensorboard.close()
 
@@ -205,8 +218,11 @@ class SFTTrainer(ABC):
             if self._wandb is not None and self.strategy.is_rank_0():
                 logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
                 self._wandb.log(logs)
+            # Trackio
+            if self._trackio is not None and self.strategy.is_rank_0():
+                self._trackio.log_train(global_step, logs_dict)
             # TensorBoard
-            elif self._tensorboard is not None and self.strategy.is_rank_0():
+            if self._wandb is None and self._tensorboard is not None and self.strategy.is_rank_0():
                 for k, v in logs_dict.items():
                     self._tensorboard.add_scalar(f"train/{k}", v, global_step)
 
@@ -262,9 +278,11 @@ class SFTTrainer(ABC):
 
             if self.strategy.is_rank_0():
                 if self._wandb is not None:
-                    logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
-                    self._wandb.log(logs)
-                elif self._tensorboard is not None:
+                    wandb_logs = {"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()}
+                    self._wandb.log(wandb_logs)
+                if self._trackio is not None:
+                    self._trackio.log_eval(steps, logs)
+                if self._wandb is None and self._tensorboard is not None:
                     for k, v in logs.items():
                         self._tensorboard.add_scalar(f"eval/{k}", v, steps)
         self.model.train()  # reset model state

--- a/openrlhf/utils/logging_utils.py
+++ b/openrlhf/utils/logging_utils.py
@@ -144,11 +144,13 @@ class TrackioLogger:
             self.handle.log({"train/generated_samples": trace}, step=global_step)
 
         metrics = {f"train/{k}": v for k, v in logs_dict.items() if v is not None}
-        self.handle.log(metrics, step=global_step)
+        if metrics:
+            self.handle.log(metrics, step=global_step)
 
     def log_eval(self, global_step: int, logs_dict: Dict[str, Any]) -> None:
         metrics = {f"eval/{k}": v for k, v in logs_dict.items() if v is not None}
-        self.handle.log(metrics, step=global_step)
+        if metrics:
+            self.handle.log(metrics, step=global_step)
 
     def close(self) -> None:
         self.handle.finish()

--- a/openrlhf/utils/logging_utils.py
+++ b/openrlhf/utils/logging_utils.py
@@ -137,7 +137,11 @@ class TrackioLogger:
         generated_samples = logs_dict.pop("generated_samples", None)
         if generated_samples:
             text, reward = generated_samples
-            self.handle.log({"train/generated_samples": f"{text}\n\nReward: {reward:.4f}"}, step=global_step)
+            trace = self.handle.Trace(
+                messages=[{"role": "assistant", "content": str(text)}],
+                metadata={"reward": float(reward), "global_step": global_step},
+            )
+            self.handle.log({"train/generated_samples": trace}, step=global_step)
 
         metrics = {f"train/{k}": v for k, v in logs_dict.items() if v is not None}
         self.handle.log(metrics, step=global_step)

--- a/openrlhf/utils/logging_utils.py
+++ b/openrlhf/utils/logging_utils.py
@@ -109,6 +109,47 @@ class WandbLogger:
         self.handle.finish()
 
 
+class TrackioLogger:
+    """Handle Trackio setup and training-time logging.
+
+    Trackio (https://github.com/gradio-app/trackio) is a lightweight, local-first
+    experiment tracker with a wandb-compatible API.
+    """
+
+    def __init__(self, args) -> None:
+        import trackio
+
+        init_kwargs = {
+            "project": args.logger.trackio.project,
+            "config": args.__dict__,
+        }
+        if getattr(args.logger.trackio, "name", None):
+            init_kwargs["name"] = args.logger.trackio.name
+        if getattr(args.logger.trackio, "group", None):
+            init_kwargs["group"] = args.logger.trackio.group
+        if getattr(args.logger.trackio, "space_id", None):
+            init_kwargs["space_id"] = args.logger.trackio.space_id
+        trackio.init(**init_kwargs)
+        self.handle = trackio
+
+    def log_train(self, global_step: int, logs_dict: Dict[str, Any]) -> None:
+        logs_dict = dict(logs_dict)
+        generated_samples = logs_dict.pop("generated_samples", None)
+        if generated_samples:
+            text, reward = generated_samples
+            self.handle.log({"train/generated_samples": f"{text}\n\nReward: {reward:.4f}"}, step=global_step)
+
+        metrics = {f"train/{k}": v for k, v in logs_dict.items() if v is not None}
+        self.handle.log(metrics, step=global_step)
+
+    def log_eval(self, global_step: int, logs_dict: Dict[str, Any]) -> None:
+        metrics = {f"eval/{k}": v for k, v in logs_dict.items() if v is not None}
+        self.handle.log(metrics, step=global_step)
+
+    def close(self) -> None:
+        self.handle.finish()
+
+
 class TensorboardLogger:
     """Handle tensorboard setup and training-time logging."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,8 +23,8 @@ torch
 torchdata
 torchmetrics
 tqdm
-transformers==5.5.4
 trackio
+transformers==5.5.4
 transformers_stream_generator
 wandb
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ torchdata
 torchmetrics
 tqdm
 transformers==5.5.4
+trackio
 transformers_stream_generator
 wandb
 wheel


### PR DESCRIPTION
## Summary
Adds [Trackio](https://github.com/gradio-app/trackio) as a third experiment-tracking backend alongside wandb and TensorBoard. Trackio is a free, local-first experiment tracking library, has a wandb-compatible API, defaults to local SQLite (no auth needed), and can optionally sync to a Hugging Face Space dashboard.

Enable from any train script:

```bash
python -m openrlhf.cli.train_sft \\
    --logger.trackio.project openrlhf-sft \\
    --logger.trackio.name my-run \\
    # --logger.trackio.space_id myorg/my-dashboard   # optional
    ...
```

## Changes
- `openrlhf/utils/logging_utils.py` — new `TrackioLogger` class mirroring `WandbLogger` (init / log_train / log_eval / close).
- `openrlhf/cli/train_{sft,dpo,rm,ppo_ray}.py` — new `--logger.trackio.*` flags.
- `openrlhf/trainer/{sft,dpo,rm,ppo,ppo_trainer_async}.py` — wire trackio init/log/close on rank 0 alongside the existing wandb/tensorboard paths.
- `requirements.txt` — add `trackio`.

Trackio logs *in addition to* wandb / tensorboard when configured, so existing runs are unaffected.