### PR TITLE
Add TokenSpeed-backed PPO rollout engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,6 +498,7 @@ ray job submit --address="http://127.0.0.1:8265" \
 # --rollout.n_samples_per_prompt 4                            # Multiple samples per prompt
 # --rollout.vllm_generate_batch_size 2048                     # Oversample at generation (> rollout_batch_size); requires --train.async_enable
 # --algo.advantage.is_correction_enable                         # vLLM importance sampling correction for off-policy rollouts
+# --vllm.rollout_backend tokenspeed                              # Use TokenSpeed rollout backend
 # --algo.advantage.is_correction_type tis                       # Correction type: tis (token clamp) | icepop (token filter) | seq-mask-tis (seq-level geom mean)
 # --algo.advantage.is_correction_threshold 0.5 5.0               # IS truncation interval: [low, high]
 # --ckpt.best_metric_key eval_default_pass1                # Save best checkpoint by eval metric (empty = auto-detect first pass1, 'none' = disable)

--- a/README_zh.md
+++ b/README_zh.md
@@ -497,6 +497,7 @@ ray job submit --address="http://127.0.0.1:8265" \
 # --rollout.n_samples_per_prompt 4                            # 每个提示多个样本
 # --rollout.vllm_generate_batch_size 2048                     # 生成阶段过采样（> rollout_batch_size）；需要配合 --train.async_enable
 # --algo.advantage.is_correction_enable                         # vLLM 重要性采样修正，用于 off-policy rollout
+# --vllm.rollout_backend tokenspeed                              # 使用 TokenSpeed rollout 后端
 # --algo.advantage.is_correction_type tis                       # 修正类型：tis（token clamp）| icepop（token 过滤）| seq-mask-tis（序列级几何平均）
 # --algo.advantage.is_correction_threshold 0.5 5.0               # IS 截断区间：[low, high]
 # --ckpt.best_metric_key eval_default_pass1                # 按评估指标保存最佳检查点（留空自动探测首个 pass1，'none' 禁用）

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -6,6 +6,7 @@ import ray
 from ray.util.placement_group import placement_group
 
 from openrlhf.trainer.ray import create_vllm_engines
+from openrlhf.trainer.ray.vllm_engine import batch_vllm_engine_call
 from openrlhf.trainer.ray.launcher import (
     RayActorGroup,
     ReferenceModelActor,
@@ -63,23 +64,45 @@ def train(args):
                 f"and {args.vllm.num_engines * args.vllm.tensor_parallel_size}"
             )
 
-        vllm_engines = create_vllm_engines(
-            args.vllm.num_engines,
-            args.vllm.tensor_parallel_size,
-            args.actor.model_name_or_path,
-            args.train.seed,
-            args.train.full_determinism_enable,
-            args.vllm.enable_prefix_caching,
-            args.vllm.enforce_eager,
-            max_len,
-            pg if args.train.colocate_all and not args.train.async_enable else None,
-            args.vllm.gpu_memory_utilization,
-            args.vllm.enable_sleep,
-            "processed_logprobs" if args.algo.advantage.is_correction_enable else None,
-            agent_func_path=args.train.agent_func_path,
-            remote_rm_url=args.reward.remote_url,
-            max_images_per_prompt=getattr(args.data, "max_images_per_prompt", 0),
-        )
+        rollout_backend = getattr(args.vllm, "rollout_backend", "vllm")
+        if rollout_backend == "tokenspeed":
+            from openrlhf.trainer.ray.tokenspeed_engine import create_tokenspeed_engines
+
+            vllm_engines = create_tokenspeed_engines(
+                args.vllm.num_engines,
+                args.vllm.tensor_parallel_size,
+                args.actor.model_name_or_path,
+                args.train.seed,
+                args.train.full_determinism_enable,
+                args.vllm.enable_prefix_caching,
+                args.vllm.enforce_eager,
+                max_len,
+                pg if args.train.colocate_all and not args.train.async_enable else None,
+                args.vllm.gpu_memory_utilization,
+                args.vllm.enable_sleep,
+                "processed_logprobs" if args.algo.advantage.is_correction_enable else None,
+                agent_func_path=args.train.agent_func_path,
+                remote_rm_url=args.reward.remote_url,
+                max_images_per_prompt=getattr(args.data, "max_images_per_prompt", 0),
+            )
+        else:
+            vllm_engines = create_vllm_engines(
+                args.vllm.num_engines,
+                args.vllm.tensor_parallel_size,
+                args.actor.model_name_or_path,
+                args.train.seed,
+                args.train.full_determinism_enable,
+                args.vllm.enable_prefix_caching,
+                args.vllm.enforce_eager,
+                max_len,
+                pg if args.train.colocate_all and not args.train.async_enable else None,
+                args.vllm.gpu_memory_utilization,
+                args.vllm.enable_sleep,
+                "processed_logprobs" if args.algo.advantage.is_correction_enable else None,
+                agent_func_path=args.train.agent_func_path,
+                remote_rm_url=args.reward.remote_url,
+                max_images_per_prompt=getattr(args.data, "max_images_per_prompt", 0),
+            )
 
     actor_model = RayActorGroup(
         args.actor.num_nodes,
@@ -246,6 +269,13 @@ if __name__ == "__main__":
         action="store_true",
         default=False,
         help="Enable sleep mode for vLLM when using --colocate_all_models",
+    )
+    parser.add_argument(
+        "--vllm.rollout_backend",
+        type=str,
+        default="vllm",
+        choices=["vllm", "tokenspeed"],
+        help="Rollout engine backend: vllm (default) or tokenspeed",
     )
     parser.add_argument(
         "--vllm.gpu_memory_utilization",

--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -6,7 +6,6 @@ import ray
 from ray.util.placement_group import placement_group
 
 from openrlhf.trainer.ray import create_vllm_engines
-from openrlhf.trainer.ray.vllm_engine import batch_vllm_engine_call
 from openrlhf.trainer.ray.launcher import (
     RayActorGroup,
     ReferenceModelActor,

--- a/openrlhf/trainer/ray/__init__.py
+++ b/openrlhf/trainer/ray/__init__.py
@@ -1,7 +1,16 @@
-# No implicit imports of deepspeed here to avoid vllm environment gets comtaminated
+# No implicit imports of deepspeed here to avoid vllm environment gets contaminated
 from .vllm_engine import batch_vllm_engine_call, create_vllm_engines
 
 __all__ = [
     "create_vllm_engines",
     "batch_vllm_engine_call",
 ]
+
+# TokenSpeed backend — lazy import to avoid hard dependency
+try:
+    from .tokenspeed_engine import batch_engine_call as batch_tokenspeed_engine_call
+    from .tokenspeed_engine import create_tokenspeed_engines
+
+    __all__ += ["create_tokenspeed_engines", "batch_tokenspeed_engine_call"]
+except ImportError:
+    pass

--- a/openrlhf/trainer/ray/tokenspeed_engine.py
+++ b/openrlhf/trainer/ray/tokenspeed_engine.py
@@ -67,9 +67,7 @@ def _torch_dtype_name(dtype) -> str:
 
 def _select_ipc_handle(ipc_handles: dict[int, Any], gpu_id: int):
     if gpu_id not in ipc_handles:
-        raise RuntimeError(
-            f"GPU ID {gpu_id} not found in ipc_handles; available GPU IDs: {sorted(ipc_handles)}"
-        )
+        raise RuntimeError(f"GPU ID {gpu_id} not found in ipc_handles; available GPU IDs: {sorted(ipc_handles)}")
     return ipc_handles[gpu_id]
 
 

--- a/openrlhf/trainer/ray/tokenspeed_engine.py
+++ b/openrlhf/trainer/ray/tokenspeed_engine.py
@@ -119,9 +119,7 @@ def _tokenspeed_logprobs(meta_info: dict[str, Any], token_ids: list[int]):
     if raw_logprobs is None:
         raise RuntimeError("TokenSpeed did not return output token logprobs")
     if len(raw_logprobs) != len(token_ids):
-        raise RuntimeError(
-            f"TokenSpeed returned {len(raw_logprobs)} logprobs for {len(token_ids)} generated tokens"
-        )
+        raise RuntimeError(f"TokenSpeed returned {len(raw_logprobs)} logprobs for {len(token_ids)} generated tokens")
 
     converted = []
     for token_id, raw in zip(token_ids, raw_logprobs):

--- a/openrlhf/trainer/ray/tokenspeed_engine.py
+++ b/openrlhf/trainer/ray/tokenspeed_engine.py
@@ -1,0 +1,335 @@
+"""TokenSpeed rollout engine for OpenRLHF.
+
+Provides the same Ray actor interface as ``vllm_engine.py`` so that
+``SamplesGenerator``, ``ActorPPOTrainer``, and the CLI can treat TokenSpeed
+and vLLM interchangeably.
+
+TokenSpeed exposes weight-update and memory-management RPCs that map
+one-to-one to the vLLM APIs OpenRLHF already depends on:
+
+    vLLM                          TokenSpeed
+    ─────────────────────────     ──────────────────────────────────
+    init_process_group            init_weights_update_group
+    update_weight                 update_weights_from_distributed
+    sleep / wake_up               release / resume_memory_occupation
+    AsyncLLMEngine.generate       tokenspeed Engine.generate
+"""
+
+import asyncio
+import os
+from copy import deepcopy
+from typing import Any, List, Optional
+
+import ray
+from ray.util.placement_group import placement_group
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+from openrlhf.utils.agent import AgentExecutorBase, SingleTurnAgentExecutor
+
+from .utils import get_bundle_indices, ray_noset_visible_devices
+
+
+def _load_agent_executor(agent_func_path: str) -> AgentExecutorBase:
+    assert agent_func_path.endswith(".py"), "Agent path must be a Python file"
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("agent_module", agent_func_path)
+    agent_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(agent_module)
+
+    assert hasattr(agent_module, "AgentExecutor"), "Agent module must contain AgentExecutor class"
+    agent_executor_cls = agent_module.AgentExecutor
+    assert issubclass(agent_executor_cls, AgentExecutorBase), "AgentExecutor must inherit from AgentExecutorBase"
+    return agent_executor_cls()
+
+
+@ray.remote
+class TokenSpeedRolloutActor:
+    """Async TokenSpeed-backed actor that mirrors ``RolloutRayActor``."""
+
+    async def __init__(
+        self,
+        *args,
+        bundle_indices: list = None,
+        agent_func_path: Optional[str] = None,
+        remote_rm_url: Optional[str] = None,
+        mm_pad_token_ids: Optional[set] = None,
+        **kwargs,
+    ):
+        num_gpus = kwargs.pop("num_gpus")
+        self._configure_device_env(
+            backend=kwargs.get("distributed_executor_backend"),
+            bundle_indices=bundle_indices,
+            num_gpus=num_gpus,
+        )
+
+        if agent_func_path:
+            self.executor = _load_agent_executor(agent_func_path)
+        else:
+            self.executor = SingleTurnAgentExecutor(remote_rm_url)
+
+        self._mm_pad_token_ids = mm_pad_token_ids
+
+        # Import tokenspeed lazily so it doesn't pollute other Ray actors.
+        from tokenspeed.runtime.entrypoints.engine import Engine
+
+        self.engine = Engine(*args, **kwargs)
+        self.tokenizer = self.engine.get_tokenizer()
+
+    def _configure_device_env(self, backend, bundle_indices, num_gpus):
+        if backend == "ray":
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+            os.environ.pop("ROCR_VISIBLE_DEVICES", None)
+            os.environ.pop("HIP_VISIBLE_DEVICES", None)
+        elif ray_noset_visible_devices():
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
+
+        if bundle_indices is not None:
+            os.environ["TOKENSPEED_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
+            print(f"creating TokenSpeed engine with bundle_indices={bundle_indices}")
+
+    # ------------------------------------------------------------------
+    # Weight synchronisation — maps to TokenSpeed's distributed API
+    # ------------------------------------------------------------------
+
+    async def init_process_group(
+        self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray
+    ):
+        """Initialise NCCL process group for DeepSpeed -> TokenSpeed weight sync."""
+        success, msg = self.engine.init_weights_update_group(
+            master_address=master_address,
+            master_port=master_port,
+            rank_offset=rank_offset,
+            world_size=world_size,
+            group_name=group_name,
+            backend=backend,
+        )
+        if not success:
+            raise RuntimeError(f"TokenSpeed init_weights_update_group failed: {msg}")
+
+    async def update_weight(self, name, dtype, shape, empty_cache=False):
+        """Receive a single weight tensor via the NCCL group."""
+        success, msg = self.engine.update_weights_from_distributed(
+            name=name,
+            dtype=str(dtype),
+            shape=list(shape),
+        )
+        if not success:
+            raise RuntimeError(f"TokenSpeed update_weight failed for {name}: {msg}")
+
+    async def update_weight_cuda_ipc(self, name, dtype, shape, ipc_handles, empty_cache=False):
+        """IPC weight path — convert to tensor and call ``update_weights_from_tensor``."""
+        import torch
+        from openrlhf.trainer.ray.utils import get_physical_gpu_id
+
+        handle = ipc_handles[get_physical_gpu_id()]
+        func, handle_args = handle
+        args_list = list(handle_args)
+        args_list[6] = torch.cuda.current_device()
+        weight = func(*args_list)
+
+        import pickle
+
+        serialized = pickle.dumps({name: weight})
+        success, msg = self.engine.update_weights_from_tensor(
+            serialized_named_tensors=serialized,
+            load_format=None,
+            flush_cache=empty_cache,
+        )
+        torch.cuda.synchronize()
+        if not success:
+            raise RuntimeError(f"TokenSpeed update_weight_cuda_ipc failed for {name}: {msg}")
+
+    # ------------------------------------------------------------------
+    # Memory management — maps to sleep / wake_up
+    # ------------------------------------------------------------------
+
+    async def sleep(self, level=1):
+        """Release GPU memory (KV cache, optionally weights)."""
+        self.engine.release_memory_occupation()
+
+    async def wake_up(self, tags=None):
+        """Resume GPU memory occupation."""
+        if tags is None:
+            tags = ["weights", "kv_cache"]
+        self.engine.resume_memory_occupation()
+
+    async def reset_prefix_cache(self):
+        """Flush the prefix / KV cache."""
+        # TokenSpeed scheduler manages KV cache via its C++ FSM.
+        # A full flush is equivalent to aborting all cached state.
+        pass
+
+    async def pause_generation(self):
+        """Pause in-flight generation (for partial rollout weight sync)."""
+        pass
+
+    async def resume_generation(self):
+        """Resume generation after pause."""
+        pass
+
+    # ------------------------------------------------------------------
+    # Generation — mirrors the vLLM actor interface
+    # ------------------------------------------------------------------
+
+    async def generate(self, prompt_token_ids, sampling_params, multi_modal_data=None):
+        """Token-level generation compatible with ``SamplesGenerator``."""
+        if multi_modal_data and self._mm_pad_token_ids:
+            from openrlhf.utils.vlm_utils import dedup_media_tokens
+
+            prompt_token_ids = dedup_media_tokens(prompt_token_ids, self._mm_pad_token_ids)
+
+        # Convert vLLM SamplingParams to a plain dict that TokenSpeed accepts.
+        gen_kwargs = {
+            "temperature": getattr(sampling_params, "temperature", 1.0),
+            "top_p": getattr(sampling_params, "top_p", 1.0),
+            "top_k": getattr(sampling_params, "top_k", -1),
+            "max_new_tokens": getattr(sampling_params, "max_tokens", 512),
+            "min_new_tokens": getattr(sampling_params, "min_tokens", 1),
+            "skip_special_tokens": getattr(sampling_params, "skip_special_tokens", False),
+        }
+
+        logprobs_k = getattr(sampling_params, "logprobs", None)
+
+        output = self.engine.generate(
+            prompt_token_ids=prompt_token_ids,
+            sampling_params=gen_kwargs,
+            logprobs=logprobs_k,
+        )
+        return output
+
+    def get_num_unfinished_requests(self) -> int:
+        return 0
+
+    async def generate_responses(
+        self,
+        prompt: str,
+        label: str,
+        sampling_params,
+        max_length: int,
+        hf_tokenizer,
+        num_samples: int = 1,
+        images=None,
+    ):
+        """Generate N samples for a single prompt."""
+        tasks = [
+            self.executor.execute(
+                prompt=prompt,
+                label=label,
+                sampling_params=sampling_params,
+                max_length=max_length,
+                hf_tokenizer=hf_tokenizer,
+                llm_engine=self,
+                images=images,
+            )
+            for _ in range(num_samples)
+        ]
+        return await asyncio.gather(*tasks)
+
+
+# ------------------------------------------------------------------
+# Factory — mirrors ``create_vllm_engines``
+# ------------------------------------------------------------------
+
+
+def create_tokenspeed_engines(
+    num_engines: int,
+    tensor_parallel_size: int,
+    pretrain: str,
+    seed: int,
+    full_determinism: bool,
+    enable_prefix_caching: bool,
+    enforce_eager: bool,
+    max_model_len: int,
+    shared_pg=None,
+    gpu_memory_utilization=None,
+    enable_sleep=False,
+    logprobs_mode=None,
+    agent_func_path: Optional[str] = None,
+    remote_rm_url: Optional[str] = None,
+    max_images_per_prompt: int = 0,
+):
+    """Spin up TokenSpeed Ray actors with the same placement logic as vLLM."""
+    mm_pad_token_ids: set = set()
+    if max_images_per_prompt > 0:
+        from transformers import AutoProcessor
+
+        processor = AutoProcessor.from_pretrained(pretrain, trust_remote_code=True)
+        for attr in ("image_token_id", "video_token_id"):
+            tid = getattr(processor, attr, None)
+            if tid is not None:
+                mm_pad_token_ids.add(tid)
+        del processor
+
+    engines = []
+    distributed_executor_backend = "uni" if tensor_parallel_size == 1 else "ray"
+    use_hybrid_engine = shared_pg is not None
+    num_gpus = int(tensor_parallel_size == 1)
+    if use_hybrid_engine and tensor_parallel_size == 1:
+        num_gpus = 0.2
+
+    if not use_hybrid_engine:
+        bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_engines * tensor_parallel_size)]
+        shared_pg = placement_group(bundles, strategy="PACK")
+        ray.get(shared_pg.ready())
+
+    for i in range(num_engines):
+        bundle_indices = None
+        if tensor_parallel_size > 1:
+            bundle_indices = get_bundle_indices(shared_pg, i, tensor_parallel_size)
+
+        scheduling_strategy = PlacementGroupSchedulingStrategy(
+            placement_group=shared_pg,
+            placement_group_capture_child_tasks=True,
+            placement_group_bundle_index=bundle_indices[0] if bundle_indices else i,
+        )
+
+        actor_kwargs = {
+            "model": pretrain,
+            "enforce_eager": enforce_eager,
+            "tensor_parallel_size": tensor_parallel_size,
+            "seed": seed + i,
+            "distributed_executor_backend": distributed_executor_backend,
+            "max_model_len": max_model_len,
+            "enable_prefix_caching": enable_prefix_caching,
+            "dtype": "bfloat16",
+            "trust_remote_code": True,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "bundle_indices": bundle_indices,
+            "num_gpus": 0.2 if use_hybrid_engine else 1,
+            "agent_func_path": agent_func_path,
+            "remote_rm_url": remote_rm_url,
+            "mm_pad_token_ids": mm_pad_token_ids,
+        }
+
+        if max_images_per_prompt > 0:
+            actor_kwargs["limit_mm_per_prompt"] = {"image": max_images_per_prompt}
+
+        engines.append(
+            TokenSpeedRolloutActor.options(
+                num_cpus=num_gpus,
+                num_gpus=num_gpus,
+                scheduling_strategy=scheduling_strategy,
+            ).remote(**actor_kwargs)
+        )
+
+    if enable_sleep:
+        batch_engine_call(engines, "sleep")
+
+    return engines
+
+
+def batch_engine_call(engines: List[Any], method_name: str, *args, rank_0_only: bool = True, **kwargs):
+    """Call the same method on a list of engines and gather results."""
+    import torch
+
+    if torch.distributed.is_initialized():
+        if rank_0_only and torch.distributed.get_rank() != 0:
+            return None
+
+    refs = []
+    for engine in engines:
+        method = getattr(engine, method_name)
+        refs.append(method.remote(*args, **kwargs))
+
+    return ray.get(refs)

--- a/openrlhf/trainer/ray/tokenspeed_engine.py
+++ b/openrlhf/trainer/ray/tokenspeed_engine.py
@@ -17,7 +17,7 @@ one-to-one to the vLLM APIs OpenRLHF already depends on:
 
 import asyncio
 import os
-from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 import ray
@@ -26,7 +26,25 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from openrlhf.utils.agent import AgentExecutorBase, SingleTurnAgentExecutor
 
-from .utils import get_bundle_indices, ray_noset_visible_devices
+from .utils import ray_noset_visible_devices
+
+
+@dataclass
+class _TokenSpeedLogprob:
+    logprob: float
+
+
+@dataclass
+class _TokenSpeedCompletionOutput:
+    token_ids: list[int]
+    text: str
+    finish_reason: Optional[str]
+    logprobs: Optional[list[dict[int, _TokenSpeedLogprob]]] = None
+
+
+@dataclass
+class _TokenSpeedRequestOutput:
+    outputs: list[_TokenSpeedCompletionOutput]
 
 
 def _load_agent_executor(agent_func_path: str) -> AgentExecutorBase:
@@ -43,6 +61,115 @@ def _load_agent_executor(agent_func_path: str) -> AgentExecutorBase:
     return agent_executor_cls()
 
 
+def _torch_dtype_name(dtype) -> str:
+    return str(dtype).removeprefix("torch.")
+
+
+def _tokenspeed_sampling_params(sampling_params) -> dict[str, Any]:
+    max_tokens = getattr(sampling_params, "max_tokens", None)
+    if max_tokens is None:
+        raise ValueError("TokenSpeed rollout requires sampling_params.max_tokens to be set")
+
+    params = {"max_new_tokens": max_tokens}
+    attr_map = {
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "top_k": "top_k",
+        "min_p": "min_p",
+        "min_tokens": "min_new_tokens",
+        "presence_penalty": "presence_penalty",
+        "frequency_penalty": "frequency_penalty",
+        "repetition_penalty": "repetition_penalty",
+        "skip_special_tokens": "skip_special_tokens",
+        "spaces_between_special_tokens": "spaces_between_special_tokens",
+        "stop": "stop",
+        "stop_token_ids": "stop_token_ids",
+        "ignore_eos": "ignore_eos",
+        "seed": "seed",
+    }
+    for source, target in attr_map.items():
+        value = getattr(sampling_params, source, None)
+        if value is not None:
+            params[target] = value
+
+    return params
+
+
+def _tokenspeed_image_data(multi_modal_data):
+    if multi_modal_data is None:
+        return None
+
+    unsupported = set(multi_modal_data) - {"image"}
+    if unsupported:
+        raise NotImplementedError(f"TokenSpeed rollout does not support multimodal keys: {sorted(unsupported)}")
+
+    return multi_modal_data.get("image")
+
+
+def _finish_reason_from_tokenspeed(reason) -> Optional[str]:
+    if reason is None:
+        return None
+    if isinstance(reason, dict):
+        return reason.get("type")
+    return str(reason)
+
+
+def _tokenspeed_logprobs(meta_info: dict[str, Any], token_ids: list[int]):
+    raw_logprobs = meta_info.get("output_token_logprobs")
+    if raw_logprobs is None:
+        raise RuntimeError("TokenSpeed did not return output token logprobs")
+    if len(raw_logprobs) != len(token_ids):
+        raise RuntimeError(
+            f"TokenSpeed returned {len(raw_logprobs)} logprobs for {len(token_ids)} generated tokens"
+        )
+
+    converted = []
+    for token_id, raw in zip(token_ids, raw_logprobs):
+        if isinstance(raw, dict):
+            logged_token_id = raw.get("token_id", token_id)
+            logprob = raw.get("logprob")
+        elif isinstance(raw, (list, tuple)) and len(raw) >= 2:
+            logprob, logged_token_id = raw[0], raw[1]
+        else:
+            raise TypeError(f"Unsupported TokenSpeed logprob entry: {raw!r}")
+
+        if int(logged_token_id) != int(token_id):
+            raise RuntimeError(
+                f"TokenSpeed logprob token id {logged_token_id} does not match output token id {token_id}"
+            )
+        converted.append({int(token_id): _TokenSpeedLogprob(float(logprob))})
+
+    return converted
+
+
+def _adapt_tokenspeed_output(output: dict[str, Any] | list[dict[str, Any]], require_logprobs: bool):
+    if isinstance(output, list):
+        if len(output) != 1:
+            raise ValueError(f"Expected one TokenSpeed generation output, got {len(output)}")
+        output = output[0]
+    if not isinstance(output, dict):
+        raise TypeError(f"Expected TokenSpeed generation output to be a dict, got {type(output)!r}")
+    if "text" not in output:
+        raise ValueError("TokenSpeed generation output is missing text")
+    if "output_ids" not in output:
+        raise ValueError("TokenSpeed generation output is missing output_ids")
+
+    token_ids = list(output["output_ids"])
+    meta_info = output.get("meta_info") or {}
+    logprobs = _tokenspeed_logprobs(meta_info, token_ids) if require_logprobs else None
+
+    return _TokenSpeedRequestOutput(
+        outputs=[
+            _TokenSpeedCompletionOutput(
+                token_ids=token_ids,
+                text=output["text"],
+                finish_reason=_finish_reason_from_tokenspeed(meta_info.get("finish_reason")),
+                logprobs=logprobs,
+            )
+        ]
+    )
+
+
 @ray.remote
 class TokenSpeedRolloutActor:
     """Async TokenSpeed-backed actor that mirrors ``RolloutRayActor``."""
@@ -57,8 +184,9 @@ class TokenSpeedRolloutActor:
         **kwargs,
     ):
         num_gpus = kwargs.pop("num_gpus")
+        distributed_executor_backend = kwargs.pop("distributed_executor_backend", None)
         self._configure_device_env(
-            backend=kwargs.get("distributed_executor_backend"),
+            backend=distributed_executor_backend,
             bundle_indices=bundle_indices,
             num_gpus=num_gpus,
         )
@@ -69,24 +197,27 @@ class TokenSpeedRolloutActor:
             self.executor = SingleTurnAgentExecutor(remote_rm_url)
 
         self._mm_pad_token_ids = mm_pad_token_ids
+        self._num_unfinished_requests = 0
+        self._generation_resumed = asyncio.Event()
+        self._generation_resumed.set()
 
         # Import tokenspeed lazily so it doesn't pollute other Ray actors.
         from tokenspeed.runtime.entrypoints.engine import Engine
 
         self.engine = Engine(*args, **kwargs)
-        self.tokenizer = self.engine.get_tokenizer()
 
     def _configure_device_env(self, backend, bundle_indices, num_gpus):
-        if backend == "ray":
-            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
-            os.environ.pop("ROCR_VISIBLE_DEVICES", None)
-            os.environ.pop("HIP_VISIBLE_DEVICES", None)
-        elif ray_noset_visible_devices():
-            os.environ["CUDA_VISIBLE_DEVICES"] = str(ray.get_gpu_ids()[0])
+        if ray_noset_visible_devices():
+            gpu_ids = ray.get_gpu_ids()
+            if gpu_ids:
+                os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpu_ids))
 
         if bundle_indices is not None:
             os.environ["TOKENSPEED_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
             print(f"creating TokenSpeed engine with bundle_indices={bundle_indices}")
+
+    def _run_tokenizer_manager(self, coroutine):
+        return self.engine.llm.run(coroutine)
 
     # ------------------------------------------------------------------
     # Weight synchronisation — maps to TokenSpeed's distributed API
@@ -96,7 +227,12 @@ class TokenSpeedRolloutActor:
         self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray
     ):
         """Initialise NCCL process group for DeepSpeed -> TokenSpeed weight sync."""
-        success, msg = self.engine.init_weights_update_group(
+        if use_ray:
+            raise NotImplementedError("TokenSpeed rollout weight sync does not support Ray collective mode")
+
+        from tokenspeed.runtime.engine.io_struct import InitWeightsUpdateGroupReqInput
+
+        obj = InitWeightsUpdateGroupReqInput(
             master_address=master_address,
             master_port=master_port,
             rank_offset=rank_offset,
@@ -104,16 +240,20 @@ class TokenSpeedRolloutActor:
             group_name=group_name,
             backend=backend,
         )
+        success, msg = self._run_tokenizer_manager(self.engine.tokenizer_manager.init_weights_update_group(obj))
         if not success:
             raise RuntimeError(f"TokenSpeed init_weights_update_group failed: {msg}")
 
     async def update_weight(self, name, dtype, shape, empty_cache=False):
         """Receive a single weight tensor via the NCCL group."""
-        success, msg = self.engine.update_weights_from_distributed(
+        from tokenspeed.runtime.engine.io_struct import UpdateWeightsFromDistributedReqInput
+
+        obj = UpdateWeightsFromDistributedReqInput(
             name=name,
-            dtype=str(dtype),
+            dtype=_torch_dtype_name(dtype),
             shape=list(shape),
         )
+        success, msg = self._run_tokenizer_manager(self.engine.tokenizer_manager.update_weights_from_distributed(obj))
         if not success:
             raise RuntimeError(f"TokenSpeed update_weight failed for {name}: {msg}")
 
@@ -128,11 +268,8 @@ class TokenSpeedRolloutActor:
         args_list[6] = torch.cuda.current_device()
         weight = func(*args_list)
 
-        import pickle
-
-        serialized = pickle.dumps({name: weight})
         success, msg = self.engine.update_weights_from_tensor(
-            serialized_named_tensors=serialized,
+            named_tensors=[(name, weight)],
             load_format=None,
             flush_cache=empty_cache,
         )
@@ -146,27 +283,31 @@ class TokenSpeedRolloutActor:
 
     async def sleep(self, level=1):
         """Release GPU memory (KV cache, optionally weights)."""
-        self.engine.release_memory_occupation()
+        from tokenspeed.runtime.engine.io_struct import ReleaseMemoryOccupationReqInput
+
+        obj = ReleaseMemoryOccupationReqInput()
+        self._run_tokenizer_manager(self.engine.tokenizer_manager.release_memory_occupation(obj))
 
     async def wake_up(self, tags=None):
         """Resume GPU memory occupation."""
-        if tags is None:
-            tags = ["weights", "kv_cache"]
-        self.engine.resume_memory_occupation()
+        from tokenspeed.runtime.engine.io_struct import ResumeMemoryOccupationReqInput
+
+        obj = ResumeMemoryOccupationReqInput()
+        self._run_tokenizer_manager(self.engine.tokenizer_manager.resume_memory_occupation(obj))
 
     async def reset_prefix_cache(self):
         """Flush the prefix / KV cache."""
-        # TokenSpeed scheduler manages KV cache via its C++ FSM.
-        # A full flush is equivalent to aborting all cached state.
-        pass
+        result = self.engine.flush_cache()
+        if not getattr(result, "success", False):
+            raise RuntimeError("TokenSpeed flush_cache failed")
 
     async def pause_generation(self):
         """Pause in-flight generation (for partial rollout weight sync)."""
-        pass
+        self._generation_resumed.clear()
 
     async def resume_generation(self):
         """Resume generation after pause."""
-        pass
+        self._generation_resumed.set()
 
     # ------------------------------------------------------------------
     # Generation — mirrors the vLLM actor interface
@@ -174,32 +315,31 @@ class TokenSpeedRolloutActor:
 
     async def generate(self, prompt_token_ids, sampling_params, multi_modal_data=None):
         """Token-level generation compatible with ``SamplesGenerator``."""
+        await self._generation_resumed.wait()
         if multi_modal_data and self._mm_pad_token_ids:
             from openrlhf.utils.vlm_utils import dedup_media_tokens
 
             prompt_token_ids = dedup_media_tokens(prompt_token_ids, self._mm_pad_token_ids)
 
-        # Convert vLLM SamplingParams to a plain dict that TokenSpeed accepts.
-        gen_kwargs = {
-            "temperature": getattr(sampling_params, "temperature", 1.0),
-            "top_p": getattr(sampling_params, "top_p", 1.0),
-            "top_k": getattr(sampling_params, "top_k", -1),
-            "max_new_tokens": getattr(sampling_params, "max_tokens", 512),
-            "min_new_tokens": getattr(sampling_params, "min_tokens", 1),
-            "skip_special_tokens": getattr(sampling_params, "skip_special_tokens", False),
-        }
+        require_logprobs = getattr(sampling_params, "logprobs", None) is not None
+        self._num_unfinished_requests += 1
+        try:
+            output = await asyncio.to_thread(
+                self.engine.generate,
+                input_ids=list(prompt_token_ids),
+                image_data=_tokenspeed_image_data(multi_modal_data),
+                sampling_params=_tokenspeed_sampling_params(sampling_params),
+                return_logprob=require_logprobs,
+                logprob_start_len=-1 if require_logprobs else None,
+                top_logprobs_num=0,
+            )
+        finally:
+            self._num_unfinished_requests -= 1
 
-        logprobs_k = getattr(sampling_params, "logprobs", None)
-
-        output = self.engine.generate(
-            prompt_token_ids=prompt_token_ids,
-            sampling_params=gen_kwargs,
-            logprobs=logprobs_k,
-        )
-        return output
+        return _adapt_tokenspeed_output(output, require_logprobs=require_logprobs)
 
     def get_num_unfinished_requests(self) -> int:
-        return 0
+        return self._num_unfinished_requests
 
     async def generate_responses(
         self,
@@ -250,6 +390,10 @@ def create_tokenspeed_engines(
     max_images_per_prompt: int = 0,
 ):
     """Spin up TokenSpeed Ray actors with the same placement logic as vLLM."""
+    use_hybrid_engine = shared_pg is not None
+    if use_hybrid_engine and tensor_parallel_size > 1:
+        raise ValueError("TokenSpeed rollout does not support colocated tensor_parallel_size > 1")
+
     mm_pad_token_ids: set = set()
     if max_images_per_prompt > 0:
         from transformers import AutoProcessor
@@ -262,53 +406,44 @@ def create_tokenspeed_engines(
         del processor
 
     engines = []
-    distributed_executor_backend = "uni" if tensor_parallel_size == 1 else "ray"
-    use_hybrid_engine = shared_pg is not None
-    num_gpus = int(tensor_parallel_size == 1)
-    if use_hybrid_engine and tensor_parallel_size == 1:
-        num_gpus = 0.2
+    actor_num_gpus = 0.2 if use_hybrid_engine else tensor_parallel_size
+    actor_num_cpus = actor_num_gpus
 
     if not use_hybrid_engine:
-        bundles = [{"GPU": 1, "CPU": 1} for _ in range(num_engines * tensor_parallel_size)]
+        bundles = [{"GPU": tensor_parallel_size, "CPU": max(1, tensor_parallel_size)} for _ in range(num_engines)]
         shared_pg = placement_group(bundles, strategy="PACK")
         ray.get(shared_pg.ready())
 
     for i in range(num_engines):
-        bundle_indices = None
-        if tensor_parallel_size > 1:
-            bundle_indices = get_bundle_indices(shared_pg, i, tensor_parallel_size)
-
         scheduling_strategy = PlacementGroupSchedulingStrategy(
             placement_group=shared_pg,
             placement_group_capture_child_tasks=True,
-            placement_group_bundle_index=bundle_indices[0] if bundle_indices else i,
+            placement_group_bundle_index=i,
         )
 
         actor_kwargs = {
             "model": pretrain,
             "enforce_eager": enforce_eager,
-            "tensor_parallel_size": tensor_parallel_size,
             "seed": seed + i,
-            "distributed_executor_backend": distributed_executor_backend,
             "max_model_len": max_model_len,
             "enable_prefix_caching": enable_prefix_caching,
             "dtype": "bfloat16",
             "trust_remote_code": True,
             "gpu_memory_utilization": gpu_memory_utilization,
-            "bundle_indices": bundle_indices,
-            "num_gpus": 0.2 if use_hybrid_engine else 1,
+            "world_size": tensor_parallel_size,
+            "nprocs_per_node": tensor_parallel_size,
+            "attn_tp_size": tensor_parallel_size,
+            "enable_output_logprobs": bool(logprobs_mode),
+            "num_gpus": actor_num_gpus,
             "agent_func_path": agent_func_path,
             "remote_rm_url": remote_rm_url,
             "mm_pad_token_ids": mm_pad_token_ids,
         }
 
-        if max_images_per_prompt > 0:
-            actor_kwargs["limit_mm_per_prompt"] = {"image": max_images_per_prompt}
-
         engines.append(
             TokenSpeedRolloutActor.options(
-                num_cpus=num_gpus,
-                num_gpus=num_gpus,
+                num_cpus=actor_num_cpus,
+                num_gpus=actor_num_gpus,
                 scheduling_strategy=scheduling_strategy,
             ).remote(**actor_kwargs)
         )

--- a/openrlhf/trainer/ray/tokenspeed_engine.py
+++ b/openrlhf/trainer/ray/tokenspeed_engine.py
@@ -65,6 +65,14 @@ def _torch_dtype_name(dtype) -> str:
     return str(dtype).removeprefix("torch.")
 
 
+def _select_ipc_handle(ipc_handles: dict[int, Any], gpu_id: int):
+    if gpu_id not in ipc_handles:
+        raise RuntimeError(
+            f"GPU ID {gpu_id} not found in ipc_handles; available GPU IDs: {sorted(ipc_handles)}"
+        )
+    return ipc_handles[gpu_id]
+
+
 def _tokenspeed_sampling_params(sampling_params) -> dict[str, Any]:
     max_tokens = getattr(sampling_params, "max_tokens", None)
     if max_tokens is None:
@@ -260,7 +268,7 @@ class TokenSpeedRolloutActor:
         import torch
         from openrlhf.trainer.ray.utils import get_physical_gpu_id
 
-        handle = ipc_handles[get_physical_gpu_id()]
+        handle = _select_ipc_handle(ipc_handles, get_physical_gpu_id())
         func, handle_args = handle
         args_list = list(handle_args)
         args_list[6] = torch.cuda.current_device()

--- a/tests/test_tokenspeed_engine.py
+++ b/tests/test_tokenspeed_engine.py
@@ -67,6 +67,17 @@ def _load_tokenspeed_engine_module():
 tokenspeed_engine = _load_tokenspeed_engine_module()
 
 
+def test_select_ipc_handle_returns_matching_handle():
+    handle = object()
+
+    assert tokenspeed_engine._select_ipc_handle({2: handle}, 2) is handle
+
+
+def test_select_ipc_handle_fails_when_gpu_id_is_missing():
+    with pytest.raises(RuntimeError, match="GPU ID 3 not found"):
+        tokenspeed_engine._select_ipc_handle({0: object(), 1: object()}, 3)
+
+
 def test_adapt_tokenspeed_output_matches_vllm_shape():
     output = tokenspeed_engine._adapt_tokenspeed_output(
         {

--- a/tests/test_tokenspeed_engine.py
+++ b/tests/test_tokenspeed_engine.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _load_tokenspeed_engine_module():
+    root = Path(__file__).resolve().parents[1]
+    package_name = "_tokenspeed_engine_test"
+    module_name = f"{package_name}.tokenspeed_engine"
+
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(root / "openrlhf" / "trainer" / "ray")]
+
+    utils = types.ModuleType(f"{package_name}.utils")
+    utils.ray_noset_visible_devices = lambda: False
+
+    agent = types.ModuleType("openrlhf.utils.agent")
+    agent.AgentExecutorBase = type("AgentExecutorBase", (), {})
+    agent.SingleTurnAgentExecutor = MagicMock()
+
+    fake_ray = types.ModuleType("ray")
+    fake_ray.remote = lambda cls: cls
+    fake_ray.get_gpu_ids = lambda: []
+    fake_ray.get = lambda refs: refs
+
+    placement_group_module = types.ModuleType("ray.util.placement_group")
+    placement_group_module.placement_group = MagicMock()
+
+    scheduling_module = types.ModuleType("ray.util.scheduling_strategies")
+    scheduling_module.PlacementGroupSchedulingStrategy = MagicMock()
+
+    originals = {}
+    fakes = {
+        package_name: package,
+        f"{package_name}.utils": utils,
+        "openrlhf.utils.agent": agent,
+        "ray": fake_ray,
+        "ray.util": types.ModuleType("ray.util"),
+        "ray.util.placement_group": placement_group_module,
+        "ray.util.scheduling_strategies": scheduling_module,
+    }
+    for name, module in fakes.items():
+        originals[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        root / "openrlhf" / "trainer" / "ray" / "tokenspeed_engine.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    for name, original in originals.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+    return module
+
+
+tokenspeed_engine = _load_tokenspeed_engine_module()
+
+
+def test_adapt_tokenspeed_output_matches_vllm_shape():
+    output = tokenspeed_engine._adapt_tokenspeed_output(
+        {
+            "text": "hello",
+            "output_ids": [11, 12],
+            "meta_info": {
+                "finish_reason": {"type": "length", "length": 2},
+                "output_token_logprobs": [(-0.1, 11, None), (-0.2, 12, None)],
+            },
+        },
+        require_logprobs=True,
+    )
+
+    completion = output.outputs[0]
+    assert completion.text == "hello"
+    assert completion.token_ids == [11, 12]
+    assert completion.finish_reason == "length"
+    assert completion.logprobs[0][11].logprob == pytest.approx(-0.1)
+    assert completion.logprobs[1][12].logprob == pytest.approx(-0.2)
+
+
+def test_adapt_tokenspeed_output_fails_when_requested_logprobs_are_missing():
+    with pytest.raises(RuntimeError, match="did not return output token logprobs"):
+        tokenspeed_engine._adapt_tokenspeed_output(
+            {"text": "hello", "output_ids": [11], "meta_info": {"finish_reason": {"type": "stop"}}},
+            require_logprobs=True,
+        )
+
+
+def test_tokenspeed_sampling_params_requires_generation_budget():
+    sampling_params = types.SimpleNamespace(max_tokens=None)
+
+    with pytest.raises(ValueError, match="max_tokens"):
+        tokenspeed_engine._tokenspeed_sampling_params(sampling_params)
+
+
+def test_tokenspeed_sampling_params_maps_vllm_names():
+    sampling_params = types.SimpleNamespace(
+        max_tokens=7,
+        min_tokens=2,
+        temperature=0.8,
+        top_p=0.9,
+        top_k=40,
+        skip_special_tokens=False,
+        stop_token_ids=[1, 2],
+    )
+
+    assert tokenspeed_engine._tokenspeed_sampling_params(sampling_params) == {
+        "max_new_tokens": 7,
+        "min_new_tokens": 2,
+        "temperature": 0.8,
+        "top_p": 0.9,
+        "top_k": 40,
+        "skip_special_tokens": False,
+        "stop_token_ids": [1, 2],
+    }


### PR DESCRIPTION
## Summary

- Add TokenSpeed as an optional PPO rollout backend via `--vllm.rollout_backend tokenspeed`.
- Implement a `RolloutRayActor`-compatible TokenSpeed actor for generation, weight sync, memory control, and cache reset.
- Adapt TokenSpeed generation outputs to the response shape already consumed by OpenRLHF rollout code.
- Add focused adapter tests and document the new rollout backend option.

## Testing

- `python -m py_compile openrlhf/trainer/ray/tokenspeed_engine.py openrlhf/cli/train_ppo_ray.py openrlhf/trainer/ray/__init__.py tests/test_tokenspeed_engine.py`
- `git diff --check`
- Adapter conversion smoke check