### PR TITLE
fix(ray): distribute uneven batches across all actors

### DIFF
--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -10,7 +10,7 @@ from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 from tqdm import tqdm
 
 from openrlhf.models import Actor, get_llm_for_sequence_regression
-from openrlhf.trainer.ray.utils import ray_noset_visible_devices
+from openrlhf.trainer.ray.utils import get_balanced_batch_ranges, ray_noset_visible_devices
 from openrlhf.utils.deepspeed import DeepspeedStrategy
 
 
@@ -346,22 +346,12 @@ class RayActorGroup:
         # Calculate chunk size based on number of effective actors (considering ring groups)
         num_actors = len(self._actor_handlers)
         effective_actors = num_actors // self.duplicate_actors
-        if total_length == 0 or total_length < effective_actors:
-            raise ValueError(
-                f"Insufficient batch size for async_run_method_batch: total_length={total_length}, "
-                f"effective_actors={effective_actors}"
-            )
-        chunk_size = total_length // effective_actors
-        if total_length % effective_actors != 0:
-            chunk_size += 1
+        chunk_ranges = get_balanced_batch_ranges(total_length, effective_actors)
 
         # Pre-slice data before ray.put so each worker only receives its chunk.
         # This avoids transferring the full batch to every node (critical at scale).
         refs = []
-        for chunk_idx in range(effective_actors):
-            start_idx = chunk_idx * chunk_size
-            end_idx = min((chunk_idx + 1) * chunk_size, total_length)
-
+        for chunk_idx, (start_idx, end_idx) in enumerate(chunk_ranges):
             chunk_data = {key: value[start_idx:end_idx] for key, value in kwargs.items()}
             chunk_ref = ray.put(chunk_data)
 

--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -1,6 +1,23 @@
 import os
 
 
+def get_balanced_batch_ranges(total_length, num_chunks):
+    """Split a batch into contiguous, non-empty ranges with near-equal sizes."""
+    if num_chunks <= 0:
+        raise ValueError(f"num_chunks must be positive, got {num_chunks}")
+    if total_length < num_chunks:
+        raise ValueError(f"total_length={total_length} must be at least num_chunks={num_chunks}")
+
+    chunk_size, remainder = divmod(total_length, num_chunks)
+    ranges = []
+    start = 0
+    for chunk_idx in range(num_chunks):
+        end = start + chunk_size + (1 if chunk_idx < remainder else 0)
+        ranges.append((start, end))
+        start = end
+    return ranges
+
+
 # Address https://github.com/ray-project/ray/issues/51117
 # This function is used to get the bundle indices of a placement group
 # and ensure that the bundles placed on the same node are grouped together.

--- a/tests/test_ray_utils.py
+++ b/tests/test_ray_utils.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_ray_utils_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.trainer.ray.utils", root / "openrlhf" / "trainer" / "ray" / "utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+get_balanced_batch_ranges = _load_ray_utils_module().get_balanced_batch_ranges
+
+
+def test_balanced_batch_ranges_keep_uneven_chunks_non_empty():
+    ranges = get_balanced_batch_ranges(total_length=5, num_chunks=4)
+
+    assert ranges == [(0, 2), (2, 3), (3, 4), (4, 5)]
+    assert all(end > start for start, end in ranges)
+
+
+@pytest.mark.parametrize(("total_length", "num_chunks"), [(0, 1), (3, 4), (4, 0)])
+def test_balanced_batch_ranges_reject_invalid_sizes(total_length, num_chunks):
+    with pytest.raises(ValueError):
+        get_balanced_batch_ranges(total_length, num_chunks)


### PR DESCRIPTION
## Background

`RayActorGroup.async_run_method_batch` uses a single ceiling-divided chunk size for every effective actor. For uneven batches, that can advance the final range past the end of the input and dispatch an empty chunk.

For example, distributing 5 items over 4 effective actors currently produces:

```text
actor 0: [0, 1], requested_count=2
actor 1: [2, 3], requested_count=2
actor 2: [4],    requested_count=1
actor 3: [],     requested_count=-1
```

The empty actor can leave distributed workers out of sync during batched forward or replay-buffer dispatch.

## Changes

- Partition batches using quotient and remainder ranges.
- Keep ranges contiguous, non-empty, and within one item of each other.
- Reject invalid sizes before dispatch.
- Add regression tests for uneven and invalid partitions.

After the change, the same input is distributed as:

```text
actor 0: [0, 1], requested_count=2
actor 1: [2],    requested_count=1
actor 2: [3],    requested_count=1
actor 3: [4],    requested_count=1
```

## Verification

```bash
.venv/bin/python -m pytest tests/test_ray_utils.py -q
# 4 passed

.venv/bin/python -m pytest tests -q
# 21 passed

.venv/bin/pre-commit run --files \
  openrlhf/trainer/ray/launcher.py \
  openrlhf/trainer/ray/utils.py \
  tests/test_ray_utils.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS; the changed partition helper is dependency-free.

## Impact

- Breaking change: No
- Affected module: Ray actor batch dispatch
- Performance impact: None expected
- Scope: Evenly divisible batches retain the same ranges

## Checklist

- [x] The change addresses one distributed correctness issue.
- [x] Regression tests cover the failing uneven-batch case.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
