### PR TITLE
fix: disable expandable segments for vLLM sleep mode

### DIFF
--- a/openrlhf/env_utils.py
+++ b/openrlhf/env_utils.py
@@ -1,0 +1,57 @@
+import os
+from typing import MutableMapping
+
+PYTORCH_ALLOC_CONF_ENV_VARS = (
+    "PYTORCH_CUDA_ALLOC_CONF",
+    "PYTORCH_ALLOC_CONF",
+)
+
+
+def configure_vllm_allocator_env(
+    enable_sleep_mode: bool,
+    env_vars: MutableMapping[str, str] | None = None,
+) -> list[str]:
+    """Make allocator settings compatible with vLLM sleep mode.
+
+    vLLM's ``CuMemAllocator`` rejects ``expandable_segments:True``. Preserve
+    every other allocator setting so the rollout actor does not discard user
+    tuning unrelated to expandable segments.
+
+    Returns the names of environment variables that were updated.
+    """
+    if not enable_sleep_mode:
+        return []
+
+    env_vars = os.environ if env_vars is None else env_vars
+    updated = []
+
+    for env_name in PYTORCH_ALLOC_CONF_ENV_VARS:
+        value = env_vars.get(env_name)
+        if value is None:
+            continue
+
+        kept_options = []
+        removed = False
+        for option in value.split(","):
+            option = option.strip()
+            if not option:
+                continue
+            key, separator, option_value = option.partition(":")
+            if (
+                separator
+                and key.strip().lower() == "expandable_segments"
+                and option_value.strip().lower() in {"true", "1"}
+            ):
+                removed = True
+                continue
+            kept_options.append(option)
+
+        if not removed:
+            continue
+        if kept_options:
+            env_vars[env_name] = ",".join(kept_options)
+        else:
+            env_vars.pop(env_name, None)
+        updated.append(env_name)
+
+    return updated

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -11,6 +11,7 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from vllm.inputs import TokensPrompt
 from vllm.utils import random_uuid
 
+from openrlhf.env_utils import configure_vllm_allocator_env
 from openrlhf.utils.agent import AgentExecutorBase, SingleTurnAgentExecutor
 
 from .utils import get_bundle_indices, ray_noset_visible_devices
@@ -48,7 +49,12 @@ class RolloutRayActor:
             bundle_indices=bundle_indices,
             num_gpus=kwargs.pop("num_gpus"),
         )
-        self._configure_vllm_env(version, vllm, kwargs.pop("full_determinism", False))
+        self._configure_vllm_env(
+            version,
+            vllm,
+            kwargs.pop("full_determinism", False),
+            bool(kwargs.get("enable_sleep_mode", False)),
+        )
 
         # Execution mode mapping:
         # - custom agent executor: user-provided AgentExecutorBase subclass
@@ -87,7 +93,11 @@ class RolloutRayActor:
             os.environ["VLLM_RAY_BUNDLE_INDICES"] = ",".join(map(str, bundle_indices))
             print(f"creating LLM with bundle_indices={bundle_indices}")
 
-    def _configure_vllm_env(self, version, vllm, full_determinism: bool):
+    def _configure_vllm_env(self, version, vllm, full_determinism: bool, enable_sleep_mode: bool):
+        updated_allocator_envs = configure_vllm_allocator_env(enable_sleep_mode)
+        if updated_allocator_envs:
+            print("Disabled expandable CUDA allocator segments for vLLM in " + ", ".join(updated_allocator_envs))
+
         assert version.parse(vllm.__version__) > version.parse(
             "0.8.5"
         ), "Streaming VLLM version must be greater than 0.8.5"

--- a/tests/test_vllm_allocator_env.py
+++ b/tests/test_vllm_allocator_env.py
@@ -1,0 +1,62 @@
+from openrlhf.env_utils import configure_vllm_allocator_env
+
+
+def test_removes_sole_legacy_expandable_segments_option():
+    env = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+    updated = configure_vllm_allocator_env(True, env)
+
+    assert updated == ["PYTORCH_CUDA_ALLOC_CONF"]
+    assert "PYTORCH_CUDA_ALLOC_CONF" not in env
+
+
+def test_preserves_other_allocator_options():
+    env = {
+        "PYTORCH_CUDA_ALLOC_CONF": "max_split_size_mb:128, expandable_segments:True, garbage_collection_threshold:0.8"
+    }
+
+    configure_vllm_allocator_env(True, env)
+
+    expected = "max_split_size_mb:128,garbage_collection_threshold:0.8"
+    assert env["PYTORCH_CUDA_ALLOC_CONF"] == expected
+
+
+def test_preserves_disabled_and_malformed_options():
+    original = "expandable_segments:False,expandable_segments,max_split_size_mb:64"
+    env = {"PYTORCH_CUDA_ALLOC_CONF": original}
+
+    updated = configure_vllm_allocator_env(True, env)
+
+    assert updated == []
+    assert env["PYTORCH_CUDA_ALLOC_CONF"] == original
+
+
+def test_sanitizes_legacy_and_current_environment_names():
+    env = {
+        "PYTORCH_CUDA_ALLOC_CONF": "EXPANDABLE_SEGMENTS : 1",
+        "PYTORCH_ALLOC_CONF": "expandable_segments:true,backend:cudaMallocAsync",
+    }
+
+    updated = configure_vllm_allocator_env(True, env)
+
+    assert updated == ["PYTORCH_CUDA_ALLOC_CONF", "PYTORCH_ALLOC_CONF"]
+    assert "PYTORCH_CUDA_ALLOC_CONF" not in env
+    assert env["PYTORCH_ALLOC_CONF"] == "backend:cudaMallocAsync"
+
+
+def test_missing_allocator_configuration_is_a_noop():
+    env = {"NCCL_DEBUG": "INFO"}
+
+    updated = configure_vllm_allocator_env(True, env)
+
+    assert updated == []
+    assert env == {"NCCL_DEBUG": "INFO"}
+
+
+def test_sleep_mode_disabled_preserves_expandable_segments():
+    env = {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}
+
+    updated = configure_vllm_allocator_env(False, env)
+
+    assert updated == []
+    assert env == {"PYTORCH_CUDA_ALLOC_CONF": "expandable_segments:True"}


### PR DESCRIPTION
## Summary

- remove expandable_segments:True before constructing vLLM rollout engines that use sleep mode
- preserve every unrelated PyTorch allocator option and leave non-sleep rollouts unchanged
- support both PYTORCH_CUDA_ALLOC_CONF and the newer PYTORCH_ALLOC_CONF name

Fixes #1011

## Why here

The sanitizer runs inside each rollout actor, after Ray has applied its runtime environment and immediately before AsyncLLMEngine creation. This covers Ray jobs that are already initialized and avoids changing allocator behavior for trainer actors.

## Validation

- pytest tests/test_ray_env_vars.py tests/test_vllm_allocator_env.py — 15 passed
- official pre-commit hooks on all changed files — passed (private-key/large-file checks, autoflake, isort, Black)
- Python 3.12 compile and git diff --check — passed
- process-environment smoke test — removed only expandable_segments:True and retained max_split_size_mb:128

A live vLLM sleep-mode startup requires the repository CUDA environment and is left to maintainer/GPU validation.