### PR TITLE
Fix Qwen3.5 ZeRO-3 frozen weights from set_z3_leaf_modules hybrid detection

### DIFF
--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -203,7 +203,7 @@ class Actor(nn.Module):
                 print("[MoE] set output_router_logits as True")
                 self.model.config.output_router_logits = True
 
-            set_z3_leaf_modules(self.model)
+            set_z3_leaf_modules(self.model, detect_hybrid=False)
 
             # https://github.com/huggingface/transformers/issues/26877
             # Use `model.generate(use_cache=True)` instead.`

--- a/openrlhf/models/model.py
+++ b/openrlhf/models/model.py
@@ -153,7 +153,7 @@ def get_llm_for_sequence_regression(
         print("[MoE] set output_router_logits as True")
         model.config.output_router_logits = True
 
-    set_z3_leaf_modules(model)
+    set_z3_leaf_modules(model, detect_hybrid=False)
 
     # https://github.com/huggingface/transformers/issues/26877
     model.config.use_cache = False

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional, Tuple, Union
 
 import deepspeed
@@ -6,7 +7,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-def set_z3_leaf_modules(model: nn.Module) -> None:
+def set_z3_leaf_modules(model: nn.Module, detect_hybrid: bool = True) -> None:
     """Auto-detect and set DeepSpeed ZeRO3 leaf modules.
 
     ZeRO3 prefetches submodule parameters assuming a fixed module traversal order.
@@ -17,8 +18,22 @@ def set_z3_leaf_modules(model: nn.Module) -> None:
         child submodules per instance (self_attn vs linear_attn).
 
     Marking these as z3 leaves forces whole-module allgather instead of per-submodule
-    prefetch, fixing the issue at the cost of slightly higher peak memory.
+    prefetch, at the cost of slightly higher peak memory.
+
+    For hybrid architectures (detect_hybrid=True), the leaf marking works by
+    registering a backwards hook that triggers allgather before backward. This
+    interacts poorly with Qwen3.5's hybrid decoder layers: the hook steals
+    gradient computation for ~390/417 inner parameters, leaving them frozen at
+    their initial values. DeepSpeed's native per-instance prefetch handles the
+    hybrid layout correctly on its own, so hybrid detection is disabled by
+    default for actor/reward model training.
+
+    Set OPENRLHF_Z3_LEAF_HYBRID=1 to re-enable hybrid detection for
+    architectures that genuinely need it.
     """
+    if os.environ.get("OPENRLHF_Z3_LEAF_HYBRID", "").strip().lower() in ("1", "true", "yes", "on"):
+        detect_hybrid = True
+
     z3_leaf_classes = set()
     child_sigs: dict[type, frozenset[str]] = {}
 
@@ -29,15 +44,16 @@ def set_z3_leaf_modules(model: nn.Module) -> None:
             continue
 
         # Hybrid: same class, different child submodules across instances
-        cls = m.__class__
-        children = frozenset(name for name, _ in m.named_children())
-        if not children:
-            continue
-        if cls in child_sigs:
-            if child_sigs[cls] != children:
-                z3_leaf_classes.add(cls)
-        else:
-            child_sigs[cls] = children
+        if detect_hybrid:
+            cls = m.__class__
+            children = frozenset(name for name, _ in m.named_children())
+            if not children:
+                continue
+            if cls in child_sigs:
+                if child_sigs[cls] != children:
+                    z3_leaf_classes.add(cls)
+            else:
+                child_sigs[cls] = children
 
     if z3_leaf_classes:
         deepspeed.utils.set_z3_leaf_modules(model, list(z3_leaf_classes))


### PR DESCRIPTION
Fixes #1258.

set_z3_leaf_modules registers register_full_backward_pre_hook on hybrid decoder classes, stealing gradient computation for inner parameters under ZeRO-3.

Fix: add detect_hybrid=False parameter to skip hybrid detection while keeping MoE leaf marking. Applied to actor.py and model.py. Env var OPENRLHF_Z3_LEAF_HYBRID=1 restores old behavior for architectures that need it.