### PR TITLE
fix(reward): extract answers from fbox commands

### DIFF
--- a/openrlhf/utils/math_utils.py
+++ b/openrlhf/utils/math_utils.py
@@ -353,17 +353,14 @@ def last_boxed_only_string(string: str) -> str | None:
 
 
 def remove_boxed(value: str) -> str | None:
-    left = "\\boxed{"
-    try:
-        assert value[: len(left)] == left
-        assert value[-1] == "}"
-        return value[len(left) : -1]
-    except Exception:
-        return None
+    for left in ("\\boxed{", "\\fbox{"):
+        if value.startswith(left) and value.endswith("}"):
+            return value[len(left) : -1]
+    return None
 
 
 def extract_boxed_answer(solution: str) -> str | None:
-    """Extract the answer from inside a LaTeX \\boxed{} command."""
+    """Extract the answer from inside a LaTeX \\boxed{} or \\fbox{} command."""
     solution = last_boxed_only_string(solution)
     solution = remove_boxed(solution) if solution is not None else None
     return solution

--- a/tests/test_boxed_answer_extraction.py
+++ b/tests/test_boxed_answer_extraction.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_math_utils_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.math_utils", root / "openrlhf" / "utils" / "math_utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+extract_boxed_answer = _load_math_utils_module().extract_boxed_answer
+
+
+@pytest.mark.parametrize(
+    ("solution", "expected"),
+    [
+        (r"answer: \boxed{42}", "42"),
+        (r"answer: \fbox{42}", "42"),
+        (r"answer: \fbox{\frac{1}{2}}", r"\frac{1}{2}"),
+    ],
+)
+def test_extract_boxed_answer_supports_box_commands(solution, expected):
+    assert extract_boxed_answer(solution) == expected
+
+
+def test_extract_boxed_answer_rejects_unclosed_command():
+    assert extract_boxed_answer(r"answer: \fbox{42") is None


### PR DESCRIPTION
## Background

The math answer extractor searches for both `\boxed{}` and `\fbox{}` commands, but `remove_boxed` only accepts the `\boxed{` prefix. As a result:

```text
extract_boxed_answer(r"\boxed{42}") -> "42"
extract_boxed_answer(r"\fbox{42}")  -> None
```

This silently drops otherwise valid math answers before reward grading.

## Changes

- Accept both `\boxed{}` and `\fbox{}` prefixes during answer removal.
- Preserve malformed-input behavior (`None`).
- Update the public helper docstring.
- Add coverage for scalar, nested fraction, and unclosed commands.

## Verification

After the change:

```text
\boxed{42}             -> 42
\fbox{42}              -> 42
\fbox{\frac{1}{2}}     -> \frac{1}{2}
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_boxed_answer_extraction.py -q
# 4 passed

.venv/bin/python -m pytest tests -q
# 21 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/math_utils.py \
  tests/test_boxed_answer_extraction.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No
- Affected module: math reward answer extraction
- Performance impact: None
- Scope: Existing `\boxed{}` behavior is unchanged

## Checklist

- [x] The change addresses one reward correctness issue.
- [x] Regression tests cover valid and malformed commands.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
