### PR TITLE
fix(vlm): release image sources after loading

### DIFF
--- a/openrlhf/utils/vlm_utils.py
+++ b/openrlhf/utils/vlm_utils.py
@@ -27,6 +27,12 @@ def _is_base64_image(s: str) -> bool:
     return False
 
 
+def _open_image_copy(source) -> Image.Image:
+    """Open and materialize an image without retaining the source resource."""
+    with Image.open(source) as image:
+        return image.copy()
+
+
 def load_images(image_refs: Union[str, List[str], Image.Image, List[Any]]) -> List[Image.Image]:
     """Load PIL images from paths, URLs, base64 strings, raw bytes, or PIL objects.
 
@@ -44,20 +50,20 @@ def load_images(image_refs: Union[str, List[str], Image.Image, List[Any]]) -> Li
             if isinstance(img, Image.Image):
                 pil_images.append(img)
             elif isinstance(img, bytes):
-                pil_images.append(Image.open(io.BytesIO(img)))
+                pil_images.append(_open_image_copy(io.BytesIO(img)))
             elif isinstance(img, str):
                 if img.startswith(("http://", "https://")):
                     import requests
 
-                    pil_images.append(Image.open(io.BytesIO(requests.get(img, timeout=30).content)))
+                    pil_images.append(_open_image_copy(io.BytesIO(requests.get(img, timeout=30).content)))
                 elif _is_base64_image(img):
                     import base64
 
                     # Strip optional data-URI header: "data:image/png;base64,..."
                     raw = img.split(",", 1)[-1] if img.startswith("data:") else img
-                    pil_images.append(Image.open(io.BytesIO(base64.b64decode(raw))))
+                    pil_images.append(_open_image_copy(io.BytesIO(base64.b64decode(raw))))
                 else:
-                    pil_images.append(Image.open(img))
+                    pil_images.append(_open_image_copy(img))
             else:
                 logger.warning(f"Skipping unsupported image type: {type(img)}")
         except Exception as e:

--- a/tests/test_vlm_image_loading.py
+++ b/tests/test_vlm_image_loading.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+
+from PIL import Image
+
+
+def _load_vlm_utils_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.vlm_utils", root / "openrlhf" / "utils" / "vlm_utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+load_images = _load_vlm_utils_module().load_images
+
+
+def test_load_images_closes_path_handle_before_returning(tmp_path):
+    path = tmp_path / "sample.png"
+    Image.new("RGB", (2, 2), color="red").save(path)
+
+    images = load_images(str(path))
+
+    assert len(images) == 1
+    assert getattr(images[0], "fp", None) is None
+    assert images[0].getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_load_images_preserves_caller_owned_pil_image():
+    source = Image.new("RGB", (1, 1), color="blue")
+
+    images = load_images(source)
+
+    assert images == [source]


### PR DESCRIPTION
## Background

`load_images` returns PIL objects created with `Image.open` from paths and in-memory streams. PIL loads lazily, so those returned objects retain their backing file handles until callers explicitly close them.

Loading the same local image 20 times currently returns 20 images with 20 open `image.fp` handles. Long-running VLM rollouts can therefore accumulate descriptors.

## Changes

- Materialize a pixel copy for images opened by `load_images`.
- Close path and in-memory sources before returning.
- Apply the same lifecycle to URL, bytes, and base64 image inputs.
- Preserve ownership of caller-provided `PIL.Image` objects.
- Add regression coverage for handle closure and caller-owned images.

## Verification

Before:

```text
images=20 open_file_handles=20
```

After:

```text
images=20 open_file_handles=0
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_vlm_image_loading.py -q
# 2 passed

.venv/bin/python -m pytest tests -q
# 19 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/vlm_utils.py \
  tests/test_vlm_image_loading.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No
- Affected module: VLM image loading
- Performance impact: Eagerly materializes images that downstream processors already consume
- Scope: Caller-provided PIL image ownership is unchanged

## Checklist

- [x] The change addresses one resource lifecycle issue.
- [x] Regression tests cover handle closure and ownership.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
