### PR TITLE
fix(batch): align dynamic micro-batches upward

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience_maker.py
+++ b/openrlhf/trainer/ppo_utils/experience_maker.py
@@ -11,7 +11,11 @@ from openrlhf.trainer.ppo_utils.experience import Experience
 from openrlhf.trainer.ppo_utils.length_penalty import apply_length_penalties
 from openrlhf.trainer.ray.launcher import RayActorGroup
 from openrlhf.utils.logging_utils import init_logger
-from openrlhf.utils.seqlen_balancing import get_minimum_num_micro_batch_size, get_seqlen_balanced_partitions
+from openrlhf.utils.seqlen_balancing import (
+    align_num_micro_batches,
+    get_minimum_num_micro_batch_size,
+    get_seqlen_balanced_partitions,
+)
 
 logger = init_logger(__name__)
 
@@ -60,8 +64,7 @@ class RemoteExperienceMaker:
                 self.args.ds.ring_attn_size,
                 self.args.ds.tensor_parallel_size,
             )
-            minimum_batch_num = minimum_batch_num // effective_actor_num * effective_actor_num
-            num_batch = max(minimum_batch_num, effective_actor_num)
+            num_batch = align_num_micro_batches(minimum_batch_num, effective_actor_num, len(total_lengths))
             batch_indexes = get_seqlen_balanced_partitions(total_lengths, num_batch, False)
             for micro_index in batch_indexes:
                 micro_batch = [rollout_samples[idx] for idx in micro_index]

--- a/openrlhf/utils/seqlen_balancing.py
+++ b/openrlhf/utils/seqlen_balancing.py
@@ -222,6 +222,20 @@ def ceildiv(a, b):
     return -(a // -b)
 
 
+def align_num_micro_batches(minimum_batches: int, effective_actors: int, num_samples: int) -> int:
+    """Round a minimum batch count up for equal actor work without empty batches."""
+    if effective_actors <= 0:
+        raise ValueError(f"effective_actors must be positive, got {effective_actors}")
+
+    aligned_batches = max(ceildiv(minimum_batches, effective_actors) * effective_actors, effective_actors)
+    if aligned_batches > num_samples:
+        raise ValueError(
+            f"Cannot create {aligned_batches} non-empty micro-batches from {num_samples} samples "
+            f"(minimum_batches={minimum_batches}, effective_actors={effective_actors})"
+        )
+    return aligned_batches
+
+
 def get_reverse_idx(idx_map):
     reverse_idx_map = copy.deepcopy(idx_map)
 

--- a/tests/test_dynamic_batch_alignment.py
+++ b/tests/test_dynamic_batch_alignment.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_seqlen_balancing_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.seqlen_balancing", root / "openrlhf" / "utils" / "seqlen_balancing.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+align_num_micro_batches = _load_seqlen_balancing_module().align_num_micro_batches
+
+
+def test_micro_batch_alignment_rounds_minimum_up_to_actor_multiple():
+    assert align_num_micro_batches(minimum_batches=5, effective_actors=4, num_samples=8) == 8
+
+
+def test_micro_batch_alignment_keeps_feasible_actor_minimum():
+    assert align_num_micro_batches(minimum_batches=3, effective_actors=4, num_samples=4) == 4
+
+
+def test_micro_batch_alignment_rejects_empty_required_partitions():
+    with pytest.raises(ValueError, match="Cannot create 8 non-empty micro-batches from 5 samples"):
+        align_num_micro_batches(minimum_batches=5, effective_actors=4, num_samples=5)


### PR DESCRIPTION
## Background

Dynamic rollout batching first computes the minimum number of micro-batches needed to respect the token capacity, then aligns that number to the effective actor count:

```python
minimum_batch_num = minimum_batch_num // effective_actor_num * effective_actor_num
```

This rounds down. If the capacity calculation requires 5 micro-batches and there are 4 effective actors, the result becomes 4, violating the already-computed minimum and potentially exceeding the per-GPU token limit.

## Changes

- Round the minimum micro-batch count up to an effective-actor multiple.
- Keep at least one non-empty batch per effective actor.
- Reject configurations where the aligned count exceeds the sample count and would require empty partitions.
- Add regression coverage for upward alignment, actor minimum, and infeasible alignment.

## Verification

Before:

```text
minimum=5, actors=4 -> aligned=4
```

After:

```text
minimum=5, actors=4, samples=8 -> aligned=8
minimum=3, actors=4, samples=4 -> aligned=4
minimum=5, actors=4, samples=5 -> explicit ValueError
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_dynamic_batch_alignment.py -q
# 3 passed

.venv/bin/python -m pytest tests -q
# 20 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/seqlen_balancing.py \
  openrlhf/trainer/ppo_utils/experience_maker.py \
  tests/test_dynamic_batch_alignment.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No for feasible configurations
- Affected module: dynamic rollout micro-batch partitioning
- Performance impact: May use more micro-batches when required to preserve the configured token limit
- Scope: Already aligned counts are unchanged

## Checklist

- [x] The change addresses one dynamic-batch correctness issue.
- [x] Regression tests cover feasible and infeasible boundaries.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
