### PR TITLE
test: run loss aggregation checks on accelerators

### DIFF
--- a/tests/test_loss_aggregation.py
+++ b/tests/test_loss_aggregation.py
@@ -3,6 +3,7 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
 import torch
 
 _TEST_PACKAGE = "_openrlhf_loss_test"
@@ -44,26 +45,57 @@ get_loss_batch_info = _loss_utils_module.get_loss_batch_info
 iter_grad_accum_global_norm = _loss_utils_module.iter_grad_accum_global_norm
 
 
-def test_token_mean_aggregation_matches_verl_dp_average():
-    loss = torch.tensor([[1.0, 2.0, 0.0], [3.0, 4.0, 5.0], [7.0, 0.0, 0.0]])
-    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 0.0]])
+def _discover_devices() -> list[str]:
+    """CPU plus whichever accelerator torch.accelerator reports as available, by name -
+    no hardcoded vendor list, so this picks up CUDA, XPU, ROCm, or any future backend
+    torch.accelerator recognizes without this file needing to change."""
+    devices = ["cpu"]
+    if torch.accelerator.is_available():
+        acc = torch.accelerator.current_accelerator(check_available=True)
+        if acc is not None:
+            devices.append(acc.type)
+    return devices
+
+
+DEVICES = _discover_devices()
+
+
+def _synchronize(device: str):
+    if device != "cpu":
+        torch.accelerator.synchronize()
+
+
+def _assert_on_device(device: str, *tensors):
+    if device == "cpu":
+        return
+    for t in tensors:
+        assert str(t.device).startswith(device), f"expected {device}, got {t.device}"
+
+
+@pytest.mark.parametrize("device", DEVICES)
+def test_token_mean_aggregation_matches_verl_dp_average(device):
+    loss = torch.tensor([[1.0, 2.0, 0.0], [3.0, 4.0, 5.0], [7.0, 0.0, 0.0]], device=device)
+    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 0.0]], device=device)
 
     global_token_mean = aggregate_loss(loss, mask)
     batch_num_tokens = mask.sum()
 
     rank0 = aggregate_loss(loss[:2], mask[:2], dp_size=2, batch_num_tokens=batch_num_tokens)
     rank1 = aggregate_loss(loss[2:], mask[2:], dp_size=2, batch_num_tokens=batch_num_tokens)
+    _synchronize(device)
 
     # DeepSpeed/DDP averages gradients across DP ranks; verl compensates by multiplying by dp_size.
+    _assert_on_device(device, global_token_mean, rank0, rank1)
     assert torch.allclose((rank0 + rank1) / 2, global_token_mean)
 
 
-def test_seq_mean_token_mean_aggregation_matches_verl_dp_average():
-    loss = torch.tensor([[1.0, 3.0, 9.0], [2.0, 4.0, 0.0], [8.0, 0.0, 0.0]])
-    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]])
+@pytest.mark.parametrize("device", DEVICES)
+def test_seq_mean_token_mean_aggregation_matches_verl_dp_average(device):
+    loss = torch.tensor([[1.0, 3.0, 9.0], [2.0, 4.0, 0.0], [8.0, 0.0, 0.0]], device=device)
+    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]], device=device)
 
     global_seq_mean = aggregate_loss(loss, mask, token_level_loss=False)
-    global_batch_size = torch.tensor(3.0)
+    global_batch_size = torch.tensor(3.0, device=device)
 
     rank0 = aggregate_loss(
         loss[:2],
@@ -79,26 +111,34 @@ def test_seq_mean_token_mean_aggregation_matches_verl_dp_average():
         dp_size=2,
         global_batch_size=global_batch_size,
     )
+    _synchronize(device)
 
+    _assert_on_device(device, global_seq_mean, rank0, rank1)
     assert torch.allclose((rank0 + rank1) / 2, global_seq_mean)
 
 
-def test_loss_batch_info_excludes_fully_masked_sequences():
-    loss = torch.tensor([[1.0, 3.0], [5.0, 7.0]])
-    mask = torch.tensor([[1.0, 1.0], [0.0, 0.0]])
+@pytest.mark.parametrize("device", DEVICES)
+def test_loss_batch_info_excludes_fully_masked_sequences(device):
+    loss = torch.tensor([[1.0, 3.0], [5.0, 7.0]], device=device)
+    mask = torch.tensor([[1.0, 1.0], [0.0, 0.0]], device=device)
 
     info = get_loss_batch_info(strategy=object(), loss_mask=mask)
     seq_loss = aggregate_loss(loss, mask, token_level_loss=False, **info)
+    _synchronize(device)
 
+    _assert_on_device(device, seq_loss)
     assert info["global_batch_size"].item() == 1.0
-    assert torch.allclose(seq_loss, torch.tensor(2.0))
+    assert torch.allclose(seq_loss, torch.tensor(2.0, device=device))
 
 
-def test_policy_loss_token_mean_aggregation_matches_full_batch():
-    log_probs = torch.tensor([[-0.20, -0.40, -0.10], [-0.70, -0.30, -0.20], [-0.60, -0.10, -0.50]])
-    old_log_probs = log_probs.detach() - torch.tensor([[0.03, -0.04, 0.01], [0.02, 0.05, -0.03], [0.04, 0.0, -0.02]])
-    advantages = torch.tensor([[1.0, -0.5, 0.0], [0.3, -1.2, 0.5], [1.5, 0.0, -0.7]])
-    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0]])
+@pytest.mark.parametrize("device", DEVICES)
+def test_policy_loss_token_mean_aggregation_matches_full_batch(device):
+    log_probs = torch.tensor([[-0.20, -0.40, -0.10], [-0.70, -0.30, -0.20], [-0.60, -0.10, -0.50]], device=device)
+    old_log_probs = log_probs.detach() - torch.tensor(
+        [[0.03, -0.04, 0.01], [0.02, 0.05, -0.03], [0.04, 0.0, -0.02]], device=device
+    )
+    advantages = torch.tensor([[1.0, -0.5, 0.0], [0.3, -1.2, 0.5], [1.5, 0.0, -0.7]], device=device)
+    mask = torch.tensor([[1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0]], device=device)
 
     loss_fn = PolicyLoss(clip_eps_low=0.2, clip_eps_high=0.2)
     full_loss, *_ = loss_fn(log_probs, old_log_probs, advantages, action_mask=mask)
@@ -120,14 +160,17 @@ def test_policy_loss_token_mean_aggregation_matches_full_batch():
         dp_size=2,
         batch_num_tokens=batch_num_tokens,
     )
+    _synchronize(device)
 
+    _assert_on_device(device, full_loss, rank0_loss, rank1_loss)
     assert torch.allclose((rank0_loss + rank1_loss) / 2, full_loss)
 
 
-def test_policy_kl_metric_uses_policy_ratio_when_vllm_correction_is_enabled():
-    log_probs = torch.tensor([[-0.2, -0.4]])
-    old_log_probs = torch.tensor([[-0.3, -0.1]])
-    rollout_log_probs = torch.tensor([[-1.3, -1.1]])
+@pytest.mark.parametrize("device", DEVICES)
+def test_policy_kl_metric_uses_policy_ratio_when_vllm_correction_is_enabled(device):
+    log_probs = torch.tensor([[-0.2, -0.4]], device=device)
+    old_log_probs = torch.tensor([[-0.3, -0.1]], device=device)
+    rollout_log_probs = torch.tensor([[-1.3, -1.1]], device=device)
     advantages = torch.ones_like(log_probs)
     mask = torch.ones_like(log_probs)
 
@@ -143,17 +186,20 @@ def test_policy_kl_metric_uses_policy_ratio_when_vllm_correction_is_enabled():
         action_mask=mask,
         rollout_log_probs=rollout_log_probs,
     )
+    _synchronize(device)
 
+    _assert_on_device(device, ppo_kl, vllm_kl)
     assert torch.allclose(ppo_kl, (old_log_probs - log_probs).mean())
     assert torch.allclose(vllm_kl, (rollout_log_probs - old_log_probs).mean())
 
 
-def test_grad_accum_global_norm_matches_global_token_mean_over_window():
+@pytest.mark.parametrize("device", DEVICES)
+def test_grad_accum_global_norm_matches_global_token_mean_over_window(device):
     # Two micro-batches in one optimizer-step window (gas=2) with UNEVEN token counts.
-    mb0 = torch.tensor([[1.0, 2.0, 0.0]])  # 2 tokens
-    mask0 = torch.tensor([[1.0, 1.0, 0.0]])
-    mb1 = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 0.0]])  # 5 tokens
-    mask1 = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]])
+    mb0 = torch.tensor([[1.0, 2.0, 0.0]], device=device)  # 2 tokens
+    mask0 = torch.tensor([[1.0, 1.0, 0.0]], device=device)
+    mb1 = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 0.0]], device=device)  # 5 tokens
+    mask1 = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]], device=device)
     gas = 2
 
     # Reference: a single per-token mean over the whole optimizer step (global token count).
@@ -177,28 +223,34 @@ def test_grad_accum_global_norm_matches_global_token_mean_over_window():
         assert torch.allclose(info["batch_num_tokens"], n_global / gas)
         per_mb = aggregate_loss(loss_mat, loss_mask, **{k: v for k, v in info.items() if k != "global_batch_size"})
         accumulated = accumulated + per_mb / gas  # DeepSpeed _scale_loss_by_gas
+    _synchronize(device)
     assert torch.allclose(accumulated, expected)
 
 
-def test_grad_accum_global_norm_differs_from_per_microbatch_when_uneven():
+@pytest.mark.parametrize("device", DEVICES)
+def test_grad_accum_global_norm_differs_from_per_microbatch_when_uneven(device):
     # Sanity: the OLD per-micro-batch normalization (mean of per-mb token-means) does NOT
     # equal the global token-mean when token counts are uneven -> confirms the fix matters.
-    mb0 = torch.tensor([[1.0, 2.0, 0.0]])
-    mask0 = torch.tensor([[1.0, 1.0, 0.0]])
-    mb1 = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 0.0]])
-    mask1 = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]])
+    mb0 = torch.tensor([[1.0, 2.0, 0.0]], device=device)
+    mask0 = torch.tensor([[1.0, 1.0, 0.0]], device=device)
+    mb1 = torch.tensor([[3.0, 4.0, 5.0], [6.0, 7.0, 0.0]], device=device)
+    mask1 = torch.tensor([[1.0, 1.0, 1.0], [1.0, 1.0, 0.0]], device=device)
 
     global_mean = ((mb0 * mask0).sum() + (mb1 * mask1).sum()) / (mask0.sum() + mask1.sum())
     per_mb = (aggregate_loss(mb0, mask0) + aggregate_loss(mb1, mask1)) / 2
+    _synchronize(device)
     assert not torch.allclose(per_mb, global_mean)
 
 
-def test_policy_kl_metric_is_not_clamped():
-    log_probs = torch.tensor([[100.0]])
+@pytest.mark.parametrize("device", DEVICES)
+def test_policy_kl_metric_is_not_clamped(device):
+    log_probs = torch.tensor([[100.0]], device=device)
     old_log_probs = torch.zeros_like(log_probs)
     advantages = torch.ones_like(log_probs)
     mask = torch.ones_like(log_probs)
 
     _, _, ppo_kl, _ = PolicyLoss()(log_probs, old_log_probs, advantages, action_mask=mask)
+    _synchronize(device)
 
+    _assert_on_device(device, ppo_kl)
     assert torch.allclose(ppo_kl, (old_log_probs - log_probs).mean())


### PR DESCRIPTION
Relates to https://github.com/OpenRLHF/OpenRLHF/issues/1303
## Summary

Extend `tests/test_loss_aggregation.py` to run the existing loss-aggregation test suite on CPU and, when available, the accelerator detected by PyTorch.

The tests currently create tensors without an explicit device, so they execute only on CPU. While this validates the mathematical logic, it does not verify numerical behavior, operator support, or tensor placement on the accelerator used during actual training.

This change adds accelerator coverage through PyTorch's generic accelerator API while retaining CPU coverage and avoiding separate CUDA-, XPU-, or vendor-specific copies of the tests.

## Changes

- Parameterize all eight existing loss-aggregation tests over:
  - CPU, which is always included.
  - The available accelerator reported by `torch.accelerator`, when present.
- Create input, mask, expected-result, log-probability, and advantage tensors directly on the selected device.
- Synchronize accelerator operations before validating results.
- Verify that relevant output tensors remain on the selected device.
- Preserve the original mathematical assertions and behavioral coverage of all eight tests.
- Keep the tests backend-neutral, without separate CUDA- or XPU-specific implementations.

## Motivation

During OpenRLHF training, loss, log-probability, advantage, and mask tensors normally reside on the training accelerator. CPU-only tests validate the formulas but do not exercise the same device path used in real training.

An implementation can behave correctly on CPU while still failing on an accelerator because of:

- Unsupported device operations.
- Accidental creation of CPU tensors.
- Device-mismatch errors.
- Unexpected movement of outputs back to CPU.
- Accelerator-specific numerical or reduction behavior.

Running the same tests on CPU and the available accelerator validates both mathematical correctness and tensor placement without duplicating the test suite for individual hardware vendors.

CPU-only environments remain unaffected because CPU is always included and accelerator parameterizations are added only when PyTorch reports an available accelerator.

## Test Coverage

The eight existing test functions continue to validate:

- Token-level mean aggregation across data-parallel partitions.
- Sequence-level mean aggregation across data-parallel partitions.
- Exclusion of fully masked sequences from batch-size calculation.
- Policy-loss token-mean aggregation.
- PPO and vLLM KL metric calculations.
- Global token normalization across gradient-accumulation windows.
- The difference between global and per-microbatch normalization for uneven token counts.
- Unclamped policy KL metric behavior.

The change extends these existing checks to the selected accelerator and does not alter their intended mathematical behavior.

## Test Plan

### Focused validation

```bash
python -m pytest tests/test_loss_aggregation.py -v
```

Results:

```text
Intel XPU:   16 passed - 8 CPU + 8 XPU
NVIDIA CUDA: 16 passed - 8 CPU + 8 CUDA
```

The focused validation confirms that all eight loss-aggregation tests:

- Preserve their original numerical behavior on CPU.
- Execute successfully on Intel XPU and NVIDIA CUDA.
- Keep relevant output tensors on the selected accelerator.
- Use the same backend-neutral test implementation across platforms.

### Full regression validation

```bash
python -m pytest tests -v
```

Results:

```text
Intel XPU:   25 passed, 0 failed
NVIDIA CUDA: 25 passed, 0 failed
```

This confirms that extending the loss-aggregation tests to accelerators does not regress the existing OpenRLHF test suite.

### Code-quality checks

```bash
pre-commit run --all-files
```

Result:

```text
All checks passed
```

## Scope

This PR modifies only:

```text
tests/test_loss_aggregation.py
```

It does not modify OpenRLHF training logic, loss-computation implementation, distributed initialization, Ray, DeepSpeed, or vLLM behavior.