### PR TITLE
fix: ignore zero-action samples in group reward baselines

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -244,30 +244,49 @@ class RemoteExperienceMaker:
 
         # ── Reward shaping (baseline subtraction) ──
         exp_len = [len(experience.index) for experience in experiences]
-        indices = torch.tensor(list(itertools.chain.from_iterable(experience.index for experience in experiences)))
+        indices = torch.tensor(
+            list(itertools.chain.from_iterable(experience.index for experience in experiences)),
+            device=experiences[0].rewards.device,
+        )
         raw_rewards = torch.cat([experience.rewards for experience in experiences], dim=0)
         rewards = torch.empty_like(raw_rewards)
         rewards[indices] = raw_rewards  # sorted by original prompt order
 
         rewards = rewards.reshape(-1, args.rollout.n_samples_per_prompt)
+        raw_has_actions = torch.cat(
+            [experience.action_mask.any(dim=-1) for experience in experiences],
+            dim=0,
+        ).to(device=raw_rewards.device)
+        has_actions = torch.empty_like(raw_has_actions, dtype=torch.bool)
+        has_actions[indices] = raw_has_actions
+        has_actions = has_actions.reshape(-1, args.rollout.n_samples_per_prompt)
+        valid_reward_mask = has_actions.to(dtype=rewards.dtype)
+        valid_reward_count = valid_reward_mask.sum(-1, keepdim=True)
+        valid_reward_sum = (rewards * valid_reward_mask).sum(-1, keepdim=True)
+        valid_reward_mean = valid_reward_sum / valid_reward_count.clamp(min=1)
+        valid_reward_delta = torch.where(has_actions, rewards - valid_reward_mean, torch.zeros_like(rewards))
+        valid_reward_std = (
+            valid_reward_delta.pow(2).sum(-1, keepdim=True) / (valid_reward_count - 1).clamp(min=1)
+        ).sqrt()
 
         if args.rollout.n_samples_per_prompt > 1:
             group_reward_stds = (
-                rewards.std(-1, keepdim=True)
-                .repeat(1, args.rollout.n_samples_per_prompt)
-                .reshape(-1)[indices]
-                .split(exp_len)
+                valid_reward_std.repeat(1, args.rollout.n_samples_per_prompt).reshape(-1)[indices].split(exp_len)
             )
             for experience, group_reward_std in zip(experiences, group_reward_stds):
                 experience.info["group_reward_std"] = group_reward_std
 
         if args.algo.advantage.estimator == "rloo":
-            baseline = (rewards.sum(-1, keepdim=True) - rewards) / (args.rollout.n_samples_per_prompt - 1)
-            rewards = rewards - baseline
+            baseline = (valid_reward_sum - rewards * valid_reward_mask) / (
+                valid_reward_count - valid_reward_mask
+            ).clamp(min=1)
+            rewards = torch.where(has_actions, rewards - baseline, torch.zeros_like(rewards))
         elif args.algo.advantage.estimator in ["reinforce_baseline", "dr_grpo"]:
-            rewards = rewards - rewards.mean(-1, keepdim=True)
+            rewards = valid_reward_delta
         elif args.algo.advantage.estimator == "group_norm":
-            rewards = (rewards - rewards.mean(-1, keepdim=True)) / (rewards.std(-1, keepdim=True) + 1e-9)
+            rewards = valid_reward_delta / (valid_reward_std + 1e-9)
+        else:
+            rewards = torch.where(has_actions, rewards, torch.zeros_like(rewards))
 
         rewards = rewards.reshape(-1)[indices].split(exp_len)
 

--- a/tests/test_experience_maker.py
+++ b/tests/test_experience_maker.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import torch
+
+from openrlhf.trainer.ppo_utils.experience import Experience
+from openrlhf.trainer.ppo_utils.experience_maker import RemoteExperienceMaker
+
+
+def _make_args(estimator="dr_grpo", n_samples_per_prompt=2):
+    return SimpleNamespace(
+        rollout=SimpleNamespace(n_samples_per_prompt=n_samples_per_prompt),
+        reward=SimpleNamespace(clip_range=None, overlong_buffer_len=None, stop_properly_penalty_coef=None),
+        algo=SimpleNamespace(
+            advantage=SimpleNamespace(estimator=estimator, gamma=1.0, lambd=1.0, no_std_norm=True),
+        ),
+    )
+
+
+def _make_maker(estimator="dr_grpo", n_samples_per_prompt=2):
+    args = _make_args(estimator=estimator, n_samples_per_prompt=n_samples_per_prompt)
+    maker = object.__new__(RemoteExperienceMaker)
+    maker.strategy = SimpleNamespace(args=args)
+    maker.args = args
+    maker.advantage_estimator = args.algo.advantage.estimator
+    maker.kl_ctl = SimpleNamespace(value=0.0)
+    return maker
+
+
+def _experience(index, reward, action_mask):
+    action_mask = torch.tensor([action_mask], dtype=torch.bool)
+    return Experience(
+        action_mask=action_mask,
+        rewards=torch.tensor([reward], dtype=torch.float32),
+        kl=torch.zeros_like(action_mask, dtype=torch.float32),
+        values=torch.zeros_like(action_mask, dtype=torch.float32),
+        index=[index],
+        info={},
+    )
+
+
+def test_dr_grpo_group_baseline_ignores_zero_action_rewards():
+    zero_action = _experience(0, 100.0, [0, 0, 0])
+    valid_action = _experience(1, 1.0, [1, 1, 1])
+
+    _, valid_after = _make_maker("dr_grpo").compute_advantages_and_returns([zero_action, valid_action])
+
+    assert torch.allclose(valid_after.advantages, torch.zeros_like(valid_after.advantages))
+    assert torch.allclose(valid_after.info["return"], torch.tensor([0.0]))
+
+
+def test_dr_grpo_group_baseline_uses_valid_siblings_only():
+    zero_action = _experience(0, 100.0, [0, 0])
+    valid_low = _experience(1, 1.0, [1, 1])
+    valid_high = _experience(2, 3.0, [1, 1])
+
+    _, low_after, high_after = _make_maker("dr_grpo", n_samples_per_prompt=3).compute_advantages_and_returns(
+        [zero_action, valid_low, valid_high],
+    )
+
+    assert torch.allclose(low_after.advantages, torch.tensor([[-1.0, -1.0]]))
+    assert torch.allclose(high_after.advantages, torch.tensor([[1.0, 1.0]]))


### PR DESCRIPTION
## Summary

This fixes a quiet reward/advantage bug in `RemoteExperienceMaker.compute_advantages_and_returns`.

For group-style estimators such as `dr_grpo`, OpenRLHF centers rewards within `n_samples_per_prompt` groups. A rollout sibling can have `action_mask.sum() == 0` after response truncation/filtering while still carrying a scalar reward. Before this change, that zero-action sibling participated in the group reward mean and shifted the advantages of valid siblings.

The fix builds a per-sample `has_actions` mask from `action_mask`, excludes zero-action samples from group reward means/stds/baselines, and assigns zero shaped reward to zero-action samples.

## Concrete Failure Shape

The minimal failing group is two rollout siblings from the same prompt:

```text
n_samples_per_prompt: 2
advantage_estimator: dr_grpo

sample index:      [0, 1]
raw reward:        [100.0, 1.0]
action_mask.sum(): [0, 2]

zero-action action_mask:
  [[0, 0, 0, 0, 0]]

valid action_mask:
  [[0, 0, 0, 0, 0, 1, 1]]
```

The first sibling has no trainable action tokens after response processing, but
it still carries reward `100.0`. Before this fix, `dr_grpo` reward centering
used both siblings:

```text
wrong group mean:              (100.0 + 1.0) / 2 = 50.5
wrong valid centered reward:   1.0 - 50.5 = -49.5
wrong valid token advantages:  [-49.5, -49.5, ...]
```

That silently turns the accepted sibling's policy-gradient signal negative even
though the rejected/empty sibling has no trainable tokens.

After this fix, group reward statistics only use siblings with at least one
trainable action token:

```text
fixed group mean:              1.0
fixed valid centered reward:   1.0 - 1.0 = 0.0
fixed zero-action reward:      0.0
fixed valid token advantages:  [0.0, 0.0, ...]
```

## Reproduction Recipe

```json
{
  "bug_id": "BUG-FC8EB1E7D0C6",
  "target": "openrlhf",
  "boundaries": [
    "vllm.LLM.generate",
    "openrlhf.trainer.ppo_utils.samples_generator.SamplesGenerator._process_response_into_experience",
    "openrlhf.trainer.ppo_utils.experience_maker.RemoteExperienceMaker.compute_advantages_and_returns"
  ],
  "model": "Qwen/Qwen2.5-0.5B-Instruct",
  "scenario": {
    "n_samples_per_prompt": 2,
    "advantage_estimator": "dr_grpo",
    "zero_action_sibling": {
      "reward": 100.0,
      "action_mask_sum": 0
    },
    "valid_sibling": {
      "reward": 1.0,
      "action_mask_sum": 2
    }
  },
  "expected_unpatched": {
    "valid_action_advantages": "negative because zero-action reward enters the group mean"
  },
  "expected_fixed": {
    "zero_action_sample_excluded_from_group_baseline": true,
    "valid_action_advantages_not_shifted_by_zero_action_reward": true
  }
}
```

## Portable Runner

```bash
#!/usr/bin/env bash
set -euo pipefail

REPO="${REPO:-$(pwd)}"
MODEL_ID="${MODEL_ID:-Qwen/Qwen2.5-0.5B-Instruct}"
export PYTHONPATH="${REPO}${PYTHONPATH:+:${PYTHONPATH}}"
export VLLM_USE_V1="${VLLM_USE_V1:-0}"

python3 - <<'PY'
import json
import os
from types import SimpleNamespace

import torch
from huggingface_hub import snapshot_download
from transformers import AutoTokenizer
from vllm import LLM, SamplingParams

from openrlhf.trainer.ppo_utils.experience_maker import RemoteExperienceMaker
from openrlhf.trainer.ppo_utils.samples_generator import SamplesGenerator


def make_args():
    return SimpleNamespace(
        rollout=SimpleNamespace(n_samples_per_prompt=2, max_new_tokens=16),
        data=SimpleNamespace(max_len=16),
        reward=SimpleNamespace(clip_range=None, overlong_buffer_len=None, stop_properly_penalty_coef=None),
        algo=SimpleNamespace(
            advantage=SimpleNamespace(estimator="dr_grpo", gamma=1.0, lambd=1.0, no_std_norm=True)
        ),
    )


def make_maker(args):
    maker = object.__new__(RemoteExperienceMaker)
    maker.strategy = SimpleNamespace(args=args)
    maker.args = args
    maker.advantage_estimator = args.algo.advantage.estimator
    maker.kl_ctl = SimpleNamespace(value=0.0)
    return maker


def process_response(response, max_len):
    generator = object.__new__(SamplesGenerator)
    return SamplesGenerator._process_response_into_experience(generator, response, max_len=max_len)


model_id = os.environ["MODEL_ID"]
model_path = snapshot_download(model_id, local_files_only=True)
tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
prompt_ids = tokenizer(text="Answer with one short token:", add_special_tokens=False, return_tensors="pt")[
    "input_ids"
][0].tolist()

llm = LLM(
    model=model_path,
    trust_remote_code=True,
    skip_tokenizer_init=True,
    tensor_parallel_size=1,
    gpu_memory_utilization=0.20,
    max_model_len=256,
    enforce_eager=True,
)
outputs = llm.generate(
    [{"prompt_token_ids": prompt_ids}],
    SamplingParams(max_tokens=2, min_tokens=0, temperature=0.0, logprobs=1),
)
action_ids = list(outputs[0].outputs[0].token_ids)
if not action_ids:
    raise RuntimeError("vLLM produced no tokens; cannot construct the zero-action truncation scenario")

observation_tokens = prompt_ids + action_ids
response = {
    "prompt": "Answer with one short token:",
    "label": "label",
    "images": None,
    "mm_train_inputs": None,
    "observation_tokens": observation_tokens,
    "action_ranges": [(len(prompt_ids), len(observation_tokens))],
    "rollout_log_probs": None,
    "truncated": False,
    "reward": 100.0,
    "scores": 1.0,
    "extra_logs": {},
}

zero_action = process_response(response, max_len=len(prompt_ids))
valid_response = dict(response)
valid_response["reward"] = 1.0
valid_action = process_response(valid_response, max_len=len(observation_tokens))

for idx, exp in enumerate([zero_action, valid_action]):
    exp.index = [idx]
    exp.kl = torch.zeros_like(exp.action_mask, dtype=torch.float32)
    exp.values = torch.zeros_like(exp.action_mask, dtype=torch.float32)

zero_after, valid_after = make_maker(make_args()).compute_advantages_and_returns([zero_action, valid_action])

print(json.dumps({
    "real_vllm_generated_token_count": len(action_ids),
    "zero_action_mask_sum": int(zero_after.action_mask.sum().item()),
    "valid_action_mask_sum": int(valid_after.action_mask.sum().item()),
    "valid_action_advantages": valid_after.advantages.detach().cpu().tolist(),
    "valid_action_info_return": valid_after.info["return"].detach().cpu().tolist(),
}, indent=2))
PY
```

## Observed Output

Unpatched OpenRLHF `main@c3188af37cec984614aaa38906e71fa2fc57b079`:

```json
{
  "zero_action_mask_sum": 0,
  "valid_action_mask_sum": 2,
  "valid_action_advantages": [[-49.5, -49.5, -49.5, -49.5, -49.5, -49.5, -49.5]],
  "valid_action_info_return": [-49.5],
  "candidate_bug_reproduced": true
}
```

Fixed branch `94d06f391e534e8abe68a6a343fddf19ab5c4a26`:

```json
{
  "zero_action_mask_sum": 0,
  "valid_action_mask_sum": 2,
  "valid_action_advantages": [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
  "valid_action_info_return": [0.0],
  "candidate_bug_reproduced": false
}
```

The fixed validation uses real vLLM token-id generation and the real OpenRLHF response-processing and advantage-computation boundaries.

## Duplicate Search

OpenRLHF has no PR template. I followed `CONTRIBUTING.md`, which asks contributors to use pre-commit hooks.

Searched OpenRLHF upstream PRs/issues for exact and related reports:

- `repo:OpenRLHF/OpenRLHF is:pr dr_grpo zero action reward group baseline`: 0 results
- `repo:OpenRLHF/OpenRLHF is:pr compute_advantages_and_returns dr_grpo action_mask reward`: 0 results
- `repo:OpenRLHF/OpenRLHF is:issue dr_grpo zero action reward group baseline`: 0 results

Related but not duplicate:

- `OpenRLHF#924`: related `dr_grpo` discussion, not a zero-action reward contamination fix.
- `OpenRLHF#1115`: broad action-mask/search hit, but it changes distributed backend plumbing, not this reward-centering path.

## Tests

```bash
python3 -m pytest tests/test_experience_maker.py tests/test_loss_aggregation.py -q
python3 -m ruff check openrlhf/trainer/ppo_utils/experience_maker.py tests/test_experience_maker.py
pre-commit run --files openrlhf/trainer/ppo_utils/experience_maker.py tests/test_experience_maker.py
```

Results:

- `tests/test_experience_maker.py tests/test_loss_aggregation.py`: 8 passed
- `ruff`: passed
- `pre-commit`: passed
