### PR TITLE
fix(metrics): normalize dynamic filter pass rate

### DIFF
--- a/openrlhf/trainer/ppo_utils/samples_generator.py
+++ b/openrlhf/trainer/ppo_utils/samples_generator.py
@@ -120,7 +120,10 @@ class SamplesGenerator:
                 batch_vllm_engine_call(self.vllm_engines, "sleep")
 
             if self.args.algo.dynamic_filtering_enable and prompts_consumed:
-                filter_pass_rate = len(experiences) / prompts_consumed * 100
+                n_samples_per_prompt = generate_kwargs.get(
+                    "n_samples_per_prompt", self.args.rollout.n_samples_per_prompt
+                )
+                filter_pass_rate = len(experiences) / n_samples_per_prompt / prompts_consumed * 100
 
             self._sample_buffer.extend(experiences)
 

--- a/tests/test_dynamic_filtering_metrics.py
+++ b/tests/test_dynamic_filtering_metrics.py
@@ -1,0 +1,60 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_samples_generator_module(monkeypatch):
+    ray_module = types.ModuleType("ray")
+    monkeypatch.setitem(sys.modules, "ray", ray_module)
+
+    vllm_module = types.ModuleType("vllm")
+    vllm_module.SamplingParams = object
+    monkeypatch.setitem(sys.modules, "vllm", vllm_module)
+
+    experience_module = types.ModuleType("openrlhf.trainer.ppo_utils.experience")
+    experience_module.Experience = object
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ppo_utils.experience", experience_module)
+
+    engine_module = types.ModuleType("openrlhf.trainer.ray.vllm_engine")
+    engine_module.batch_vllm_engine_call = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ray.vllm_engine", engine_module)
+
+    logging_module = types.ModuleType("openrlhf.utils.logging_utils")
+    logging_module.init_logger = logging.getLogger
+    monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", logging_module)
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.trainer.ppo_utils.samples_generator",
+        root / "openrlhf" / "trainer" / "ppo_utils" / "samples_generator.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dynamic_filter_pass_rate_counts_accepted_prompts(monkeypatch):
+    module = _load_samples_generator_module(monkeypatch)
+    args = SimpleNamespace(
+        vllm=SimpleNamespace(enable_sleep=False),
+        rollout=SimpleNamespace(batch_size=1, n_samples_per_prompt=8, vllm_generate_batch_size=1),
+        algo=SimpleNamespace(dynamic_filtering_enable=True),
+    )
+    generator = module.SamplesGenerator(
+        strategy=SimpleNamespace(args=args),
+        prompts_dataloader=[None],
+        eval_dataloader=None,
+        tokenizer=None,
+        vllm_engines=[],
+    )
+    generator._generate_vllm = lambda **kwargs: ([object()] * 8, 1, False)
+
+    samples, pass_rate, prompts_consumed, exhausted = generator.generate_samples(n_samples_per_prompt=8)
+
+    assert len(samples) == 8
+    assert pass_rate == 100.0
+    assert prompts_consumed == 1
+    assert not exhausted


### PR DESCRIPTION
## Background

The dynamic-filter pass rate currently divides accepted experiences by consumed prompts:

```python
len(experiences) / prompts_consumed * 100
```

Each accepted prompt produces `n_samples_per_prompt` experiences. With `n_samples_per_prompt=8`, one accepted prompt and no filtering therefore reports `800%` instead of `100%`.

## Changes

- Convert accepted experience count back to accepted prompt-group count.
- Respect a call-specific `n_samples_per_prompt` override.
- Add a mocked `SamplesGenerator` regression test for the common `n=8` case.

## Verification

Before:

```text
accepted experiences=8
consumed prompts=1
n_samples_per_prompt=8
pass rate=800%
```

After:

```text
pass rate=100%
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_dynamic_filtering_metrics.py -q
# 1 passed

.venv/bin/python -m pytest tests -q
# 18 passed

.venv/bin/pre-commit run --files \
  openrlhf/trainer/ppo_utils/samples_generator.py \
  tests/test_dynamic_filtering_metrics.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS. Ray and vLLM are mocked in the focused metric test.

## Impact

- Breaking change: No
- Affected module: dynamic-filter observability
- Performance impact: None
- Scope: Filtering and sample acceptance behavior are unchanged

## Checklist

- [x] The change addresses one metric correctness issue.
- [x] Regression coverage verifies multi-sample normalization.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
