### PR TITLE
Security: Arbitrary Code Execution via trust_remote_code=True in Dataset Loading

### DIFF
--- a/openrlhf/datasets/utils.py
+++ b/openrlhf/datasets/utils.py
@@ -45,7 +45,7 @@ def blending_datasets(
         if ext == ".py" or (
             os.path.isdir(dataset) and os.path.exists(os.path.join(dataset, f"{dataset_basename}.py"))
         ):
-            data = load_dataset(dataset, trust_remote_code=True)
+            data = load_dataset(dataset)
             strategy.print(f"loaded {dataset} with python script")
         # local text file
         elif ext in [".json", ".jsonl", ".csv", ".parquet", ".arrow"]:

--- a/openrlhf/utils/utils.py
+++ b/openrlhf/utils/utils.py
@@ -42,7 +42,7 @@ def is_vlm_model(pretrain: str) -> bool:
     from transformers import AutoConfig
 
     try:
-        cfg = AutoConfig.from_pretrained(pretrain, trust_remote_code=True)
+        cfg = AutoConfig.from_pretrained(pretrain)
         return hasattr(cfg, "vision_config")
     except Exception:
         return False
@@ -56,7 +56,7 @@ def get_tokenizer(pretrain, model, padding_side="left", strategy=None, use_fast=
 
         # AutoProcessor wraps tokenizer + image_processor; downstream code
         # detects VLM via hasattr(tokenizer, "image_processor").
-        tokenizer = AutoProcessor.from_pretrained(pretrain, trust_remote_code=True)
+        tokenizer = AutoProcessor.from_pretrained(pretrain)
         # AutoProcessor doesn't delegate tokenizer attributes, so set them on
         # the inner tokenizer and mirror the essentials back.
         inner = tokenizer.tokenizer
@@ -67,7 +67,7 @@ def get_tokenizer(pretrain, model, padding_side="left", strategy=None, use_fast=
         for attr in ("pad_token", "pad_token_id", "eos_token", "eos_token_id"):
             setattr(tokenizer, attr, getattr(inner, attr))
     else:
-        tokenizer = AutoTokenizer.from_pretrained(pretrain, trust_remote_code=True, use_fast=use_fast)
+        tokenizer = AutoTokenizer.from_pretrained(pretrain, use_fast=use_fast)
         tokenizer.padding_side = padding_side
         # NOTE: When enable vLLM, do not resize_token_embeddings, or the vocab size will mismatch with vLLM.
         # https://github.com/facebookresearch/llama-recipes/pull/196


### PR DESCRIPTION
## Problem

The `blending_datasets` function in `openrlhf/datasets/utils.py` loads datasets with `trust_remote_code=True` when loading local Python scripts (.py files) or directories containing Python scripts. This allows arbitrary code execution from downloaded or local dataset repositories. An attacker could craft a malicious dataset repository that executes arbitrary code when loaded. The function also uses `load_dataset` with `trust_remote_code=True` for remote datasets when the path doesn't match other patterns.

**Severity**: `high`
**File**: `openrlhf/datasets/utils.py`

## Solution

Remove `trust_remote_code=True` or make it an explicit opt-in flag with clear warnings. Validate dataset sources before loading. Consider using sandboxed execution or restricting to known safe dataset formats.

## Changes

- `openrlhf/datasets/utils.py` (modified)
- `openrlhf/utils/utils.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
