### PR TITLE
fix(batch): reject sequences above token capacity

### DIFF
--- a/openrlhf/utils/seqlen_balancing.py
+++ b/openrlhf/utils/seqlen_balancing.py
@@ -234,11 +234,17 @@ def get_reverse_idx(idx_map):
 def get_minimum_num_micro_batch_size(total_lengths, max_tokens_per_gpu, ring_attn_size, ds_tensor_parallel_size):
     # use first fit to get the number of micro batches
     # eg: [5, 3, 7, 2, 6] 10 -> [10, 7, 6]
-    max_tokens_per_gpu *= ring_attn_size * ds_tensor_parallel_size
+    effective_max_tokens = max_tokens_per_gpu * ring_attn_size * ds_tensor_parallel_size
     batches = []
     for l in total_lengths:
+        if l > effective_max_tokens:
+            raise ValueError(
+                f"Sequence length {l} exceeds effective dynamic-batch capacity {effective_max_tokens} "
+                f"(max_tokens_per_gpu={max_tokens_per_gpu}, ring_attn_size={ring_attn_size}, "
+                f"ds_tensor_parallel_size={ds_tensor_parallel_size})"
+            )
         for i in range(len(batches)):
-            if batches[i] + l <= max_tokens_per_gpu:
+            if batches[i] + l <= effective_max_tokens:
                 batches[i] += l
                 break
         else:

--- a/tests/test_seqlen_balancing.py
+++ b/tests/test_seqlen_balancing.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_seqlen_balancing_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.seqlen_balancing", root / "openrlhf" / "utils" / "seqlen_balancing.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+get_minimum_num_micro_batch_size = _load_seqlen_balancing_module().get_minimum_num_micro_batch_size
+
+
+def test_micro_batch_sizing_rejects_sequence_over_effective_capacity():
+    with pytest.raises(ValueError, match=r"Sequence length 21 exceeds .* capacity 20"):
+        get_minimum_num_micro_batch_size(
+            total_lengths=[21],
+            max_tokens_per_gpu=10,
+            ring_attn_size=2,
+            ds_tensor_parallel_size=1,
+        )
+
+
+def test_micro_batch_sizing_accepts_sequence_at_effective_capacity():
+    num_batches = get_minimum_num_micro_batch_size(
+        total_lengths=[20],
+        max_tokens_per_gpu=10,
+        ring_attn_size=2,
+        ds_tensor_parallel_size=1,
+    )
+
+    assert num_batches == 1


### PR DESCRIPTION
## Background

Dynamic micro-batch sizing treats every sequence as a bin-packing item. A single sequence cannot be split across bins, but the current implementation still returns one "valid" micro-batch when that sequence is larger than the effective token capacity.

For example:

```text
total_lengths=[21]
max_tokens_per_gpu=10
ring_attn_size=2
ds_tensor_parallel_size=1
effective capacity=20
current result=1 micro-batch
```

That configuration cannot satisfy the token limit and can defer the failure to model execution as a GPU OOM.

## Changes

- Compute the effective token capacity without mutating the input setting.
- Reject a sequence that exceeds that capacity before bin packing.
- Include the sequence length, effective capacity, and parallel sizes in the error.
- Add regression coverage for over-capacity and exact-capacity boundaries.

Feasible batches retain the existing first-fit behavior.

## Verification

After the change:

```text
length=21, capacity=20 -> ValueError with configuration details
length=20, capacity=20 -> 1 micro-batch
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_seqlen_balancing.py -q
# 2 passed

.venv/bin/python -m pytest tests -q
# 19 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/seqlen_balancing.py \
  tests/test_seqlen_balancing.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS; the changed sizing helper is dependency-free.

## Impact

- Breaking change: No for valid configurations
- Affected module: dynamic batch sequence-length sizing
- Performance impact: None
- Scope: Only impossible single-sequence configurations fail earlier

## Checklist

- [x] The change addresses one configuration correctness issue.
- [x] Regression tests cover failure and boundary behavior.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
