### PR TITLE
fix(reward): stabilize log-exp loss for large gaps

### DIFF
--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -294,7 +294,7 @@ class LogExpLoss(nn.Module):
     def forward(
         self, chosen_reward: torch.Tensor, reject_reward: torch.Tensor, margin: torch.Tensor = None
     ) -> torch.Tensor:
-        loss = torch.log(1 + torch.exp(reject_reward - chosen_reward)).mean()
+        loss = F.softplus(reject_reward - chosen_reward).mean()
         return loss
 
 

--- a/tests/test_loss_aggregation.py
+++ b/tests/test_loss_aggregation.py
@@ -38,6 +38,7 @@ def _load_loss_utils_module():
 
 _loss_module = _load_loss_module()
 _loss_utils_module = _load_loss_utils_module()
+LogExpLoss = _loss_module.LogExpLoss
 PolicyLoss = _loss_module.PolicyLoss
 aggregate_loss = _loss_module.aggregate_loss
 get_loss_batch_info = _loss_utils_module.get_loss_batch_info
@@ -202,3 +203,14 @@ def test_policy_kl_metric_is_not_clamped():
     _, _, ppo_kl, _ = PolicyLoss()(log_probs, old_log_probs, advantages, action_mask=mask)
 
     assert torch.allclose(ppo_kl, (old_log_probs - log_probs).mean())
+
+
+def test_log_exp_loss_stays_finite_for_large_reward_gap():
+    chosen_reward = torch.tensor([0.0], requires_grad=True)
+    reject_reward = torch.tensor([1000.0])
+
+    loss = LogExpLoss()(chosen_reward, reject_reward)
+    loss.backward()
+
+    assert torch.allclose(loss.detach(), torch.tensor(1000.0))
+    assert torch.isfinite(chosen_reward.grad).all()


### PR DESCRIPTION
## Background

`LogExpLoss` currently evaluates the pairwise objective as:

```python
torch.log(1 + torch.exp(reject_reward - chosen_reward))
```

This direct exponential overflows for large reward gaps. For example, a rejected-minus-chosen gap of `100` produces an infinite loss and a `NaN` gradient in float32, which can poison reward model training when `--model.loss_type` selects the log-exp path.

## Changes

- Evaluate the same objective with `torch.nn.functional.softplus`.
- Add a regression test that checks both the large-gap loss value and gradient finiteness.

`softplus(x)` is mathematically equivalent to `log(1 + exp(x))` while using a numerically stable implementation.

## Verification

Before:

```text
gap=100  loss=inf  grad=nan
gap=1000 loss=inf  grad=nan
```

After:

```text
gap=100  loss=100.0  grad=-1.0
gap=1000 loss=1000.0 grad=-1.0
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_loss_aggregation.py -q
# 9 passed

.venv/bin/python -m pytest tests -q
# 18 passed

.venv/bin/pre-commit run --files openrlhf/models/loss.py tests/test_loss_aggregation.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS; no DeepSpeed behavior is exercised by these tests.

## Impact

- Breaking change: No
- Affected module: reward model pairwise log-exp loss
- Performance impact: None expected
- Scope: The default sigmoid loss and other training losses are unchanged

## Checklist

- [x] The change is focused on one numerical correctness issue.
- [x] Regression coverage includes forward and backward behavior.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
