### PR TITLE
Fix two latent bugs: dr_grpo n=1 guard and masked_normalize broadcast

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -605,7 +605,11 @@ if __name__ == "__main__":
         else:
             args.critic.model_name_or_path = args.actor.model_name_or_path
 
-    if args.algo.advantage.estimator in ["rloo", "reinforce_baseline", "group_norm"]:
+    # These estimators compute a per-prompt-group baseline (mean / std / leave-one-out),
+    # so with n_samples_per_prompt == 1 every advantage collapses to 0 and training is a
+    # silent no-op. dr_grpo subtracts the group mean too (see experience_maker), so it
+    # belongs here as well.
+    if args.algo.advantage.estimator in ["rloo", "reinforce_baseline", "group_norm", "dr_grpo"]:
         assert (
             args.rollout.n_samples_per_prompt > 1
         ), f"{args.algo.advantage.estimator} requires n_samples_per_prompt > 1"

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -154,10 +154,12 @@ def masked_mean(tensor: torch.Tensor, mask: Optional[torch.Tensor], dim: int = N
 
 
 def masked_normalize(tensor: torch.Tensor, mask: torch.Tensor, dim: int = 1, eps: float = 1e-8) -> torch.Tensor:
-    tensor = tensor * mask
-    mean = masked_mean(tensor, mask, dim=dim)
-    mean_centered = tensor - mean
-    var = masked_mean(mean_centered**2, mask, dim=dim)
+    # keepdim=True so the per-row mean/var broadcast back over `dim` correctly; masked_mean
+    # reduces `dim` without keepdim, so using it here would broadcast along the wrong axis.
+    mask_sum = mask.sum(dim=dim, keepdim=True).clamp(min=1)
+    mean = (tensor * mask).sum(dim=dim, keepdim=True) / mask_sum
+    mean_centered = (tensor - mean) * mask
+    var = (mean_centered**2).sum(dim=dim, keepdim=True) / mask_sum
     return mean_centered * var.clamp(min=eps).rsqrt()
 
 


### PR DESCRIPTION
1. dr_grpo was missing from the n_samples_per_prompt > 1 assertion. Like reinforce_baseline/group_norm, dr_grpo subtracts the per-prompt group mean from rewards (experience_maker), so with n_samples_per_prompt == 1 the group mean equals the single reward and every advantage collapses to 0 -- training silently does nothing. Add dr_grpo to the guarded estimators.

2. masked_normalize computed the per-row mean/var with masked_mean (no keepdim), so a (batch,) statistic was subtracted from a (batch, seq) tensor -- broadcasting along the wrong axis (or erroring when seq != batch). Reduce over `dim` with keepdim so the statistics broadcast correctly, mask the centered values, and guard empty rows. Verified: per-row masked mean ~0 / std ~1, masked positions stay 0, shape preserved.