### PR TITLE
test: propagate oneCCL log level to Ray workers

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -21,11 +21,15 @@ def train(args):
     if not ray.is_initialized():
         # Use os.environ.get() to respect user-set values (e.g. NCCL_DEBUG=INFO via
         # ray job submit --runtime-env-json), falling back to sensible defaults.
+        # NCCL_DEBUG and CCL_LOG_LEVEL are separate env vars read by separate libraries
+        # (NCCL for CUDA, oneCCL for XCCL/XPU) - each is set unconditionally so the right
+        # one applies regardless of which accelerator a given Ray worker ends up on.
         ray.init(
             runtime_env={
                 "env_vars": {
                     "TOKENIZERS_PARALLELISM": os.environ.get("TOKENIZERS_PARALLELISM", "true"),
                     "NCCL_DEBUG": os.environ.get("NCCL_DEBUG", "WARN"),
+                    "CCL_LOG_LEVEL": os.environ.get("CCL_LOG_LEVEL", "warn"),
                     "RAY_ENABLE_ZERO_COPY_TORCH_TENSORS": os.environ.get("RAY_ENABLE_ZERO_COPY_TORCH_TENSORS", "1"),
                 }
             }

--- a/tests/test_ray_env_vars.py
+++ b/tests/test_ray_env_vars.py
@@ -149,6 +149,13 @@ class TestRayEnvVarsDefaults:
             env_vars = _get_ray_init_env_vars()
         assert env_vars["RAY_ENABLE_ZERO_COPY_TORCH_TENSORS"] == "1"
 
+    def test_ccl_log_level_default(self):
+        # CCL_LOG_LEVEL is oneCCL/XCCL's own log-verbosity variable; independent of NCCL_DEBUG.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CCL_LOG_LEVEL", None)
+            env_vars = _get_ray_init_env_vars()
+        assert env_vars["CCL_LOG_LEVEL"] == "warn"
+
 
 # ---------------------------------------------------------------------------
 # Tests: user overrides
@@ -165,6 +172,11 @@ class TestRayEnvVarsUserOverride:
     def test_nccl_debug_user_trace(self):
         env_vars = _get_ray_init_env_vars({"NCCL_DEBUG": "TRACE"})
         assert env_vars["NCCL_DEBUG"] == "TRACE"
+
+    def test_ccl_log_level_user_debug(self):
+        # Same override guarantee as NCCL_DEBUG above, for CCL_LOG_LEVEL.
+        env_vars = _get_ray_init_env_vars({"CCL_LOG_LEVEL": "debug"})
+        assert env_vars["CCL_LOG_LEVEL"] == "debug"
 
     def test_tokenizers_parallelism_user_false(self):
         env_vars = _get_ray_init_env_vars({"TOKENIZERS_PARALLELISM": "false"})


### PR DESCRIPTION
Relates to https://github.com/OpenRLHF/OpenRLHF/issues/1303

## Summary

Propagate `CCL_LOG_LEVEL` to Ray workers and add tests covering its default and user-override behavior.

OpenRLHF already propagates `NCCL_DEBUG` through `ray.init(runtime_env=...)` for NVIDIA/NCCL diagnostics. Intel XPU distributed workloads use PyTorch's XCCL backend and the underlying oneCCL communication runtime, whose logging verbosity is controlled separately through `CCL_LOG_LEVEL`.

This change provides equivalent distributed-backend logging control for Intel XPU while preserving the existing NVIDIA/NCCL behavior.

## Changes

### `openrlhf/cli/train_ppo_ray.py`

Add `CCL_LOG_LEVEL` to the environment variables passed through `ray.init(runtime_env=...)`:

```python
"CCL_LOG_LEVEL": os.environ.get("CCL_LOG_LEVEL", "warn"),
```

This provides a warning-level default while preserving any value explicitly configured by the user.

### `tests/test_ray_env_vars.py`

Add two tests:

- `test_ccl_log_level_default`
  - Verifies that `CCL_LOG_LEVEL=warn` is passed to Ray workers when the user has not configured the variable.

- `test_ccl_log_level_user_debug`
  - Verifies that a user-provided value such as `CCL_LOG_LEVEL=debug` is preserved and propagated.

The tests exercise the actual environment-variable construction in `train_ppo_ray.py` while mocking the expensive Ray, DeepSpeed, and vLLM execution paths.

No existing test is modified.

## Motivation

`NCCL_DEBUG` controls NVIDIA NCCL logging and does not configure the oneCCL runtime used by XCCL.

Without propagating `CCL_LOG_LEVEL` through Ray's runtime environment, users cannot reliably control oneCCL/XCCL logging verbosity across Ray workers. This makes distributed Intel XPU failures more difficult to diagnose.

The logging configuration is therefore:

```text
NVIDIA CUDA -> NCCL         -> NCCL_DEBUG
Intel XPU   -> XCCL/oneCCL  -> CCL_LOG_LEVEL
```

Both variables can safely be included in the Ray runtime environment. Each communication library reads its corresponding variable, so accelerator-specific branching is not required during `ray.init()`.

## Test Plan

### Focused validation

```bash
python -m pytest tests/test_ray_env_vars.py -v
```

Results:

```text
Intel XPU:   11 passed
NVIDIA CUDA: 11 passed
```

The focused validation confirms that:

- The default `CCL_LOG_LEVEL=warn` is propagated correctly.
- User-provided `CCL_LOG_LEVEL` values are preserved.
- All nine existing Ray environment-variable tests continue to pass.
- Adding the oneCCL logging variable introduces no regression on NVIDIA/NCCL systems.

### Full regression validation

```bash
python -m pytest tests -v
```

Results:

```text
Intel XPU:   19 passed, 0 failed
NVIDIA CUDA: 19 passed, 0 failed
```

This confirms that the change works on Intel XPU and does not regress the existing OpenRLHF test suite on NVIDIA CUDA.

### Code-quality checks

```bash
pre-commit run --all-files
```

Result:

```text
All checks passed
```

## Scope

This PR modifies only:

```text
openrlhf/cli/train_ppo_ray.py
tests/test_ray_env_vars.py
```

It does not modify:
- Distributed-backend selection
- OpenRLHF training calculations
- Existing `NCCL_DEBUG` behavior
- Ray resource scheduling
- DeepSpeed or vLLM execution logic