### PR TITLE
fix(data): normalize local dataset extensions

### DIFF
--- a/openrlhf/datasets/utils.py
+++ b/openrlhf/datasets/utils.py
@@ -40,7 +40,7 @@ def blending_datasets(
         dataset = dataset.split("@")[0].strip()
         dataset_basename = os.path.basename(dataset)
 
-        ext = os.path.splitext(dataset)[-1]
+        ext = os.path.splitext(dataset)[-1].lower()
         # local python script
         if ext == ".py" or (
             os.path.isdir(dataset) and os.path.exists(os.path.join(dataset, f"{dataset_basename}.py"))
@@ -49,7 +49,7 @@ def blending_datasets(
             strategy.print(f"loaded {dataset} with python script")
         # local text file
         elif ext in [".json", ".jsonl", ".csv", ".parquet", ".arrow"]:
-            ext = ext.lower().strip(".")
+            ext = ext.strip(".")
             if ext == "jsonl":
                 ext = "json"
             data = load_dataset(ext, data_files=dataset)

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,65 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+class _FakeDataset:
+    def __len__(self):
+        return 1
+
+    def __contains__(self, key):
+        return False
+
+    def select(self, indices):
+        return self
+
+
+def _load_dataset_utils_module(monkeypatch, calls):
+    datasets_module = types.ModuleType("datasets")
+
+    def load_dataset(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FakeDataset()
+
+    datasets_module.load_dataset = load_dataset
+    datasets_module.load_from_disk = lambda path: _FakeDataset()
+    datasets_module.interleave_datasets = lambda data, **kwargs: data[0]
+    datasets_module.concatenate_datasets = lambda data: data[0]
+    monkeypatch.setitem(sys.modules, "datasets", datasets_module)
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.datasets.utils", root / "openrlhf" / "datasets" / "utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("suffix", "loader_name"),
+    [
+        ("JSON", "json"),
+        ("JSONL", "json"),
+        ("CSV", "csv"),
+        ("PARQUET", "parquet"),
+        ("ARROW", "arrow"),
+    ],
+)
+def test_blending_datasets_normalizes_local_file_extension(monkeypatch, suffix, loader_name):
+    calls = []
+    module = _load_dataset_utils_module(monkeypatch, calls)
+    strategy = SimpleNamespace(
+        args=SimpleNamespace(use_ms=False),
+        print=lambda message: None,
+        is_rank_0=lambda: False,
+    )
+    path = f"/tmp/train.{suffix}"
+
+    module.blending_datasets(path, strategy=strategy)
+
+    assert calls[0] == ((loader_name,), {"data_files": path})


### PR DESCRIPTION
## Background

Local dataset format detection compares file extensions before normalizing their case. Uppercase or mixed-case paths such as `train.JSONL` therefore skip the local-file branch and are passed to Hugging Face as dataset repository names:

```text
load_dataset("/tmp/train.JSONL", data_dir=None)
```

File extensions are case-insensitive on common workflows, and the expected call is:

```text
load_dataset("json", data_files="/tmp/train.JSONL")
```

## Changes

- Normalize the local path extension before format dispatch.
- Preserve the existing JSONL-to-JSON loader mapping.
- Add regression coverage for uppercase JSON, JSONL, CSV, Parquet, and Arrow paths.

## Verification

```bash
.venv/bin/python -m pytest tests/test_dataset_utils.py -q
# 5 passed

.venv/bin/python -m pytest tests -q
# 22 passed

.venv/bin/pre-commit run --files \
  openrlhf/datasets/utils.py \
  tests/test_dataset_utils.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS. Dataset loading is mocked in the focused test to verify exact loader arguments.

## Impact

- Breaking change: No
- Affected module: local dataset loading
- Performance impact: None
- Scope: Lowercase paths and remote dataset names retain their existing behavior

## Checklist

- [x] The change addresses one compatibility issue.
- [x] Regression tests cover all supported local file formats.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
