### PR TITLE
fix(logging): align W&B eval step metric

### DIFF
--- a/openrlhf/utils/logging_utils.py
+++ b/openrlhf/utils/logging_utils.py
@@ -78,8 +78,8 @@ class WandbLogger:
 
         wandb.define_metric("train/global_step")
         wandb.define_metric("train/*", step_metric="train/global_step", step_sync=True)
-        wandb.define_metric("eval/epoch")
-        wandb.define_metric("eval/*", step_metric="eval/epoch", step_sync=True)
+        wandb.define_metric("eval/global_step")
+        wandb.define_metric("eval/*", step_metric="eval/global_step", step_sync=True)
         self.handle = wandb
         self.samples_table = wandb.Table(columns=["global_step", "text", "reward"])
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_logging_utils_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.logging_utils", root / "openrlhf" / "utils" / "logging_utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeTable:
+    def __init__(self, columns=None, data=None):
+        self.columns = columns or []
+        self.data = data or []
+
+
+class _FakeWandb(types.ModuleType):
+    def __init__(self):
+        super().__init__("wandb")
+        self.api = SimpleNamespace(api_key="configured")
+        self.metric_calls = []
+        self.logged = []
+        self.Table = _FakeTable
+
+    def init(self, **kwargs):
+        pass
+
+    def define_metric(self, *args, **kwargs):
+        self.metric_calls.append((args, kwargs))
+
+    def log(self, payload):
+        self.logged.append(payload)
+
+
+def test_wandb_eval_metrics_use_the_logged_global_step(monkeypatch):
+    fake_wandb = _FakeWandb()
+    monkeypatch.setitem(sys.modules, "wandb", fake_wandb)
+    WandbLogger = _load_logging_utils_module().WandbLogger
+    args = SimpleNamespace(
+        logger=SimpleNamespace(
+            wandb=SimpleNamespace(key="key", org="org", project="project", group="group", run_name="run")
+        )
+    )
+
+    logger = WandbLogger(args)
+    logger.log_eval(7, {"accuracy": 0.5})
+
+    assert (("eval/global_step",), {}) in fake_wandb.metric_calls
+    assert (("eval/*",), {"step_metric": "eval/global_step", "step_sync": True}) in fake_wandb.metric_calls
+    assert fake_wandb.logged[-1] == {"eval/accuracy": 0.5, "eval/global_step": 7}


### PR DESCRIPTION
## Background

`WandbLogger` defines PPO evaluation metrics with `eval/epoch` as their custom step:

```python
wandb.define_metric("eval/*", step_metric="eval/epoch", step_sync=True)
```

However, `log_eval` emits `eval/global_step` and never logs `eval/epoch`. The declared step metric therefore does not match the actual payload. The DPO, RM, and SFT trainers already use `eval/global_step`.

## Changes

- Define `eval/global_step` as the W&B evaluation step metric.
- Keep the existing `log_eval` payload unchanged.
- Add a fake-W&B regression test covering both metric definitions and the logged payload.

## Verification

Before:

```text
defined step metric: eval/epoch
logged step key:     eval/global_step
```

After:

```text
defined step metric: eval/global_step
logged step key:     eval/global_step
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_logging_utils.py -q
# 1 passed

.venv/bin/python -m pytest tests -q
# 18 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/logging_utils.py \
  tests/test_logging_utils.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No
- Affected module: PPO W&B evaluation logging
- Performance impact: None
- Scope: Training metrics and non-W&B loggers are unchanged

## Checklist

- [x] The change addresses one observability correctness issue.
- [x] Regression coverage verifies definitions and emitted keys.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
