### PR TITLE
fix(checkpoint): normalize legacy PPO state

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -23,6 +23,21 @@ from openrlhf.utils.utils import get_tokenizer
 logger = init_logger(__name__)
 
 
+def normalize_checkpoint_states(checkpoint_states=None):
+    """Fill controller fields missing from legacy or model-only checkpoints."""
+    defaults = {
+        "episode": 0,
+        "global_step": 0,
+        "total_consumed_prompts": 0,
+        "data_loader_state_dict": {},
+    }
+    states = dict(checkpoint_states or {})
+    missing = [key for key in defaults if key not in states]
+    if checkpoint_states is not None and missing:
+        logger.warning(f"Checkpoint is missing controller state {missing}; using defaults.")
+    return {**defaults, **states}
+
+
 def prepare_datasets(strategy, tokenizer):
     args = strategy.args
 
@@ -433,13 +448,8 @@ class BasePPOTrainer(ABC):
                 0
             ]
             logger.info(f"checkpoint_states: {checkpoint_states}")
-            return checkpoint_states
-        return {
-            "episode": 0,
-            "global_step": 0,
-            "total_consumed_prompts": 0,
-            "data_loader_state_dict": {},
-        }
+            return normalize_checkpoint_states(checkpoint_states)
+        return normalize_checkpoint_states()
 
 
 @ray.remote

--- a/openrlhf/trainer/ppo_trainer_async.py
+++ b/openrlhf/trainer/ppo_trainer_async.py
@@ -334,12 +334,11 @@ class PPOTrainerAsync:
         total_consumed_prompts = checkpoint_states.get("total_consumed_prompts", 0)
         # Keep vLLM weights and dataloader states in sync when resuming.
         if global_step > 0:
-            ray.get(
-                [
-                    self.generator_actor.load_state_dict.remote(checkpoint_states["data_loader_state_dict"]),
-                    self.trainer_actor.broadcast_to_vllm.remote(),
-                ]
-            )
+            refs = [self.trainer_actor.broadcast_to_vllm.remote()]
+            data_loader_state_dict = checkpoint_states.get("data_loader_state_dict")
+            if data_loader_state_dict:
+                refs.append(self.generator_actor.load_state_dict.remote(data_loader_state_dict))
+            ray.get(refs)
 
         # Launch async training
         ray.get(

--- a/tests/test_ppo_checkpoint_state.py
+++ b/tests/test_ppo_checkpoint_state.py
@@ -1,0 +1,75 @@
+import importlib.util
+import logging
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _load_ppo_trainer_module(monkeypatch):
+    ray_module = types.ModuleType("ray")
+    ray_module.get = lambda value: value
+    ray_module.remote = lambda obj=None, **kwargs: obj if obj is not None else lambda value: value
+    monkeypatch.setitem(sys.modules, "ray", ray_module)
+
+    stubs = {
+        "openrlhf.datasets": {"PromptDataset": object},
+        "openrlhf.datasets.utils": {"blending_datasets": lambda *args, **kwargs: None},
+        "openrlhf.trainer.ppo_utils.experience": {"balance_experiences": lambda value, args: value},
+        "openrlhf.trainer.ppo_utils.experience_maker": {"RemoteExperienceMaker": object},
+        "openrlhf.trainer.ppo_utils.kl_controller": {
+            "AdaptiveKLController": object,
+            "FixedKLController": object,
+        },
+        "openrlhf.trainer.ppo_utils.samples_generator": {"SamplesGenerator": object},
+        "openrlhf.trainer.ray.launcher": {"RayActorGroup": object},
+        "openrlhf.trainer.ray.vllm_engine": {"batch_vllm_engine_call": lambda *args, **kwargs: None},
+        "openrlhf.utils.deepspeed": {"DeepspeedStrategy": object},
+        "openrlhf.utils.logging_utils": {
+            "TensorboardLogger": object,
+            "WandbLogger": object,
+            "init_logger": logging.getLogger,
+        },
+        "openrlhf.utils.utils": {"get_tokenizer": lambda *args, **kwargs: None},
+    }
+    for name, attributes in stubs.items():
+        module = types.ModuleType(name)
+        for key, value in attributes.items():
+            setattr(module, key, value)
+        monkeypatch.setitem(sys.modules, name, module)
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.trainer.ppo_trainer", root / "openrlhf" / "trainer" / "ppo_trainer.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_checkpoint_states_fills_legacy_controller_fields(monkeypatch):
+    module = _load_ppo_trainer_module(monkeypatch)
+
+    states = module.normalize_checkpoint_states({"episode": 2, "global_step": 7})
+
+    assert states == {
+        "episode": 2,
+        "global_step": 7,
+        "total_consumed_prompts": 0,
+        "data_loader_state_dict": {},
+    }
+
+
+def test_init_checkpoint_states_normalizes_loaded_state(monkeypatch, tmp_path):
+    module = _load_ppo_trainer_module(monkeypatch)
+    trainer = module.BasePPOTrainer.__new__(module.BasePPOTrainer)
+    trainer.args = SimpleNamespace(ckpt=SimpleNamespace(path=str(tmp_path), load_enable=True))
+    (tmp_path / "_actor").mkdir()
+    trainer.actor_model_group = SimpleNamespace(async_run_method=lambda **kwargs: [{"episode": 1, "global_step": 3}])
+
+    states = trainer.init_checkpoint_states()
+
+    assert states["episode"] == 1
+    assert states["global_step"] == 3
+    assert states["total_consumed_prompts"] == 0
+    assert states["data_loader_state_dict"] == {}


### PR DESCRIPTION
## Background

PPO resume assumes every loaded checkpoint contains all current controller fields:

```python
checkpoint_states["total_consumed_prompts"]
checkpoint_states["data_loader_state_dict"]
```

Legacy checkpoints and model-only checkpoints may only contain `episode` and `global_step`. Model loading then succeeds, but controller startup fails with `KeyError`.

The async path also passes an empty dataloader state to `load_state_dict` whenever `global_step > 0`.

## Changes

- Normalize loaded checkpoint state with defaults for current controller fields.
- Preserve all fields that are present in the checkpoint.
- Warn when an actual loaded checkpoint is missing controller fields.
- Avoid calling async dataloader restoration when no state exists.
- Add regression coverage for legacy-state normalization and loaded-state integration.

Missing dataloader state cannot reconstruct a historical cursor; the warning makes that limitation explicit while allowing model/controller recovery to proceed from the loader's default position.

## Verification

Before:

```text
{"episode": 1, "global_step": 3}
-> KeyError: "total_consumed_prompts"
-> KeyError: "data_loader_state_dict"
```

After:

```text
{
  "episode": 1,
  "global_step": 3,
  "total_consumed_prompts": 0,
  "data_loader_state_dict": {}
}
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_ppo_checkpoint_state.py -q
# 2 passed

.venv/bin/python -m pytest tests -q
# 19 passed

.venv/bin/pre-commit run --files \
  openrlhf/trainer/ppo_trainer.py \
  openrlhf/trainer/ppo_trainer_async.py \
  tests/test_ppo_checkpoint_state.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No
- Affected module: sync and async PPO checkpoint recovery
- Performance impact: None
- Scope: Complete current-format checkpoints retain identical state

## Checklist

- [x] The change addresses one checkpoint compatibility issue.
- [x] Regression tests cover legacy and integration paths.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
