### PR TITLE
Add OPD Support

### DIFF
--- a/examples/scripts/train_opd.sh
+++ b/examples/scripts/train_opd.sh
@@ -1,0 +1,43 @@
+# 2-GPU sampled-mode OPD (--opd.topk == 0) on GSM8k, with held-out eval every 10 steps
+# Substitude the model path and data
+set -x
+MODEL_PATH=${MODEL_PATH:-"Qwen/Qwen2.5-0.5B-Instruct"}
+TEACHER_PATH=${TEACHER_PATH:-"Qwen/Qwen2.5-3B-Instruct"}
+DATA_DIR=${DATA_DIR:-"./data"}
+TRAIN_DATASET=${TRAIN_DATASET:-"${DATA_DIR}/gsm8k_train.jsonl"}
+EVAL_DATASET=${EVAL_DATASET:-"${DATA_DIR}/gsm8k_eval.jsonl"}
+SAVE_PATH=${SAVE_PATH:-"./exp/gsm8k_sampled_opd_k3"}
+
+[[ -n ${PYTHON_ENV} ]] && export PATH="${PYTHON_ENV}/bin:${PATH}"
+
+deepspeed --num_gpus 2 --module openrlhf.cli.train_opd \
+    --model.model_name_or_path ${MODEL_PATH} \
+    --teacher.model_name_or_path ${TEACHER_PATH} \
+    --data.prompt_dataset ${TRAIN_DATASET} \
+    --data.input_key question \
+    --data.label_key answer \
+    --data.apply_chat_template \
+    --data.max_samples 400 \
+    --data.prompt_max_len 512 \
+    --data.max_len 1024 \
+    --generate.max_new_tokens 512 \
+    --generate.temperature 1.0 \
+    --generate.top_p 1.0 \
+    --eval.dataset ${EVAL_DATASET} \
+    --eval.split train \
+    --eval.steps 10 \
+    --opd.topk 0 \
+    --opd.kl_estimator k3 \
+    --train.micro_batch_size 4 \
+    --train.batch_size 8 \
+    --train.max_epochs 1 \
+    --adam.lr 1e-6 \
+    --ds.zero_stage 2 \
+    --ds.param_dtype bf16 \
+    --ds.attn_implementation sdpa \
+    --model.gradient_checkpointing_enable \
+    --ckpt.output_dir ${SAVE_PATH} \
+    --ckpt.path "${SAVE_PATH}/ckpt" \
+    --ckpt.save_steps 1000 \
+    --logger.tensorboard_dir "${SAVE_PATH}/runs" \
+    --logger.logging_steps 1

--- a/openrlhf/cli/train_opd.py
+++ b/openrlhf/cli/train_opd.py
@@ -13,7 +13,6 @@ from openrlhf.utils import get_strategy, get_tokenizer
 def train(args):
     strategy = get_strategy(args)
     strategy.setup_distributed()
-    
 
     # student model (trainable)
     model = Actor(
@@ -32,7 +31,6 @@ def train(args):
     )
     strategy.print(model)
 
-    
     teacher_model = Actor(
         args.teacher.model_name_or_path,
         attn_implementation=args.ds.attn_implementation,
@@ -42,26 +40,30 @@ def train(args):
         ds_config=strategy.get_ds_eval_config(offload=False),
         packing_samples=args.ds.packing_samples,
     )
-    
+
     strategy.print(teacher_model)
-    
+
     tokenizer = get_tokenizer(
         args.model.model_name_or_path, model.model, "left", strategy, use_fast=not args.data.disable_fast_tokenizer
     )
     teacher_tokenizer = get_tokenizer(
-            args.teacher.model_name_or_path, teacher_model.model, "left", strategy, use_fast=not args.data.disable_fast_tokenizer
+        args.teacher.model_name_or_path,
+        teacher_model.model,
+        "left",
+        strategy,
+        use_fast=not args.data.disable_fast_tokenizer,
     )
-        
+
     if hasattr(tokenizer, "image_processor"):
         raise ValueError("Standalone image processor is not supported in OPD yet")
     if tokenizer.eos_token_id is None or tokenizer.pad_token_id is None:
         raise ValueError("Student tokenizer must define eos_token_id and pad_token_id")
     if hasattr(teacher_tokenizer, "image_processor"):
         raise ValueError("Standalone image processor is not supported in OPD yet")
-    
+
     student_vocab = tokenizer.get_vocab()
     teacher_vocab = teacher_tokenizer.get_vocab()
-        
+
     if student_vocab != teacher_vocab:
         raise ValueError("Student and teacher tokenizers must have the same vocabulary")
     if teacher_tokenizer.eos_token_id != tokenizer.eos_token_id:
@@ -70,14 +72,12 @@ def train(args):
         raise ValueError("Student and teacher tokenizers must have the same pad_token_id")
     if model.model.config.vocab_size != teacher_model.model.config.vocab_size:
         raise ValueError("Student and teacher models must have the same vocabulary size")
-    
+
     if args.model.gradient_checkpointing_enable:
         model.gradient_checkpointing_enable(
-            gradient_checkpointing_kwargs={
-                "use_reentrant": args.model.gradient_checkpointing_reentrant
-            }
+            gradient_checkpointing_kwargs={"use_reentrant": args.model.gradient_checkpointing_reentrant}
         )
-        
+
     train_data = blending_datasets(
         args.data.prompt_dataset,
         args.data.prompt_probs,
@@ -88,7 +88,7 @@ def train(args):
     )
     train_data = train_data.select(range(min(args.data.max_samples, len(train_data))))
     train_dataset = PromptDataset(train_data, tokenizer, strategy, input_template=args.data.input_template)
-    
+
     train_dataloader = strategy.setup_dataloader(
         train_dataset,
         args.train.micro_batch_size,
@@ -97,7 +97,7 @@ def train(args):
         train_dataset.collate_fn,
         num_workers=args.data.dataloader_num_workers,
     )
-    
+
     eval_dataloader = None
     if getattr(args.eval, "dataset", None):
         eval_data = blending_datasets(
@@ -119,7 +119,7 @@ def train(args):
 
     num_update_steps_per_epoch = len(train_dataset) // args.train.batch_size
     max_steps = math.ceil(args.train.max_epochs * num_update_steps_per_epoch)
-    
+
     cfg = dict(
         optim=args.optim,
         muon=vars(args.muon),
@@ -130,17 +130,17 @@ def train(args):
         max_norm=args.max_norm,
         scheduler_steps=max_steps,
     )
-    (model, optim, scheduler), teacher_model = strategy.prepare((model,cfg), teacher_model)
-    
+    (model, optim, scheduler), teacher_model = strategy.prepare((model, cfg), teacher_model)
+
     consumed_samples = 0
     if args.ckpt.load_enable and os.path.exists(args.ckpt.path):
         load_path, states = strategy.load_ckpt(model.model, args.ckpt.path)
         if load_path is not None:
-            consumed_samples = states['consumed_samples']
+            consumed_samples = states["consumed_samples"]
             strategy.print(f"Loaded checkpoint from {load_path}, consumed samples: {consumed_samples}")
-            
+
     os.makedirs(args.ckpt.output_dir, exist_ok=True)
-    
+
     trainer = OPDTrainer(
         model=model,
         teacher_model=teacher_model,
@@ -155,12 +155,12 @@ def train(args):
         save_hf_ckpt=args.ckpt.save_hf,
         disable_ds_ckpt=args.ckpt.disable_ds,
     )
-    
+
     trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
 
     strategy.save_model(model, tokenizer, args.ckpt.output_dir)
-    
-    
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     # Checkpoints
@@ -170,12 +170,12 @@ if __name__ == "__main__":
     parser.add_argument("--ckpt.disable_ds", action="store_true", default=False)
     parser.add_argument("--logger.logging_steps", type=int, default=1)
     parser.add_argument(
-        "--eval.steps", 
-        type=int, 
-        default=-1, 
+        "--eval.steps",
+        type=int,
+        default=-1,
         help="Optimizer steps between evals; -1= once per epoch when --eval.dataset is set, "
-        "otherwise never. Eval will run a full forward pass over held out prompts"
-    )    
+        "otherwise never. Eval will run a full forward pass over held out prompts",
+    )
     parser.add_argument("--ckpt.path", type=str, default="./ckpt/checkpoints_dpo")
     parser.add_argument("--ckpt.max_num", type=int, default=3)
     parser.add_argument("--ckpt.max_mem", type=int, default=int(1e8))
@@ -194,7 +194,7 @@ if __name__ == "__main__":
         default=False,
         help="Enable reproducible behavior during distributed training",
     )
-    
+
     parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
     parser.add_argument("--ds.zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
     parser.add_argument(
@@ -235,44 +235,31 @@ if __name__ == "__main__":
     parser.add_argument("--model.aux_loss_coef", type=float, default=0, help="MoE balancing loss")
     parser.add_argument("--teacher.model_name_or_path", type=str, default=None, help="Teacher model name or path")
     parser.add_argument(
-        "--opd.kl_estimator", 
-        type=str, 
-        default="k3", 
-        choices=["k1", "k2", "k3"], 
+        "--opd.kl_estimator",
+        type=str,
+        default="k3",
+        choices=["k1", "k2", "k3"],
         help="KL estimator for the sampled-token mode. Affect logged metrics only "
-        "The training gradient is always the reverse-KL score function estimator"
+        "The training gradient is always the reverse-KL score function estimator",
     )
     parser.add_argument(
-        "--opd.topk", 
-        type=int, 
-        default=0, 
-        help="0 = sampled-token reverse RL. >0 will be running reverse KL over student's topk vocab against teachers topk vocab"
+        "--opd.topk",
+        type=int,
+        default=0,
+        help="0 = sampled-token reverse RL. >0 will be running reverse KL over student's topk vocab against teachers topk vocab",
     )
     parser.add_argument(
-        "--opd.kd_temperature", 
-        type=float, 
-        default=1.0, 
-        help="Softmax temperature applied to teacher and student logits in topk reverse KL computation"
+        "--opd.kd_temperature",
+        type=float,
+        default=1.0,
+        help="Softmax temperature applied to teacher and student logits in topk reverse KL computation",
     )
-    
+
     # Generation (on-policy rollout configs)
+    parser.add_argument("--generate.max_new_tokens", type=int, default=1024, help="Max tokens generated per prompt")
+    parser.add_argument("--generate.temperature", type=float, default=1.0, help="Sampling temperature for generation")
     parser.add_argument(
-        "--generate.max_new_tokens", 
-        type=int, 
-        default=1024, 
-        help="Max tokens generated per prompt"
-    )
-    parser.add_argument(
-        "--generate.temperature", 
-        type=float, 
-        default=1.0, 
-        help="Sampling temperature for generation"
-    )
-    parser.add_argument(
-        "--generate.top_p", 
-        type=float, 
-        default=1.0, 
-        help="Nucleus top_p. Must be 1.0 in sampled mode (opd.topk=0)"
+        "--generate.top_p", type=float, default=1.0, help="Nucleus top_p. Must be 1.0 in sampled mode (opd.topk=0)"
     )
     # Optimizer + scheduler + grad clip.  Two sections:
     #   --muon.*  Muon-specific hypers (only used when --optim=muon)
@@ -320,17 +307,16 @@ if __name__ == "__main__":
     parser.add_argument("--ds.lora.target_modules", type=str, nargs="*", default="all-linear")
     parser.add_argument("--ds.lora.dropout", type=float, default=0)
 
-
     # Custom dataset
     parser.add_argument("--data.prompt_dataset", type=str, default=None, help="Path to the prompt dataset")
     parser.add_argument(
         "--data.prompt_probs", type=str, default=None, help="Sampling probabilities for training datasets"
     )
     parser.add_argument("--data.prompt_split", type=str, default="train")
-    
+
     parser.add_argument("--eval.dataset", type=str, default=None, help="Path to the evaluation dataset")
     parser.add_argument("--eval.split", type=str, default="train")
-    parser.add_argument("--data.max_samples", type=int, default=1000000, help="Maximum number of samples to use")    
+    parser.add_argument("--data.max_samples", type=int, default=1000000, help="Maximum number of samples to use")
     parser.add_argument("--data.input_key", type=str, default="input", help="Json dataset input key")
     parser.add_argument("--data.label_key", type=str, default="label", help="Json dataset label key")
     parser.add_argument("--data.input_template", type=str, default=None)
@@ -361,12 +347,12 @@ if __name__ == "__main__":
     from openrlhf.utils.config import hierarchize
 
     args = hierarchize(args)
-    
+
     if not args.model.model_name_or_path:
         parser.error("model_name_or_path is required")
     if not args.teacher.model_name_or_path:
         parser.error("teacher.model_name_or_path is required")
-    
+
     if args.ds.zero_stage > 2:
         parser.error("OPD trainer does not support DeepSpeed ZeRO stage 3")
     if args.ds.tensor_parallel_size != 1:
@@ -383,7 +369,7 @@ if __name__ == "__main__":
         parser.error("generate.top_p must be a positive integer")
     if args.data.prompt_max_len + args.generate.max_new_tokens > args.data.max_len:
         parser.error("The sum of prompt_max_len and max_new_tokens exceeds max_len")
-        
+
     if args.opd.topk > 0:
         if args.ds.packing_samples:
             parser.error("OPD trainer does not support packing_samples with topk > 0")
@@ -392,7 +378,7 @@ if __name__ == "__main__":
     else:
         if args.generate.temperature != 1.0 or args.generate.top_p != 1.0:
             parser.error("generate.temperature and generate.top_p must be 1.0 when topk is 0")
-            
+
     if args.data.input_template and "{}" not in args.data.input_template:
         print("[Warning] '{}' not in args.data.input_template, set to None")
         args.data.input_template = None
@@ -414,5 +400,3 @@ if __name__ == "__main__":
         patch_hub()
 
     train(args)
-
-    

--- a/openrlhf/cli/train_opd.py
+++ b/openrlhf/cli/train_opd.py
@@ -1,0 +1,418 @@
+import argparse
+import math
+import os
+from datetime import datetime
+
+from openrlhf.datasets import PromptDataset
+from openrlhf.datasets.utils import blending_datasets
+from openrlhf.models import Actor
+from openrlhf.trainer.opd_trainer import OPDTrainer
+from openrlhf.utils import get_strategy, get_tokenizer
+
+
+def train(args):
+    strategy = get_strategy(args)
+    strategy.setup_distributed()
+    
+
+    # student model (trainable)
+    model = Actor(
+        args.model.model_name_or_path,
+        attn_implementation=args.ds.attn_implementation,
+        experts_implementation=args.ds.experts_implementation,
+        param_dtype=args.ds.param_dtype,
+        load_in_4bit=args.ds.load_in_4bit,
+        lora_rank=args.ds.lora.rank,
+        lora_alpha=args.ds.lora.alpha,
+        lora_dropout=args.ds.lora.dropout,
+        target_modules=args.ds.lora.target_modules,
+        ds_config=strategy.get_ds_train_config(is_actor=True),
+        packing_samples=args.ds.packing_samples,
+        use_liger_kernel=args.ds.use_liger_kernel,
+    )
+    strategy.print(model)
+
+    
+    teacher_model = Actor(
+        args.teacher.model_name_or_path,
+        attn_implementation=args.ds.attn_implementation,
+        experts_implementation=args.ds.experts_implementation,
+        param_dtype=args.ds.param_dtype,
+        load_in_4bit=args.ds.load_in_4bit,
+        ds_config=strategy.get_ds_eval_config(offload=False),
+        packing_samples=args.ds.packing_samples,
+    )
+    
+    strategy.print(teacher_model)
+    
+    tokenizer = get_tokenizer(
+        args.model.model_name_or_path, model.model, "left", strategy, use_fast=not args.data.disable_fast_tokenizer
+    )
+    teacher_tokenizer = get_tokenizer(
+            args.teacher.model_name_or_path, teacher_model.model, "left", strategy, use_fast=not args.data.disable_fast_tokenizer
+    )
+        
+    if hasattr(tokenizer, "image_processor"):
+        raise ValueError("Standalone image processor is not supported in OPD yet")
+    if tokenizer.eos_token_id is None or tokenizer.pad_token_id is None:
+        raise ValueError("Student tokenizer must define eos_token_id and pad_token_id")
+    if hasattr(teacher_tokenizer, "image_processor"):
+        raise ValueError("Standalone image processor is not supported in OPD yet")
+    
+    student_vocab = tokenizer.get_vocab()
+    teacher_vocab = teacher_tokenizer.get_vocab()
+        
+    if student_vocab != teacher_vocab:
+        raise ValueError("Student and teacher tokenizers must have the same vocabulary")
+    if teacher_tokenizer.eos_token_id != tokenizer.eos_token_id:
+        raise ValueError("Student and teacher tokenizers must have the same eos_token_id")
+    if teacher_tokenizer.pad_token_id != tokenizer.pad_token_id:
+        raise ValueError("Student and teacher tokenizers must have the same pad_token_id")
+    if model.model.config.vocab_size != teacher_model.model.config.vocab_size:
+        raise ValueError("Student and teacher models must have the same vocabulary size")
+    
+    if args.model.gradient_checkpointing_enable:
+        model.gradient_checkpointing_enable(
+            gradient_checkpointing_kwargs={
+                "use_reentrant": args.model.gradient_checkpointing_reentrant
+            }
+        )
+        
+    train_data = blending_datasets(
+        args.data.prompt_dataset,
+        args.data.prompt_probs,
+        strategy,
+        args.train.seed,
+        max_count=args.data.max_samples,
+        dataset_split=args.data.prompt_split,
+    )
+    train_data = train_data.select(range(min(args.data.max_samples, len(train_data))))
+    train_dataset = PromptDataset(train_data, tokenizer, strategy, input_template=args.data.input_template)
+    
+    train_dataloader = strategy.setup_dataloader(
+        train_dataset,
+        args.train.micro_batch_size,
+        True,
+        True,
+        train_dataset.collate_fn,
+        num_workers=args.data.dataloader_num_workers,
+    )
+    
+    eval_dataloader = None
+    if getattr(args.eval, "dataset", None):
+        eval_data = blending_datasets(
+            args.eval.dataset,
+            None,
+            strategy,
+            dataset_split=args.eval.split,
+        )
+        eval_data = eval_data.select(range(min(args.data.max_samples, len(eval_data))))
+        eval_dataset = PromptDataset(eval_data, tokenizer, strategy, input_template=args.data.input_template)
+        eval_dataloader = strategy.setup_dataloader(
+            eval_dataset,
+            args.train.micro_batch_size,
+            True,
+            False,
+            eval_dataset.collate_fn,
+            num_workers=args.data.dataloader_num_workers,
+        )
+
+    num_update_steps_per_epoch = len(train_dataset) // args.train.batch_size
+    max_steps = math.ceil(args.train.max_epochs * num_update_steps_per_epoch)
+    
+    cfg = dict(
+        optim=args.optim,
+        muon=vars(args.muon),
+        adam=vars(args.adam),
+        lr_scheduler=args.lr_scheduler,
+        lr_warmup_ratio=args.lr_warmup_ratio,
+        min_lr_ratio=args.min_lr_ratio,
+        max_norm=args.max_norm,
+        scheduler_steps=max_steps,
+    )
+    (model, optim, scheduler), teacher_model = strategy.prepare((model,cfg), teacher_model)
+    
+    consumed_samples = 0
+    if args.ckpt.load_enable and os.path.exists(args.ckpt.path):
+        load_path, states = strategy.load_ckpt(model.model, args.ckpt.path)
+        if load_path is not None:
+            consumed_samples = states['consumed_samples']
+            strategy.print(f"Loaded checkpoint from {load_path}, consumed samples: {consumed_samples}")
+            
+    os.makedirs(args.ckpt.output_dir, exist_ok=True)
+    
+    trainer = OPDTrainer(
+        model=model,
+        teacher_model=teacher_model,
+        strategy=strategy,
+        tokenizer=tokenizer,
+        optim=optim,
+        train_dataloader=train_dataloader,
+        eval_dataloader=eval_dataloader,
+        scheduler=scheduler,
+        max_norm=args.max_norm,
+        max_epochs=args.train.max_epochs,
+        save_hf_ckpt=args.ckpt.save_hf,
+        disable_ds_ckpt=args.ckpt.disable_ds,
+    )
+    
+    trainer.fit(args, consumed_samples, num_update_steps_per_epoch)
+
+    strategy.save_model(model, tokenizer, args.ckpt.output_dir)
+    
+    
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # Checkpoints
+    parser.add_argument("--ckpt.output_dir", type=str, default="./ckpt")
+    parser.add_argument("--ckpt.save_steps", type=int, default=-1)
+    parser.add_argument("--ckpt.save_hf", action="store_true", default=False)
+    parser.add_argument("--ckpt.disable_ds", action="store_true", default=False)
+    parser.add_argument("--logger.logging_steps", type=int, default=1)
+    parser.add_argument(
+        "--eval.steps", 
+        type=int, 
+        default=-1, 
+        help="Optimizer steps between evals; -1= once per epoch when --eval.dataset is set, "
+        "otherwise never. Eval will run a full forward pass over held out prompts"
+    )    
+    parser.add_argument("--ckpt.path", type=str, default="./ckpt/checkpoints_dpo")
+    parser.add_argument("--ckpt.max_num", type=int, default=3)
+    parser.add_argument("--ckpt.max_mem", type=int, default=int(1e8))
+    parser.add_argument("--ds.use_universal_ckpt", action="store_true", default=False)
+    parser.add_argument("--ckpt.load_enable", action="store_true", default=False)
+
+    # DeepSpeed
+    parser.add_argument("--train.micro_batch_size", type=int, default=8, help="batch size per GPU")
+    parser.add_argument("--train.batch_size", type=int, default=128, help="Global training batch size")
+    parser.add_argument("--model.gradient_checkpointing_enable", action="store_true", default=False)
+    parser.add_argument("--ds.deepcompile", action="store_true", default=False)
+    parser.add_argument("--train.seed", type=int, default=42)
+    parser.add_argument(
+        "--train.full_determinism_enable",
+        action="store_true",
+        default=False,
+        help="Enable reproducible behavior during distributed training",
+    )
+    
+    parser.add_argument("--local_rank", type=int, default=-1, help="local_rank for deepspeed")
+    parser.add_argument("--ds.zero_stage", type=int, default=2, help="DeepSpeed ZeRO stage")
+    parser.add_argument(
+        "--ds.param_dtype",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp16"],
+        help="Model data type",
+    )
+    parser.add_argument("--ds.zpg", type=int, default=1, help="ZeRO++ max partition size")
+    parser.add_argument("--ds.adam_offload", action="store_true", default=False, help="Offload Adam Optimizer")
+    parser.add_argument(
+        "--ds.attn_implementation",
+        type=str,
+        default="flash_attention_2",
+        help="Attention implementation (e.g., eager, flash_attention_2, flash_attention_3, kernels-community/vllm-flash-attn3)",
+    )
+    parser.add_argument(
+        "--ds.experts_implementation",
+        type=str,
+        default=None,
+        choices=["eager", "batched_mm", "grouped_mm", "deepgemm"],
+        help="MoE expert computation strategy passed to transformers from_pretrained (default: auto — transformers picks grouped_mm when supported, else eager)",
+    )
+    parser.add_argument("--ds.use_liger_kernel", action="store_true", default=False, help="Enable Liger Kernel")
+    parser.add_argument("--ds.grad_accum_dtype", type=str, default=None, help="Adam grad accum data type")
+    parser.add_argument("--ds.overlap_comm", action="store_true", default=False)
+    parser.add_argument("--model.gradient_checkpointing_reentrant", action="store_true", default=False)
+    parser.add_argument("--data.disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--data.dataloader_num_workers", type=int, default=0, help="Number of dataloader workers")
+    parser.add_argument("--ds.tensor_parallel_size", type=int, default=1, help="DeepSpeed Tensor parallel size")
+    parser.add_argument("--ds.packing_samples", action="store_true", default=False)
+
+    # OPD
+    parser.add_argument("--train.max_epochs", type=int, default=1)
+    parser.add_argument("--model.beta", type=float, default=0.1)
+    parser.add_argument("--model.model_name_or_path", type=str, default=None)
+    parser.add_argument("--model.aux_loss_coef", type=float, default=0, help="MoE balancing loss")
+    parser.add_argument("--teacher.model_name_or_path", type=str, default=None, help="Teacher model name or path")
+    parser.add_argument(
+        "--opd.kl_estimator", 
+        type=str, 
+        default="k3", 
+        choices=["k1", "k2", "k3"], 
+        help="KL estimator for the sampled-token mode. Affect logged metrics only "
+        "The training gradient is always the reverse-KL score function estimator"
+    )
+    parser.add_argument(
+        "--opd.topk", 
+        type=int, 
+        default=0, 
+        help="0 = sampled-token reverse RL. >0 will be running reverse KL over student's topk vocab against teachers topk vocab"
+    )
+    parser.add_argument(
+        "--opd.kd_temperature", 
+        type=float, 
+        default=1.0, 
+        help="Softmax temperature applied to teacher and student logits in topk reverse KL computation"
+    )
+    
+    # Generation (on-policy rollout configs)
+    parser.add_argument(
+        "--generate.max_new_tokens", 
+        type=int, 
+        default=1024, 
+        help="Max tokens generated per prompt"
+    )
+    parser.add_argument(
+        "--generate.temperature", 
+        type=float, 
+        default=1.0, 
+        help="Sampling temperature for generation"
+    )
+    parser.add_argument(
+        "--generate.top_p", 
+        type=float, 
+        default=1.0, 
+        help="Nucleus top_p. Must be 1.0 in sampled mode (opd.topk=0)"
+    )
+    # Optimizer + scheduler + grad clip.  Two sections:
+    #   --muon.*  Muon-specific hypers (only used when --optim=muon)
+    #   --adam.*  AdamW hypers — drives pure AdamW when --optim=adam,
+    #             and Muon's aux-Adam subgroup when --optim=muon.
+    # Note: DS v0.18.2 Muon ignores ns_steps / nesterov (hard-coded 5 / True) so
+    # they are intentionally not exposed here.
+    parser.add_argument("--optim", type=str, default="adam", choices=["adam", "muon"])
+    # Muon-specific
+    parser.add_argument("--muon.lr", type=float, default=0.02, help="LR for Muon 2D-weight group")
+    parser.add_argument("--muon.momentum", type=float, default=0.95)
+    # Placeholder slots: DS v0.18.x hard-codes ns_steps=5, nesterov=True inside
+    # muon_update() and ignores these via config. Retained for forward-compat;
+    # runtime warns when user sets a non-default value.
+    parser.add_argument("--muon.ns_steps", type=int, default=5)
+    parser.add_argument("--muon.nesterov", action="store_true", default=True)
+    parser.add_argument("--muon.no_nesterov", dest="muon.nesterov", action="store_false")
+    # AdamW (shared: pure-AdamW when --optim=adam, Muon's aux-Adam subgroup when --optim=muon)
+    parser.add_argument("--adam.lr", type=float, default=1e-6)
+    parser.add_argument("--adam.betas", type=float, nargs=2, default=(0.9, 0.95))
+    parser.add_argument("--adam.eps", type=float, default=1e-8)
+    parser.add_argument("--adam.weight_decay", type=float, default=0.0)
+    # Scheduler
+    parser.add_argument("--lr_scheduler", type=str, default="cosine_with_min_lr")
+    parser.add_argument("--lr_warmup_ratio", type=float, default=0.03)
+    parser.add_argument("--min_lr_ratio", type=float, default=0.1)
+    # Gradient clip
+    parser.add_argument("--max_norm", type=float, default=1.0, help="Gradient clipping")
+
+    # Context Parallel
+    parser.add_argument("--ds.ring_attn_size", type=int, default=1, help="Ring attention group size")
+    parser.add_argument(
+        "--ds.ring_attn_head_stride",
+        type=int,
+        default=1,
+        help="the number of heads to do ring attention each time. "
+        "It should be a divisor of the number of heads. "
+        "A larger value may results in faster training but will consume more memory.",
+    )
+
+    # LoRA
+    parser.add_argument("--ds.load_in_4bit", action="store_true", default=False)
+    parser.add_argument("--ds.lora.rank", type=int, default=0)
+    parser.add_argument("--ds.lora.alpha", type=int, default=16)
+    parser.add_argument("--ds.lora.target_modules", type=str, nargs="*", default="all-linear")
+    parser.add_argument("--ds.lora.dropout", type=float, default=0)
+
+
+    # Custom dataset
+    parser.add_argument("--data.prompt_dataset", type=str, default=None, help="Path to the prompt dataset")
+    parser.add_argument(
+        "--data.prompt_probs", type=str, default=None, help="Sampling probabilities for training datasets"
+    )
+    parser.add_argument("--data.prompt_split", type=str, default="train")
+    
+    parser.add_argument("--eval.dataset", type=str, default=None, help="Path to the evaluation dataset")
+    parser.add_argument("--eval.split", type=str, default="train")
+    parser.add_argument("--data.max_samples", type=int, default=1000000, help="Maximum number of samples to use")    
+    parser.add_argument("--data.input_key", type=str, default="input", help="Json dataset input key")
+    parser.add_argument("--data.label_key", type=str, default="label", help="Json dataset label key")
+    parser.add_argument("--data.input_template", type=str, default=None)
+    parser.add_argument(
+        "--data.apply_chat_template", action="store_true", default=False, help="Use HF tokenizer chat template"
+    )
+    parser.add_argument("--data.prompt_max_len", type=int, default=1024, help="Max prompt length (for generation)")
+    parser.add_argument("--data.max_len", type=int, default=512, help="Max total sequence length")
+
+    # wandb parameters
+    parser.add_argument("--logger.wandb.key", type=str, default=None)
+    parser.add_argument("--logger.wandb.org", type=str, default=None)
+    parser.add_argument("--logger.wandb.group", type=str, default=None)
+    parser.add_argument("--logger.wandb.project", type=str, default="openrlhf_train_dpo")
+    parser.add_argument(
+        "--logger.wandb.run_name",
+        type=str,
+        default="exp_%s" % datetime.now().strftime("%m%dT%H:%M"),
+    )
+
+    # TensorBoard parameters
+    parser.add_argument("--logger.tensorboard_dir", type=str, default=None, help="TensorBoard logging path")
+
+    # ModelScope parameters
+    parser.add_argument("--use_ms", action="store_true", default=False)
+
+    args = parser.parse_args()
+    from openrlhf.utils.config import hierarchize
+
+    args = hierarchize(args)
+    
+    if not args.model.model_name_or_path:
+        parser.error("model_name_or_path is required")
+    if not args.teacher.model_name_or_path:
+        parser.error("teacher.model_name_or_path is required")
+    
+    if args.ds.zero_stage > 2:
+        parser.error("OPD trainer does not support DeepSpeed ZeRO stage 3")
+    if args.ds.tensor_parallel_size != 1:
+        parser.error("OPD trainer does not support tensor parallelism")
+    if args.opd.topk < 0:
+        parser.error("OPD trainer does not support negative top_k values")
+    if args.opd.kd_temperature <= 0:
+        parser.error("OPD trainer does not support non-positive kd_temperature values")
+    if args.generate.max_new_tokens <= 0:
+        parser.error("generate.max_new_tokens must be a positive integer")
+    if args.generate.temperature <= 0:
+        parser.error("generate.temperature must be a positive integer")
+    if not 0 < args.generate.top_p <= 1:
+        parser.error("generate.top_p must be a positive integer")
+    if args.data.prompt_max_len + args.generate.max_new_tokens > args.data.max_len:
+        parser.error("The sum of prompt_max_len and max_new_tokens exceeds max_len")
+        
+    if args.opd.topk > 0:
+        if args.ds.packing_samples:
+            parser.error("OPD trainer does not support packing_samples with topk > 0")
+        if args.ds.ring_attn_size > 1:
+            parser.error("OPD trainer does not support ring attention with topk > 0")
+    else:
+        if args.generate.temperature != 1.0 or args.generate.top_p != 1.0:
+            parser.error("generate.temperature and generate.top_p must be 1.0 when topk is 0")
+            
+    if args.data.input_template and "{}" not in args.data.input_template:
+        print("[Warning] '{}' not in args.data.input_template, set to None")
+        args.data.input_template = None
+
+    if args.ds.ring_attn_size > 1:
+        if not args.ds.packing_samples:
+            parser.error("ring attention requires packing_samples to be enabled")
+
+    if args.ds.packing_samples and "flash_attention" not in args.ds.attn_implementation:
+        print(
+            "[Warning] Please use --attn_implementation with flash_attention to accelerate when --packing_samples is enabled."
+        )
+        args.ds.attn_implementation = "flash_attention_2"
+
+    if args.use_ms:
+        from modelscope.utils.hf_util import patch_hub
+
+        # Patch hub to download models from modelscope to speed up.
+        patch_hub()
+
+    train(args)
+
+    

--- a/openrlhf/trainer/opd_trainer.py
+++ b/openrlhf/trainer/opd_trainer.py
@@ -12,51 +12,50 @@ from openrlhf.utils.loss_utils import get_loss_batch_info
 
 
 def build_generation_mask(sequences, prompt_len, prompt_attention_mask, eos_token_id):
-    """ Build a full attention mask and the response ``action_mask`` for the generated tokens. 
+    """Build a full attention mask and the response ``action_mask`` for the generated tokens.
     ``sequences`` is (B, prompt_len + gen_len) from model.generate. Anything after first EOS is masked
     """
     B = sequences.size(0)
     device = sequences.device
     gen = sequences[:, prompt_len:]
     gen_len = gen.size(1)
-    
+
     is_eos = gen == eos_token_id
     has_eos = is_eos.any(dim=1)
-    
+
     first_eos = torch.where(
-        has_eos,
-        is_eos.float().argmax(dim=1).long(),
-        torch.full((B, ), gen_len - 1, device=device, dtype=torch.long)
+        has_eos, is_eos.float().argmax(dim=1).long(), torch.full((B,), gen_len - 1, device=device, dtype=torch.long)
     )
     positions = torch.arange(gen_len, device=device).unsqueeze(0).expand(B, -1)
     action_mask = (positions <= first_eos.unsqueeze(1)).long()
-    
+
     attention_mask = torch.cat([prompt_attention_mask.to(device), action_mask], dim=1)
     return attention_mask, action_mask
 
+
 def align_response_logits(logits, num_actions):
-    return logits[:, -num_actions -1:-1, :]
+    return logits[:, -num_actions - 1 : -1, :]
 
 
 def compute_opd_loss(
-    student_action_log_probs, 
+    student_action_log_probs,
     teacher_action_log_probs,
-    action_mask, 
+    action_mask,
     kl_estimator="k3",
-    loss_batch_info=None, 
+    loss_batch_info=None,
 ):
     teacher_action_log_probs = teacher_action_log_probs.detach()
     log_ratio = student_action_log_probs - teacher_action_log_probs
     kl = compute_approx_kl(student_action_log_probs, teacher_action_log_probs, kl_estimator=kl_estimator)
-    
+
     surrogate = log_ratio.detach() * student_action_log_probs
     loss = kl.detach() + surrogate - surrogate.detach()
     return aggregate_loss(loss, action_mask, **(loss_batch_info or {}))
-    
-    
+
+
 def compute_topk_token_kl(
-    student_resp_logits, 
-    teacher_resp_logits, 
+    student_resp_logits,
+    teacher_resp_logits,
     topk=5,
     temperature=1.0,
 ):
@@ -68,7 +67,7 @@ def compute_topk_token_kl(
     _, top_idx = torch.topk(student_log_probs, k=topk, dim=-1)
     log_q = torch.gather(student_log_probs, dim=-1, index=top_idx)
     log_p = torch.gather(teacher_log_probs, dim=-1, index=top_idx)
-    
+
     q = log_q.exp()
     p = log_p.exp()
     kl = (q * (log_q - log_p)).sum(dim=-1)
@@ -76,31 +75,33 @@ def compute_topk_token_kl(
         q_tail = (1.0 - q.sum(dim=-1)).clamp(min=1e-7, max=1.0)
         p_tail = (1.0 - p.sum(dim=-1)).clamp(min=1e-7, max=1.0)
         kl = kl + (q_tail * (q_tail.log() - p_tail.log()))
-    
+
     return kl
 
+
 def compute_topk_kd_loss(
-    student_resp_logits, 
-    teacher_resp_logits, 
-    action_mask, 
+    student_resp_logits,
+    teacher_resp_logits,
+    action_mask,
     topk=5,
     temperature=1.0,
-    loss_batch_info=None, 
+    loss_batch_info=None,
 ):
-    kl =  compute_topk_token_kl(student_resp_logits, teacher_resp_logits, topk, temperature)
+    kl = compute_topk_token_kl(student_resp_logits, teacher_resp_logits, topk, temperature)
     return aggregate_loss(kl, action_mask, **(loss_batch_info or {}))
+
 
 class OPDTrainer(ABC):
     def __init__(
-        self, 
-        model, 
+        self,
+        model,
         teacher_model,
         strategy,
         tokenizer,
         optim: Optimizer,
         train_dataloader,
         scheduler,
-        max_norm = 1.0,
+        max_norm=1.0,
         max_epochs: int = 1,
         eval_dataloader=None,
         save_hf_ckpt: bool = False,
@@ -120,7 +121,7 @@ class OPDTrainer(ABC):
         self.disable_ds_ckpt = disable_ds_ckpt
         self.model = model
         self.teacher_model = teacher_model
-        
+
         self.kl_estimator = self.args.opd.kl_estimator
         self.topk = self.args.opd.topk
         self.kd_temperature = self.args.opd.kd_temperature
@@ -133,14 +134,14 @@ class OPDTrainer(ABC):
             pad_token_id=self.tokenizer.pad_token_id,
             eos_token_id=self.tokenizer.eos_token_id,
         )
-        
+
         self.aux_loss = self.args.model.aux_loss_coef > 1e-8
-        
+
         self._wandb = None
         self._tensorboard = None
         if self.strategy.args.logger.wandb.key and self.strategy.is_rank_0():
             import wandb
-            
+
             self._wandb = wandb
             if not wandb.api.api_key:
                 wandb.login(key=strategy.args.logger.wandb.key)
@@ -156,46 +157,46 @@ class OPDTrainer(ABC):
             wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
             wandb.define_metric("eval/global_step")
             wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
-        
+
         if self.strategy.args.logger.tensorboard_dir and self._wandb is None and self.strategy.is_rank_0():
             from torch.utils.tensorboard import SummaryWriter
-            
+
             os.makedirs(self.strategy.args.logger.tensorboard_dir, exist_ok=True)
             log_dir = os.path.join(self.strategy.args.logger.tensorboard_dir, self.strategy.args.logger.wandb.run_name)
             self._tensorboard = SummaryWriter(log_dir=log_dir)
-            
+
     @torch.no_grad()
     def generate_samples(self, prompts):
         device = next(self.model.parameters()).device
         self.tokenizer.padding_side = "left"
         inputs = self.tokenizer(
-            prompts, 
-            return_tensors="pt", 
-            padding=True, 
-            truncation=True, 
-            max_length=self.prompt_max_len, 
+            prompts,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=self.prompt_max_len,
             add_special_tokens=False,
         )
         input_ids = inputs["input_ids"].to(device)
         prompt_attention_mask = inputs["attention_mask"].to(device)
         prompt_len = input_ids.size(1)
-        
+
         was_training = self.model.training
         self.model.eval()
-        
+
         try:
             generation_model = self.strategy._unwrap_model(self.model)
             sequences = generation_model.generate(
-                input_ids=input_ids,
-                attention_mask=prompt_attention_mask,
-                **self.generate_kwargs
+                input_ids=input_ids, attention_mask=prompt_attention_mask, **self.generate_kwargs
             )
         finally:
             self.model.train(was_training)
-            
-        attention_mask, action_mask = build_generation_mask(sequences, prompt_len, prompt_attention_mask, self.tokenizer.eos_token_id)
+
+        attention_mask, action_mask = build_generation_mask(
+            sequences, prompt_len, prompt_attention_mask, self.tokenizer.eos_token_id
+        )
         return sequences, attention_mask, action_mask
-    
+
     @torch.no_grad()
     def batched_teacher_log_probs(self, sequences, attention_mask, action_mask):
         micro = self.args.train.micro_batch_size
@@ -211,16 +212,16 @@ class OPDTrainer(ABC):
                 )
             )
         return torch.cat(chunks, dim=0)
-    
+
     def compute_loss(self, sequences, attention_mask, action_mask, teacher_log_probs=None, loss_batch_info=None):
-        student_log_probs, student_output =  self.model(
+        student_log_probs, student_output = self.model(
             sequences,
             attention_mask=attention_mask,
             action_mask=action_mask,
             ring_attn_group=self.strategy.ring_attn_group,
             return_output=True,
         )
-        
+
         teacher_output = None
         if self.topk > 0 or teacher_log_probs is None:
             with torch.no_grad():
@@ -231,12 +232,12 @@ class OPDTrainer(ABC):
                     ring_attn_group=self.strategy.ring_attn_group,
                     return_output=True,
                 )
-                
+
         if self.topk > 0:
             num_actions = action_mask.size(1)
             opd_loss = compute_topk_kd_loss(
-                align_response_logits(student_output['logits'], num_actions),
-                align_response_logits(teacher_output['logits'], num_actions),
+                align_response_logits(student_output["logits"], num_actions),
+                align_response_logits(teacher_output["logits"], num_actions),
                 action_mask,
                 self.topk,
                 self.kd_temperature,
@@ -250,10 +251,10 @@ class OPDTrainer(ABC):
                 self.kl_estimator,
                 loss_batch_info=loss_batch_info,
             )
-        
+
         aux_loss = student_output.aux_loss if (self.aux_loss and "aux_loss" in student_output) else 0
         return opd_loss, aux_loss
-    
+
     @torch.no_grad()
     def compute_token_kl(self, sequences, attention_mask, action_mask):
         if self.topk > 0:
@@ -273,8 +274,8 @@ class OPDTrainer(ABC):
             )
             num_actions = action_mask.size(1)
             return compute_topk_token_kl(
-                align_response_logits(student_output['logits'], num_actions),
-                align_response_logits(teacher_output['logits'], num_actions),
+                align_response_logits(student_output["logits"], num_actions),
+                align_response_logits(teacher_output["logits"], num_actions),
                 topk=self.topk,
                 temperature=self.kd_temperature,
             )
@@ -291,33 +292,33 @@ class OPDTrainer(ABC):
             ring_attn_group=self.strategy.ring_attn_group,
         )
         return compute_approx_kl(student_log_probs, teacher_log_probs, kl_estimator=self.kl_estimator)
-    
+
     @torch.no_grad()
     def evaluate(self, eval_dataloader, steps=0):
         was_training = self.model.training
         self.teacher_model.eval()
         step_bar = tqdm(range(len(eval_dataloader)), desc="Eval Step", disable=not self.strategy.is_rank_0())
-        
+
         device = next(self.model.parameters()).device
         kl_sum = torch.zeros((), dtype=torch.float32, device=device)
         token_sum = torch.zeros((), dtype=torch.float32, device=device)
         seq_sum = torch.zeros((), dtype=torch.float32, device=device)
-        
+
         try:
             for _datasources, prompts, _labels, _images in eval_dataloader:
                 sequences, attention_mask, action_mask = self.generate_samples(prompts)
                 self.model.eval()
                 token_kl = self.compute_token_kl(sequences, attention_mask, action_mask)
-                
+
                 mask = action_mask.float()
-                
+
                 kl_sum += (token_kl.float() * mask).sum()
                 token_sum += mask.sum()
                 seq_sum += mask.size(0)
                 step_bar.update()
         finally:
             self.model.train(was_training)
-            
+
         totals = self.strategy.all_reduce(torch.stack([kl_sum, token_sum, seq_sum]), op="sum")
         kl_total, token_total, seq_total = totals.tolist()
         logs = {
@@ -325,7 +326,7 @@ class OPDTrainer(ABC):
             "eval_mean_response_length": token_total / max(seq_total, 1.0),
         }
         step_bar.set_postfix(logs)
-        
+
         if self.strategy.is_rank_0():
             if self._wandb is not None:
                 self._wandb.log({"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()})
@@ -339,27 +340,33 @@ class OPDTrainer(ABC):
             num_update_steps_per_epoch = len(self.train_dataloader)
         if num_update_steps_per_epoch <= 0:
             raise ValueError("num_update_steps_per_epoch must be a positive integer")
-        
+
         if args.eval.steps == -1:
-            args.eval.steps = num_update_steps_per_epoch if self.eval_dataloader is not None else float('inf')
+            args.eval.steps = num_update_steps_per_epoch if self.eval_dataloader is not None else float("inf")
         if args.ckpt.save_steps == -1:
-            args.ckpt.save_steps = float('inf')
-            
+            args.ckpt.save_steps = float("inf")
+
         step = consumed_samples // args.train.batch_size * self.strategy.accumulated_gradient + 1
         start_epoch = consumed_samples // args.train.batch_size // num_update_steps_per_epoch
         consumed_samples = consumed_samples % (num_update_steps_per_epoch * args.train.batch_size)
-        
+
         epoch_bar = tqdm(range(start_epoch, self.epochs), desc="Train Epoch", disable=not self.strategy.is_rank_0())
         loss_sum = 0.0
         for epoch in range(start_epoch, self.epochs):
             if isinstance(self.train_dataloader.sampler, DistributedSampler):
-                self.train_dataloader.sampler.set_epoch(epoch, consumed_samples=0 if epoch > start_epoch else consumed_samples)
-            
-            step_bar = tqdm(range(len(self.train_dataloader)), desc="Train Step of epoch %d" % epoch, disable=not self.strategy.is_rank_0())    
-            
+                self.train_dataloader.sampler.set_epoch(
+                    epoch, consumed_samples=0 if epoch > start_epoch else consumed_samples
+                )
+
+            step_bar = tqdm(
+                range(len(self.train_dataloader)),
+                desc="Train Step of epoch %d" % epoch,
+                disable=not self.strategy.is_rank_0(),
+            )
+
             self.model.train()
             self.teacher_model.eval()
-            
+
             accum = self.strategy.accumulated_gradient
             group, offsets = [], []
             for _datasources, prompts, _labels, _images in self.train_dataloader:
@@ -367,17 +374,17 @@ class OPDTrainer(ABC):
                 group.extend(prompts)
                 if len(offsets) < accum:
                     continue
-            
+
                 sequences, attention_mask, action_mask = self.generate_samples(group)
-                
+
                 loss_batch_info = get_loss_batch_info(self.strategy, action_mask)
                 loss_batch_info["batch_num_tokens"] /= accum
                 loss_batch_info["global_batch_size"] /= accum
-                
+
                 cached_teacher_lp = (
                     self.batched_teacher_log_probs(sequences, attention_mask, action_mask) if self.topk == 0 else None
                 )
-                
+
                 for start, end in offsets:
                     sl = slice(start, end)
                     teacher_lp = cached_teacher_lp[sl] if cached_teacher_lp is not None else None
@@ -389,10 +396,10 @@ class OPDTrainer(ABC):
                         loss_batch_info=loss_batch_info,
                     )
                     loss = opd_loss + aux_loss * self.args.model.aux_loss_coef
-                    
+
                     self.strategy.backward(loss, self.model, self.optimizer)
                     self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler)
-                    
+
                     log_keys = ["opd_loss", "response_length", "lr", "grad_norm"]
                     log_values = [
                         opd_loss.detach(),
@@ -409,30 +416,29 @@ class OPDTrainer(ABC):
                     )
                     logs_dict = dict(zip(log_keys, self.strategy.all_reduce(log_tensor).tolist()))
                     loss_sum += logs_dict["opd_loss"]
-                    
+
                     optimizer_boundary = step % accum == 0
                     if optimizer_boundary:
                         logs_dict["loss_mean"] = loss_sum / accum
                         loss_sum = 0.0
-                    
+
                     step_bar.set_postfix(logs_dict)
                     step_bar.update()
-                    
+
                     if optimizer_boundary:
                         global_step = step // accum
                         client_states = {"consumed_samples": global_step * args.train.batch_size}
                         self.save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
-                    
+
                     step += 1
                 group, offsets = [], []
-            
+
             epoch_bar.update()
-        
+
         if self._wandb is not None and self.strategy.is_rank_0():
             self._wandb.finish()
         if self._tensorboard is not None and self.strategy.is_rank_0():
             self._tensorboard.close()
-                    
 
     def save_logs_and_checkpoints(self, args, global_step, step_bar, logs_dict=None, client_states=None):
         logs_dict = logs_dict or {}
@@ -442,23 +448,18 @@ class OPDTrainer(ABC):
                 logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
                 self._wandb.log(logs)
         elif self._tensorboard is not None and self.strategy.is_rank_0():
-                for k, v in logs_dict.items():
-                    self._tensorboard.add_scalar(f"train/{k}", v, global_step)
-                    
+            for k, v in logs_dict.items():
+                self._tensorboard.add_scalar(f"train/{k}", v, global_step)
+
         if global_step % args.eval.steps == 0 and self.eval_dataloader is not None:
             if len(self.eval_dataloader) > 0:
                 self.evaluate(self.eval_dataloader, global_step)
-        
+
         if global_step % args.ckpt.save_steps == 0:
             tag = f"global_step_{global_step}"
             if not self.disable_ds_ckpt:
                 self.strategy.save_ckpt(
-                    self.model.model,
-                    args.ckpt.path,
-                    tag,
-                    args.ckpt.max_num,
-                    args.ckpt.max_mem,
-                    client_states
+                    self.model.model, args.ckpt.path, tag, args.ckpt.max_num, args.ckpt.max_mem, client_states
                 )
             if self.save_hf_ckpt:
                 self.strategy.save_model(self.model, self.tokenizer, os.path.join(args.ckpt.path, f"{tag}_hf"))

--- a/openrlhf/trainer/opd_trainer.py
+++ b/openrlhf/trainer/opd_trainer.py
@@ -1,0 +1,464 @@
+import os
+from abc import ABC
+
+import torch
+from torch.optim import Optimizer
+from tqdm import tqdm
+
+from openrlhf.models.loss import aggregate_loss
+from openrlhf.models.utils import compute_approx_kl
+from openrlhf.utils.distributed_sampler import DistributedSampler
+from openrlhf.utils.loss_utils import get_loss_batch_info
+
+
+def build_generation_mask(sequences, prompt_len, prompt_attention_mask, eos_token_id):
+    """ Build a full attention mask and the response ``action_mask`` for the generated tokens. 
+    ``sequences`` is (B, prompt_len + gen_len) from model.generate. Anything after first EOS is masked
+    """
+    B = sequences.size(0)
+    device = sequences.device
+    gen = sequences[:, prompt_len:]
+    gen_len = gen.size(1)
+    
+    is_eos = gen == eos_token_id
+    has_eos = is_eos.any(dim=1)
+    
+    first_eos = torch.where(
+        has_eos,
+        is_eos.float().argmax(dim=1).long(),
+        torch.full((B, ), gen_len - 1, device=device, dtype=torch.long)
+    )
+    positions = torch.arange(gen_len, device=device).unsqueeze(0).expand(B, -1)
+    action_mask = (positions <= first_eos.unsqueeze(1)).long()
+    
+    attention_mask = torch.cat([prompt_attention_mask.to(device), action_mask], dim=1)
+    return attention_mask, action_mask
+
+def align_response_logits(logits, num_actions):
+    return logits[:, -num_actions -1:-1, :]
+
+
+def compute_opd_loss(
+    student_action_log_probs, 
+    teacher_action_log_probs,
+    action_mask, 
+    kl_estimator="k3",
+    loss_batch_info=None, 
+):
+    teacher_action_log_probs = teacher_action_log_probs.detach()
+    log_ratio = student_action_log_probs - teacher_action_log_probs
+    kl = compute_approx_kl(student_action_log_probs, teacher_action_log_probs, kl_estimator=kl_estimator)
+    
+    surrogate = log_ratio.detach() * student_action_log_probs
+    loss = kl.detach() + surrogate - surrogate.detach()
+    return aggregate_loss(loss, action_mask, **(loss_batch_info or {}))
+    
+    
+def compute_topk_token_kl(
+    student_resp_logits, 
+    teacher_resp_logits, 
+    topk=5,
+    temperature=1.0,
+):
+    topk = min(topk, student_resp_logits.size(-1))
+    student_log_probs = torch.log_softmax(student_resp_logits / temperature, dim=-1)
+    with torch.no_grad():
+        teacher_log_probs = torch.log_softmax(teacher_resp_logits.detach() / temperature, dim=-1)
+    # Compute the top-k KD loss
+    _, top_idx = torch.topk(student_log_probs, k=topk, dim=-1)
+    log_q = torch.gather(student_log_probs, dim=-1, index=top_idx)
+    log_p = torch.gather(teacher_log_probs, dim=-1, index=top_idx)
+    
+    q = log_q.exp()
+    p = log_p.exp()
+    kl = (q * (log_q - log_p)).sum(dim=-1)
+    if topk < student_resp_logits.size(-1):
+        q_tail = (1.0 - q.sum(dim=-1)).clamp(min=1e-7, max=1.0)
+        p_tail = (1.0 - p.sum(dim=-1)).clamp(min=1e-7, max=1.0)
+        kl = kl + (q_tail * (q_tail.log() - p_tail.log()))
+    
+    return kl
+
+def compute_topk_kd_loss(
+    student_resp_logits, 
+    teacher_resp_logits, 
+    action_mask, 
+    topk=5,
+    temperature=1.0,
+    loss_batch_info=None, 
+):
+    kl =  compute_topk_token_kl(student_resp_logits, teacher_resp_logits, topk, temperature)
+    return aggregate_loss(kl, action_mask, **(loss_batch_info or {}))
+
+class OPDTrainer(ABC):
+    def __init__(
+        self, 
+        model, 
+        teacher_model,
+        strategy,
+        tokenizer,
+        optim: Optimizer,
+        train_dataloader,
+        scheduler,
+        max_norm = 1.0,
+        max_epochs: int = 1,
+        eval_dataloader=None,
+        save_hf_ckpt: bool = False,
+        disable_ds_ckpt: bool = False,
+    ) -> None:
+        super().__init__()
+        self.strategy = strategy
+        self.args = strategy.args
+        self.tokenizer = tokenizer
+        self.optimizer = optim
+        self.train_dataloader = train_dataloader
+        self.eval_dataloader = eval_dataloader
+        self.scheduler = scheduler
+        self.max_norm = max_norm
+        self.epochs = max_epochs
+        self.save_hf_ckpt = save_hf_ckpt
+        self.disable_ds_ckpt = disable_ds_ckpt
+        self.model = model
+        self.teacher_model = teacher_model
+        
+        self.kl_estimator = self.args.opd.kl_estimator
+        self.topk = self.args.opd.topk
+        self.kd_temperature = self.args.opd.kd_temperature
+        self.prompt_max_len = self.args.data.prompt_max_len
+        self.generate_kwargs = dict(
+            max_new_tokens=self.args.generate.max_new_tokens,
+            do_sample=True,
+            temperature=self.args.generate.temperature,
+            top_p=self.args.generate.top_p,
+            pad_token_id=self.tokenizer.pad_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
+        )
+        
+        self.aux_loss = self.args.model.aux_loss_coef > 1e-8
+        
+        self._wandb = None
+        self._tensorboard = None
+        if self.strategy.args.logger.wandb.key and self.strategy.is_rank_0():
+            import wandb
+            
+            self._wandb = wandb
+            if not wandb.api.api_key:
+                wandb.login(key=strategy.args.logger.wandb.key)
+            wandb.init(
+                entity=strategy.args.logger.wandb.org,
+                project=strategy.args.logger.wandb.project,
+                group=strategy.args.logger.wandb.group,
+                name=strategy.args.logger.wandb.run_name,
+                config=strategy.args.__dict__,
+                reinit=True,
+            )
+            wandb.define_metric("train/global_step")
+            wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
+            wandb.define_metric("eval/global_step")
+            wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
+        
+        if self.strategy.args.logger.tensorboard_dir and self._wandb is None and self.strategy.is_rank_0():
+            from torch.utils.tensorboard import SummaryWriter
+            
+            os.makedirs(self.strategy.args.logger.tensorboard_dir, exist_ok=True)
+            log_dir = os.path.join(self.strategy.args.logger.tensorboard_dir, self.strategy.args.logger.wandb.run_name)
+            self._tensorboard = SummaryWriter(log_dir=log_dir)
+            
+    @torch.no_grad()
+    def generate_samples(self, prompts):
+        device = next(self.model.parameters()).device
+        self.tokenizer.padding_side = "left"
+        inputs = self.tokenizer(
+            prompts, 
+            return_tensors="pt", 
+            padding=True, 
+            truncation=True, 
+            max_length=self.prompt_max_len, 
+            add_special_tokens=False,
+        )
+        input_ids = inputs["input_ids"].to(device)
+        prompt_attention_mask = inputs["attention_mask"].to(device)
+        prompt_len = input_ids.size(1)
+        
+        was_training = self.model.training
+        self.model.eval()
+        
+        try:
+            generation_model = self.strategy._unwrap_model(self.model)
+            sequences = generation_model.generate(
+                input_ids=input_ids,
+                attention_mask=prompt_attention_mask,
+                **self.generate_kwargs
+            )
+        finally:
+            self.model.train(was_training)
+            
+        attention_mask, action_mask = build_generation_mask(sequences, prompt_len, prompt_attention_mask, self.tokenizer.eos_token_id)
+        return sequences, attention_mask, action_mask
+    
+    @torch.no_grad()
+    def batched_teacher_log_probs(self, sequences, attention_mask, action_mask):
+        micro = self.args.train.micro_batch_size
+        chunks = []
+        for i in range(0, sequences.size(0), micro):
+            sl = slice(i, i + micro)
+            chunks.append(
+                self.teacher_model(
+                    sequences[sl],
+                    attention_mask=attention_mask[sl],
+                    action_mask=action_mask[sl],
+                    ring_attn_group=self.strategy.ring_attn_group,
+                )
+            )
+        return torch.cat(chunks, dim=0)
+    
+    def compute_loss(self, sequences, attention_mask, action_mask, teacher_log_probs=None, loss_batch_info=None):
+        student_log_probs, student_output =  self.model(
+            sequences,
+            attention_mask=attention_mask,
+            action_mask=action_mask,
+            ring_attn_group=self.strategy.ring_attn_group,
+            return_output=True,
+        )
+        
+        teacher_output = None
+        if self.topk > 0 or teacher_log_probs is None:
+            with torch.no_grad():
+                teacher_log_probs, teacher_output = self.teacher_model(
+                    sequences,
+                    attention_mask=attention_mask,
+                    action_mask=action_mask,
+                    ring_attn_group=self.strategy.ring_attn_group,
+                    return_output=True,
+                )
+                
+        if self.topk > 0:
+            num_actions = action_mask.size(1)
+            opd_loss = compute_topk_kd_loss(
+                align_response_logits(student_output['logits'], num_actions),
+                align_response_logits(teacher_output['logits'], num_actions),
+                action_mask,
+                self.topk,
+                self.kd_temperature,
+                loss_batch_info=loss_batch_info,
+            )
+        else:
+            opd_loss = compute_opd_loss(
+                student_log_probs,
+                teacher_log_probs,
+                action_mask,
+                self.kl_estimator,
+                loss_batch_info=loss_batch_info,
+            )
+        
+        aux_loss = student_output.aux_loss if (self.aux_loss and "aux_loss" in student_output) else 0
+        return opd_loss, aux_loss
+    
+    @torch.no_grad()
+    def compute_token_kl(self, sequences, attention_mask, action_mask):
+        if self.topk > 0:
+            _, student_output = self.model(
+                sequences,
+                attention_mask=attention_mask,
+                action_mask=action_mask,
+                ring_attn_group=self.strategy.ring_attn_group,
+                return_output=True,
+            )
+            _, teacher_output = self.teacher_model(
+                sequences,
+                attention_mask=attention_mask,
+                action_mask=action_mask,
+                ring_attn_group=self.strategy.ring_attn_group,
+                return_output=True,
+            )
+            num_actions = action_mask.size(1)
+            return compute_topk_token_kl(
+                align_response_logits(student_output['logits'], num_actions),
+                align_response_logits(teacher_output['logits'], num_actions),
+                topk=self.topk,
+                temperature=self.kd_temperature,
+            )
+        student_log_probs = self.model(
+            sequences,
+            attention_mask=attention_mask,
+            action_mask=action_mask,
+            ring_attn_group=self.strategy.ring_attn_group,
+        )
+        teacher_log_probs = self.teacher_model(
+            sequences,
+            attention_mask=attention_mask,
+            action_mask=action_mask,
+            ring_attn_group=self.strategy.ring_attn_group,
+        )
+        return compute_approx_kl(student_log_probs, teacher_log_probs, kl_estimator=self.kl_estimator)
+    
+    @torch.no_grad()
+    def evaluate(self, eval_dataloader, steps=0):
+        was_training = self.model.training
+        self.teacher_model.eval()
+        step_bar = tqdm(range(len(eval_dataloader)), desc="Eval Step", disable=not self.strategy.is_rank_0())
+        
+        device = next(self.model.parameters()).device
+        kl_sum = torch.zeros((), dtype=torch.float32, device=device)
+        token_sum = torch.zeros((), dtype=torch.float32, device=device)
+        seq_sum = torch.zeros((), dtype=torch.float32, device=device)
+        
+        try:
+            for _datasources, prompts, _labels, _images in eval_dataloader:
+                sequences, attention_mask, action_mask = self.generate_samples(prompts)
+                self.model.eval()
+                token_kl = self.compute_token_kl(sequences, attention_mask, action_mask)
+                
+                mask = action_mask.float()
+                
+                kl_sum += (token_kl.float() * mask).sum()
+                token_sum += mask.sum()
+                seq_sum += mask.size(0)
+                step_bar.update()
+        finally:
+            self.model.train(was_training)
+            
+        totals = self.strategy.all_reduce(torch.stack([kl_sum, token_sum, seq_sum]), op="sum")
+        kl_total, token_total, seq_total = totals.tolist()
+        logs = {
+            "eval_kl": kl_total / max(token_total, 1.0),
+            "eval_mean_response_length": token_total / max(seq_total, 1.0),
+        }
+        step_bar.set_postfix(logs)
+        
+        if self.strategy.is_rank_0():
+            if self._wandb is not None:
+                self._wandb.log({"eval/%s" % k: v for k, v in {**logs, "global_step": steps}.items()})
+            elif self._tensorboard is not None:
+                for k, v in logs.items():
+                    self._tensorboard.add_scalar(f"eval/{k}", v, steps)
+        return logs
+
+    def fit(self, args, consumed_samples=0, num_update_steps_per_epoch=None):
+        if num_update_steps_per_epoch is None:
+            num_update_steps_per_epoch = len(self.train_dataloader)
+        if num_update_steps_per_epoch <= 0:
+            raise ValueError("num_update_steps_per_epoch must be a positive integer")
+        
+        if args.eval.steps == -1:
+            args.eval.steps = num_update_steps_per_epoch if self.eval_dataloader is not None else float('inf')
+        if args.ckpt.save_steps == -1:
+            args.ckpt.save_steps = float('inf')
+            
+        step = consumed_samples // args.train.batch_size * self.strategy.accumulated_gradient + 1
+        start_epoch = consumed_samples // args.train.batch_size // num_update_steps_per_epoch
+        consumed_samples = consumed_samples % (num_update_steps_per_epoch * args.train.batch_size)
+        
+        epoch_bar = tqdm(range(start_epoch, self.epochs), desc="Train Epoch", disable=not self.strategy.is_rank_0())
+        loss_sum = 0.0
+        for epoch in range(start_epoch, self.epochs):
+            if isinstance(self.train_dataloader.sampler, DistributedSampler):
+                self.train_dataloader.sampler.set_epoch(epoch, consumed_samples=0 if epoch > start_epoch else consumed_samples)
+            
+            step_bar = tqdm(range(len(self.train_dataloader)), desc="Train Step of epoch %d" % epoch, disable=not self.strategy.is_rank_0())    
+            
+            self.model.train()
+            self.teacher_model.eval()
+            
+            accum = self.strategy.accumulated_gradient
+            group, offsets = [], []
+            for _datasources, prompts, _labels, _images in self.train_dataloader:
+                offsets.append((len(group), len(group) + len(prompts)))
+                group.extend(prompts)
+                if len(offsets) < accum:
+                    continue
+            
+                sequences, attention_mask, action_mask = self.generate_samples(group)
+                
+                loss_batch_info = get_loss_batch_info(self.strategy, action_mask)
+                loss_batch_info["batch_num_tokens"] /= accum
+                loss_batch_info["global_batch_size"] /= accum
+                
+                cached_teacher_lp = (
+                    self.batched_teacher_log_probs(sequences, attention_mask, action_mask) if self.topk == 0 else None
+                )
+                
+                for start, end in offsets:
+                    sl = slice(start, end)
+                    teacher_lp = cached_teacher_lp[sl] if cached_teacher_lp is not None else None
+                    opd_loss, aux_loss = self.compute_loss(
+                        sequences[sl],
+                        attention_mask[sl],
+                        action_mask[sl],
+                        teacher_log_probs=teacher_lp,
+                        loss_batch_info=loss_batch_info,
+                    )
+                    loss = opd_loss + aux_loss * self.args.model.aux_loss_coef
+                    
+                    self.strategy.backward(loss, self.model, self.optimizer)
+                    self.strategy.optimizer_step(self.optimizer, self.model, self.scheduler)
+                    
+                    log_keys = ["opd_loss", "response_length", "lr", "grad_norm"]
+                    log_values = [
+                        opd_loss.detach(),
+                        action_mask[sl].float().sum(dim=-1).mean(),
+                        self.scheduler.get_last_lr()[0],
+                        self.strategy.get_grad_norm(self.model),
+                    ]
+                    if self.aux_loss:
+                        log_keys.append("aux_loss")
+                        log_values.append(aux_loss.detach())
+                    device = opd_loss.device
+                    log_tensor = torch.stack(
+                        [torch.as_tensor(v, dtype=torch.float32, device=device) for v in log_values]
+                    )
+                    logs_dict = dict(zip(log_keys, self.strategy.all_reduce(log_tensor).tolist()))
+                    loss_sum += logs_dict["opd_loss"]
+                    
+                    optimizer_boundary = step % accum == 0
+                    if optimizer_boundary:
+                        logs_dict["loss_mean"] = loss_sum / accum
+                        loss_sum = 0.0
+                    
+                    step_bar.set_postfix(logs_dict)
+                    step_bar.update()
+                    
+                    if optimizer_boundary:
+                        global_step = step // accum
+                        client_states = {"consumed_samples": global_step * args.train.batch_size}
+                        self.save_logs_and_checkpoints(args, global_step, step_bar, logs_dict, client_states)
+                    
+                    step += 1
+                group, offsets = [], []
+            
+            epoch_bar.update()
+        
+        if self._wandb is not None and self.strategy.is_rank_0():
+            self._wandb.finish()
+        if self._tensorboard is not None and self.strategy.is_rank_0():
+            self._tensorboard.close()
+                    
+
+    def save_logs_and_checkpoints(self, args, global_step, step_bar, logs_dict=None, client_states=None):
+        logs_dict = logs_dict or {}
+        client_states = client_states or {}
+        if global_step % args.logger.logging_steps == 0:
+            if self._wandb is not None and self.strategy.is_rank_0():
+                logs = {"train/%s" % k: v for k, v in {**logs_dict, "global_step": global_step}.items()}
+                self._wandb.log(logs)
+        elif self._tensorboard is not None and self.strategy.is_rank_0():
+                for k, v in logs_dict.items():
+                    self._tensorboard.add_scalar(f"train/{k}", v, global_step)
+                    
+        if global_step % args.eval.steps == 0 and self.eval_dataloader is not None:
+            if len(self.eval_dataloader) > 0:
+                self.evaluate(self.eval_dataloader, global_step)
+        
+        if global_step % args.ckpt.save_steps == 0:
+            tag = f"global_step_{global_step}"
+            if not self.disable_ds_ckpt:
+                self.strategy.save_ckpt(
+                    self.model.model,
+                    args.ckpt.path,
+                    tag,
+                    args.ckpt.max_num,
+                    args.ckpt.max_mem,
+                    client_states
+                )
+            if self.save_hf_ckpt:
+                self.strategy.save_model(self.model, self.tokenizer, os.path.join(args.ckpt.path, f"{tag}_hf"))


### PR DESCRIPTION
**TLDR:** 
Adds OPD support as a standalone trainer resembling DPO/SFT/PPO trainer.

**Detailed implementations:**
OPD trainer will have the student model forward prompt once in inference mode, and then forward both student model (trainer mode) and teacher model (inference mode) to get their log_probs on vocab. Then it will apply reverse-KL loss on their output.

There are 2 supported loss, one is sampled loss where we estimate the KL divergence between student and teacher model on the sampled token log_probs. Another loss is topk loss where we will compare each top-k position's log_probs (choose student's topk tokens), and use them to estimate the KL loss. No reference model and graders are used in this module.

Caveats:
Currently this is not supporting Zero3, tensor parallelism, and require same tokenizer, vocab for both teacher and student model

Otherwise similiar to DPO/PPO trainers

Testing:

Do a actual run on 2xA100 GPUs with both sampled loss mode and top k loss mode. The training looks smooth and correct.

<img width="2210" height="1105" alt="opd_gsm8k_topk5" src="https://github.com/user-attachments/assets/1a5390f8-cbbc-402b-8c9b-48ff5fda68a8" />
<img width="2200" height="1100" alt="opd_gsm8k_sampled" src="https://github.com/user-attachments/assets/b9bbedd8-b61a-4325-8b8c-bc0f38b04308" />