### PR TITLE
fix(reward): preserve tuple delimiters in math grading

### DIFF
--- a/openrlhf/utils/math_utils.py
+++ b/openrlhf/utils/math_utils.py
@@ -383,7 +383,7 @@ def grade_answer_sympy(given_answer: str, ground_truth: str) -> bool:
     if len(ground_truth_elems) > 1 and (
         ground_truth_normalized[0] != given_normalized[0] or ground_truth_normalized[-1] != given_normalized[-1]
     ):
-        is_correct = False
+        return False
     if len(ground_truth_elems) != len(given_elems):
         is_correct = False
     else:

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,0 +1,20 @@
+import pytest
+
+from openrlhf.utils.math_utils import grade_answer
+
+
+@pytest.mark.parametrize(
+    ("given_answer", "ground_truth"),
+    [
+        ("[1,2]", "(1,2)"),
+        ("(1,2)", "[1,2]"),
+        ("(1,2]", "(1,2)"),
+        ("[1,2)", "[1,2]"),
+    ],
+)
+def test_grade_answer_rejects_mismatched_tuple_delimiters(given_answer, ground_truth):
+    assert not grade_answer(given_answer, ground_truth)
+
+
+def test_grade_answer_accepts_equivalent_tuple_with_matching_delimiters():
+    assert grade_answer("(1.0,2.0)", "(1,2)")


### PR DESCRIPTION
## Background

The math reward grader explicitly checks tuple and interval boundary delimiters, but a mismatch only assigned `is_correct = False`. The following element-wise comparison then overwrote that result, so answers such as `[1,2]` and `(1,2)` were incorrectly graded as equivalent.

This affects reward correctness for tasks where open, closed, and half-open boundaries have different meanings.

## Changes

- Return immediately when multi-element answers use different boundary delimiters.
- Add regression tests through the public `grade_answer` API for open, closed, and half-open cases.
- Keep equivalent tuples with matching delimiters accepted.

## Verification

Before the change, all of these comparisons returned `True`:

```text
grade_answer("[1,2]", "(1,2)")
grade_answer("(1,2)", "[1,2]")
grade_answer("(1,2]", "(1,2)")
```

After the change:

```bash
.venv/bin/python -m pytest tests/test_math_utils.py -q
# 5 passed

.venv/bin/python -m pytest tests -q
# 22 passed

.venv/bin/pre-commit run --files openrlhf/utils/math_utils.py tests/test_math_utils.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS; no DeepSpeed behavior is exercised by these tests.

## Impact

- Breaking change: No
- Affected module: math reward answer grading
- Performance impact: None
- Scope: No normalization or SymPy equivalence behavior changes beyond preserving delimiter mismatches

## Checklist

- [x] The change is focused on one correctness issue.
- [x] Regression tests cover the failing behavior.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
