### PR TITLE
fix: drop empty optimizer param groups (LoRA + DS 0.18 + torch 2.10)

### DIFF
--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -123,24 +123,26 @@ def get_optimizer_grouped_parameters(
     weight_decay,
     no_decay_name_list=["bias", "layer_norm.weight", "layernorm.weight", "norm.weight", "ln_f.weight"],
 ):
-    optimizer_grouped_parameters = [
-        {
-            "params": [
-                p
-                for n, p in model.named_parameters()
-                if (not any(nd in n for nd in no_decay_name_list) and p.requires_grad)
-            ],
-            "weight_decay": weight_decay,
-        },
-        {
-            "params": [
-                p
-                for n, p in model.named_parameters()
-                if (any(nd in n for nd in no_decay_name_list) and p.requires_grad)
-            ],
-            "weight_decay": 0.0,
-        },
-    ]
+    decay_params = []
+    no_decay_params = []
+    for n, p in model.named_parameters():
+        if not p.requires_grad:
+            continue
+        if any(nd in n for nd in no_decay_name_list):
+            no_decay_params.append(p)
+        else:
+            decay_params.append(p)
+    # Drop empty groups so the LR scheduler's base_lrs matches the optimizer's
+    # param_groups after deepspeed.initialize, which strips empty groups (see
+    # DeepSpeed engine.py: `basic_optimizer.param_groups[:] = [pg for pg in
+    # basic_optimizer.param_groups if len(pg["params"]) != 0]`). Without this,
+    # LoRA runs hit `_update_lr` with strict=True zip mismatch — none of the
+    # LoRA adapter names match the no_decay list, leaving that group empty.
+    optimizer_grouped_parameters = []
+    if decay_params:
+        optimizer_grouped_parameters.append({"params": decay_params, "weight_decay": weight_decay})
+    if no_decay_params:
+        optimizer_grouped_parameters.append({"params": no_decay_params, "weight_decay": 0.0})
     return optimizer_grouped_parameters
 
 


### PR DESCRIPTION
Fixes #1225.

## Summary

`get_optimizer_grouped_parameters` always returns two groups (decay / no-decay), even when one is empty. Three things together make this crash on current LoRA + DeepSpeed + torch:

- **DeepSpeed ≥ 0.18** strips empty param groups in `engine.py`:
  ```python
  basic_optimizer.param_groups[:] = [pg for pg in basic_optimizer.param_groups if len(pg["params"]) != 0]
  ```
- **LoRA** with default `bias="none"` produces only `lora_A`/`lora_B` trainables — none of which match the `no_decay_name_list` (`bias`, `layer_norm.weight`, `layernorm.weight`, `norm.weight`, `ln_f.weight`). The no-decay group is therefore empty and gets stripped.
- **PyTorch ≥ 2.10** added `strict=True` to the `zip` in `LRScheduler._update_lr`, so the now-mismatched lengths (`base_lrs` size 2 vs `param_groups` size 1) raise instead of being silently truncated.

## Repro

LoRA DPO run with `--zero_stage 0 --bf16 --lora_rank N` on torch 2.10+ / DS 0.18+:

```
File ".../torch/optim/lr_scheduler.py", line 296, in _update_lr
    for param_group, lr in zip(self.optimizer.param_groups, values, strict=True):
ValueError: zip() argument 2 is longer than argument 1
```

Triggers on the first `optimizer.step()`. Pre-2.10 torch silently dropped the extra value, so this was a latent inconsistency that's now an error.

## Fix

Build the two groups, then only include the non-empty ones in the returned list. The optimizer never sees an empty group, so the scheduler's `base_lrs` matches whatever DeepSpeed keeps. No behavior change for full fine-tuning (both groups normally populated).

## Test plan

- [ ] LoRA DPO on torch 2.10+ / DS 0.18 — run completes the first optimizer step (was crashing)
- [ ] Full fine-tune (no LoRA) — both groups still present, training unchanged