### PR TITLE
fix: only pass min_lr_rate to schedulers that accept it

### DIFF
--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -365,12 +365,22 @@ class DeepspeedStrategy(ABC):
                 },
             }
         scheduler_steps = cfg["scheduler_steps"]
+        scheduler_name = cfg.get("lr_scheduler", "cosine_with_min_lr")
+        # `min_lr_rate` is only a valid kwarg for the two cosine-with-min-lr
+        # schedulers in transformers; passing it to e.g. linear / cosine /
+        # constant / polynomial / inverse_sqrt raises TypeError inside
+        # `get_scheduler`'s downstream call.
+        scheduler_kwargs = (
+            {"min_lr_rate": cfg.get("min_lr_ratio", 0.1)}
+            if scheduler_name in {"cosine_with_min_lr", "cosine_warmup_with_min_lr"}
+            else {}
+        )
         sched_factory = partial(
             get_scheduler,
-            cfg.get("lr_scheduler", "cosine_with_min_lr"),
+            scheduler_name,
             num_warmup_steps=math.ceil(scheduler_steps * cfg.get("lr_warmup_ratio", 0.03)),
             num_training_steps=scheduler_steps,
-            scheduler_specific_kwargs={"min_lr_rate": cfg.get("min_lr_ratio", 0.1)},
+            scheduler_specific_kwargs=scheduler_kwargs,
         )
 
         is_actor = isinstance(model, Actor)


### PR DESCRIPTION
### Problem

`DeepspeedStrategy._ds_init_train_model` in
`openrlhf/utils/deepspeed/deepspeed.py` unconditionally passes
`min_lr_rate` via `scheduler_specific_kwargs` to
`transformers.get_scheduler`, regardless of the `lr_scheduler` name.
This call site was introduced in #1221, which consolidated scheduler
creation from individual trainers into `DeepspeedStrategy.prepare()`.

In `transformers`, only two scheduler factories accept `min_lr_rate`:

- `get_cosine_with_min_lr_schedule_with_warmup` (`SchedulerType.COSINE_WITH_MIN_LR`)
- `get_cosine_with_min_lr_schedule_with_warmup_lr_rate` (`SchedulerType.COSINE_WARMUP_WITH_MIN_LR`)

All other schedulers (`linear`, `cosine`, `cosine_with_restarts`,
`polynomial`, `constant`, `constant_with_warmup`, `inverse_sqrt`,
`warmup_stable_decay`, ...) raise `TypeError` when the kwarg is splatted
into them by `get_scheduler`.

### Repro

```bash
python -m openrlhf.cli.train_ppo_ray \
  --actor.model_name_or_path <model> \
  --reward.model_name_or_path <rm> \
  --data.prompt_dataset <ds> --data.input_key prompt \
  --actor.lr_scheduler linear \
  ...  # any non-default lr_scheduler
```

Crashes at DeepSpeed init with:

```
File ".../deepspeed/runtime/engine.py", line 1275, in _configure_lr_scheduler
    self.lr_scheduler = self.client_lr_scheduler(self.basic_optimizer)
File ".../transformers/optimization.py", line 1049, in get_scheduler
    return schedule_func(
TypeError: get_linear_schedule_with_warmup() got an unexpected keyword
argument 'min_lr_rate'
```

This blocks any user overriding --actor.lr_scheduler or --critic.lr_scheduler to a non-default value; both code paths flow through the same _ds_init_train_model.

### Fix

Gate `min_lr_rate` on the scheduler name so it's only included for the
two cosine-with-min-lr factories that accept it. Default behavior
(`cosine_with_min_lr`) is unchanged; the previously crash-inducing
schedulers now train normally.

```python
scheduler_name = cfg.get("lr_scheduler", "cosine_with_min_lr")
scheduler_kwargs = (
    {"min_lr_rate": cfg.get("min_lr_ratio", 0.1)}
    if scheduler_name in {"cosine_with_min_lr", "cosine_warmup_with_min_lr"}
    else {}
)
```

### Notes

- After this change, an explicit `--actor.min_lr_ratio <X>` paired with a
  non-cosine scheduler is silently dropped (the kwarg simply isn't passed
  through). Better than crashing, but a future polish could log a warning
  when the user explicitly set `min_lr_ratio` and chose an incompatible
  scheduler. Happy to extend in a follow-up if desired.
- No new tests added because `tests/` has no existing scheduler / DeepSpeed
  coverage. Happy to add a small unit test for `_ds_init_train_model`'s
  scheduler-factory construction if you'd like.