### PR TITLE
Fix overlong penalty action token length

### DIFF
--- a/openrlhf/trainer/ppo_utils/length_penalty.py
+++ b/openrlhf/trainer/ppo_utils/length_penalty.py
@@ -12,12 +12,27 @@ from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+_warned_missing_action_mask = False
+
 
 def _get_overlong_response_lengths(experience):
+    global _warned_missing_action_mask
+
     action_mask = getattr(experience, "action_mask", None)
     if action_mask is not None:
         response_lengths = action_mask.sum(dim=-1)
     else:
+        # Falling back to response_length counts every generated token, including
+        # non-action tokens such as tool responses. This is the pre-fix behavior and
+        # is only correct for non-agentic runs. A missing action_mask during agentic
+        # training is most likely a misconfiguration, so surface it once.
+        if not _warned_missing_action_mask:
+            logger.warning(
+                "action_mask is not set on experiences; overlong penalty falls back to "
+                "response_length, which counts non-action tokens (e.g. tool responses). "
+                "If this is an agentic run, ensure action_mask is populated."
+            )
+            _warned_missing_action_mask = True
         response_lengths = getattr(experience, "response_length", None)
 
     if response_lengths is None:

--- a/openrlhf/trainer/ppo_utils/length_penalty.py
+++ b/openrlhf/trainer/ppo_utils/length_penalty.py
@@ -13,6 +13,22 @@ from openrlhf.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 
+def _get_overlong_response_lengths(experience):
+    action_mask = getattr(experience, "action_mask", None)
+    if action_mask is not None:
+        response_lengths = action_mask.sum(dim=-1)
+    else:
+        response_lengths = getattr(experience, "response_length", None)
+
+    if response_lengths is None:
+        raise ValueError("Experience must have either 'action_mask' or 'response_length' populated.")
+
+    if response_lengths.dim() == 0:
+        response_lengths = response_lengths.unsqueeze(0)
+
+    return response_lengths
+
+
 def apply_overlong_penalty(
     experiences: List,
     max_new_tokens: int,
@@ -23,6 +39,8 @@ def apply_overlong_penalty(
     DAPO-style overlong penalty based on response length.
 
     Penalizes responses that exceed (max_new_tokens - overlong_buffer_len).
+    Uses action_mask when available so non-action tokens such as tool responses
+    do not count toward the trainable response length.
     Formula: penalty = -min(exceed_len, buffer_len) / buffer_len * penalty_factor
 
     Args:
@@ -42,7 +60,7 @@ def apply_overlong_penalty(
     total_penalized = 0
 
     for experience in experiences:
-        response_lengths = experience.response_length
+        response_lengths = _get_overlong_response_lengths(experience)
         batch_size = len(response_lengths)
 
         for j in range(batch_size):

--- a/tests/test_length_penalty.py
+++ b/tests/test_length_penalty.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from openrlhf.trainer.ppo_utils.length_penalty import apply_overlong_penalty
+
+
+def _experience(reward, response_length=None, action_mask=None):
+    return SimpleNamespace(
+        rewards=torch.tensor([reward], dtype=torch.float),
+        response_length=torch.tensor([response_length]) if response_length is not None else None,
+        action_mask=action_mask,
+    )
+
+
+def test_overlong_penalty_uses_action_mask_to_exclude_tool_response_tokens():
+    experience = _experience(
+        reward=1.0,
+        response_length=10,
+        action_mask=torch.tensor([[1, 1, 0, 0, 0, 1, 1, 1]], dtype=torch.bool),
+    )
+
+    num_penalized = apply_overlong_penalty([experience], max_new_tokens=8, overlong_buffer_len=3)
+
+    assert num_penalized == 0
+    assert torch.allclose(experience.rewards, torch.tensor([1.0]))
+
+
+def test_overlong_penalty_applies_to_trainable_action_tokens():
+    experience = _experience(
+        reward=1.0,
+        response_length=10,
+        action_mask=torch.tensor([[1, 1, 1, 0, 0, 1, 1, 1, 1]], dtype=torch.bool),
+    )
+
+    num_penalized = apply_overlong_penalty([experience], max_new_tokens=8, overlong_buffer_len=3)
+
+    assert num_penalized == 1
+    assert torch.allclose(experience.rewards, torch.tensor([1.0 - 2.0 / 3.0]))
+
+
+def test_overlong_penalty_falls_back_to_response_length_without_action_mask():
+    experience = _experience(reward=1.0, response_length=7, action_mask=None)
+
+    num_penalized = apply_overlong_penalty([experience], max_new_tokens=8, overlong_buffer_len=3)
+
+    assert num_penalized == 1
+    assert torch.allclose(experience.rewards, torch.tensor([1.0 - 2.0 / 3.0]))
+
+
+def test_overlong_penalty_requires_length_information():
+    experience = _experience(reward=1.0)
+
+    with pytest.raises(ValueError, match="action_mask.*response_length"):
+        apply_overlong_penalty([experience], max_new_tokens=8, overlong_buffer_len=3)

--- a/tests/test_length_penalty.py
+++ b/tests/test_length_penalty.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+import openrlhf.trainer.ppo_utils.length_penalty as length_penalty
 from openrlhf.trainer.ppo_utils.length_penalty import apply_overlong_penalty
 
 
@@ -47,6 +48,21 @@ def test_overlong_penalty_falls_back_to_response_length_without_action_mask():
 
     assert num_penalized == 1
     assert torch.allclose(experience.rewards, torch.tensor([1.0 - 2.0 / 3.0]))
+
+
+def test_overlong_penalty_warns_once_when_falling_back_without_action_mask(monkeypatch):
+    length_penalty._warned_missing_action_mask = False
+    warnings = []
+    monkeypatch.setattr(length_penalty.logger, "warning", lambda msg, *a, **k: warnings.append(msg))
+
+    experiences = [
+        _experience(reward=1.0, response_length=7, action_mask=None),
+        _experience(reward=1.0, response_length=7, action_mask=None),
+    ]
+    apply_overlong_penalty(experiences, max_new_tokens=8, overlong_buffer_len=3)
+
+    assert len(warnings) == 1
+    assert "action_mask is not set" in warnings[0]
 
 
 def test_overlong_penalty_requires_length_information():


### PR DESCRIPTION
Fixes #1243. Uses action_mask when available for overlong penalty length so tool response tokens are excluded from trainable response length accounting. Tests: python -m pytest tests; python -m pre_commit run --files openrlhf/trainer/ppo_utils/length_penalty.py tests/test_length_penalty.py