### PR TITLE
fix: use action_mask.sum() for response_length to exclude tool-call tokens in multi-turn training

### DIFF
--- a/openrlhf/trainer/ppo_utils/samples_generator.py
+++ b/openrlhf/trainer/ppo_utils/samples_generator.py
@@ -273,8 +273,8 @@ class SamplesGenerator:
             rollout_log_probs = None
 
         # Collect simple stats about lengths and clipping.
-        ones_indices = torch.where(action_mask)[0]
-        response_length = (ones_indices[-1] - ones_indices[0] + 1).item() if len(ones_indices) else 0
+        # Use sum() not span, so tool-call tokens between turns are excluded.
+        response_length = action_mask.sum().item()
         total_length = attention_mask.float().sum()
         is_clipped = total_length >= truncate_length
 

--- a/tests/test_response_length.py
+++ b/tests/test_response_length.py
@@ -31,10 +31,10 @@ def test_multiturn_sum_excludes_tool_tokens():
     """Multi-turn agentic: tool tokens sit between turns, span overcounts them."""
     # [prompt(3)] [turn1(4)] [tool(3)] [turn2(5)]
     action_mask = torch.zeros(15, dtype=torch.long)
-    action_mask[3:7] = 1    # turn 1: 4 tokens
+    action_mask[3:7] = 1  # turn 1: 4 tokens
     action_mask[10:15] = 1  # turn 2: 5 tokens
 
-    assert _compute_response_length_sum(action_mask) == 9   # correct: 4+5
+    assert _compute_response_length_sum(action_mask) == 9  # correct: 4+5
     assert _compute_response_length_span(action_mask) == 12  # wrong: 14-3+1=12, includes 3 tool tokens
 
 

--- a/tests/test_response_length.py
+++ b/tests/test_response_length.py
@@ -1,0 +1,52 @@
+"""
+Tests for response_length computation in _process_response_into_experience.
+
+response_length must equal action_mask.sum() (only model-generated tokens),
+not the span from first to last 1 (which over-counts in multi-turn agentic
+training because tool-call tokens sit in the gaps between turns).
+"""
+
+import torch
+
+
+def _compute_response_length_span(action_mask: torch.Tensor) -> int:
+    """Old (buggy) approach: span from first to last action token."""
+    ones_indices = torch.where(action_mask)[0]
+    return (ones_indices[-1] - ones_indices[0] + 1).item() if len(ones_indices) else 0
+
+
+def _compute_response_length_sum(action_mask: torch.Tensor) -> int:
+    """New (correct) approach: count of action tokens only."""
+    return action_mask.sum().item()
+
+
+def test_single_turn_approaches_agree():
+    """Single-turn: contiguous span, so both methods return the same value."""
+    # [prompt(3)] [response(5)] [padding(2)]  → action_mask over response only
+    action_mask = torch.tensor([0, 0, 0, 1, 1, 1, 1, 1, 0, 0], dtype=torch.long)
+    assert _compute_response_length_span(action_mask) == _compute_response_length_sum(action_mask) == 5
+
+
+def test_multiturn_sum_excludes_tool_tokens():
+    """Multi-turn agentic: tool tokens sit between turns, span overcounts them."""
+    # [prompt(3)] [turn1(4)] [tool(3)] [turn2(5)]
+    action_mask = torch.zeros(15, dtype=torch.long)
+    action_mask[3:7] = 1    # turn 1: 4 tokens
+    action_mask[10:15] = 1  # turn 2: 5 tokens
+
+    assert _compute_response_length_sum(action_mask) == 9   # correct: 4+5
+    assert _compute_response_length_span(action_mask) == 12  # wrong: 14-3+1=12, includes 3 tool tokens
+
+
+def test_multiturn_single_token_turns():
+    """Edge case: each turn is exactly one token."""
+    action_mask = torch.tensor([0, 1, 0, 1, 0], dtype=torch.long)
+    assert _compute_response_length_sum(action_mask) == 2
+    assert _compute_response_length_span(action_mask) == 3  # wrong: 3-1+1=3, includes the gap token
+
+
+def test_empty_action_mask():
+    """No action tokens: both approaches return 0."""
+    action_mask = torch.zeros(8, dtype=torch.long)
+    assert _compute_response_length_sum(action_mask) == 0
+    assert _compute_response_length_span(action_mask) == 0


### PR DESCRIPTION
Fixes #1243

## Problem

In `_process_response_into_experience`, `response_length` was computed as the **span** from the first to the last action token:

```python
ones_indices = torch.where(action_mask)[0]
response_length = (ones_indices[-1] - ones_indices[0] + 1).item() if len(ones_indices) else 0
```

For single-turn training this is fine — the action span is contiguous, so span == sum.

For **multi-turn agentic training** (e.g. `MultiTurnAgentExecutor`), `action_mask` has gaps between turns where tool-call tokens sit. The span overcounts those gaps:

```
action_mask: [0 0 0 | 1 1 1 1 | 0 0 0 | 1 1 1 1 1]
                       turn1      tool    turn2
span = 14-3+1 = 12   ← includes 3 tool tokens
sum  = 4+5    = 9    ← only model-generated tokens  ✓
```

This causes `apply_overlong_penalty` to measure a longer-than-actual response and trigger false penalties on responses that are not actually overlong.

## Fix

Replace the span with `action_mask.sum()`, which matches the field's documented semantics (`"number of generated tokens"`) and is correct for both single-turn and multi-turn:

```python
response_length = action_mask.sum().item()
```

## Tests

Added `tests/test_response_length.py` with four cases:
- single-turn (both approaches agree — no regression)
- multi-turn with two turns separated by tool tokens (sum gives 9, span gives 12)
- single-token turns with a gap (sum gives 2, span gives 3)
- empty action mask (both give 0)