### PR TITLE
fix(cli): require positive sample counts

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -13,7 +13,7 @@ from openrlhf.trainer.ray.launcher import (
 )
 from openrlhf.trainer.ray.ppo_actor import PolicyModelActor
 from openrlhf.trainer.ray.ppo_critic import CriticModelActor
-from openrlhf.utils import get_strategy
+from openrlhf.utils import get_strategy, positive_int
 
 
 def train(args):
@@ -411,7 +411,10 @@ if __name__ == "__main__":
         help="Freeze the actor for the first N steps to let the critic warm up",
     )
     parser.add_argument(
-        "--rollout.n_samples_per_prompt", type=int, default=1, help="number of responses for each prompt in generation"
+        "--rollout.n_samples_per_prompt",
+        type=positive_int,
+        default=1,
+        help="number of responses for each prompt in generation",
     )
     parser.add_argument("--critic.save_value_network", action="store_true", default=False, help="Save critic model")
     parser.add_argument("--algo.kl.target", type=float, default=None)
@@ -536,7 +539,10 @@ if __name__ == "__main__":
     parser.add_argument("--eval.split", type=str, default="train")
     parser.add_argument("--eval.temperature", type=float, default=0.6, help="Temperature for evaluation")
     parser.add_argument(
-        "--eval.n_samples_per_prompt", type=int, default=4, help="Number of samples per prompt for evaluation"
+        "--eval.n_samples_per_prompt",
+        type=positive_int,
+        default=4,
+        help="Number of samples per prompt for evaluation",
     )
 
     parser.add_argument("--data.input_key", type=str, default="input", help="JSON dataset key")

--- a/openrlhf/utils/__init__.py
+++ b/openrlhf/utils/__init__.py
@@ -1,3 +1,4 @@
+from .config import positive_int
 from .math_utils import extract_boxed_answer, grade_answer
 from .utils import get_strategy, get_tokenizer
 
@@ -6,4 +7,5 @@ __all__ = [
     "grade_answer",
     "get_strategy",
     "get_tokenizer",
+    "positive_int",
 ]

--- a/openrlhf/utils/config.py
+++ b/openrlhf/utils/config.py
@@ -6,7 +6,19 @@ dots (e.g. ``"muon.lr"``) into a nested SimpleNamespace so callers can write
 at the top level.
 """
 
+import argparse
 from types import SimpleNamespace
+
+
+def positive_int(value):
+    """Parse a strictly positive integer for argparse options."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
 
 
 def hierarchize(args):

--- a/tests/test_config_types.py
+++ b/tests/test_config_types.py
@@ -1,0 +1,26 @@
+import argparse
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_config_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location("openrlhf.utils.config", root / "openrlhf" / "utils" / "config.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+positive_int = _load_config_module().positive_int
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "invalid"])
+def test_positive_int_rejects_non_positive_values(value):
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_int(value)
+
+
+def test_positive_int_accepts_positive_value():
+    assert positive_int("8") == 8


### PR DESCRIPTION
## Background

Both PPO sample-count options currently use unconstrained `int` parsing:

```text
--rollout.n_samples_per_prompt
--eval.n_samples_per_prompt
```

Zero or negative values therefore pass argument parsing. A zero rollout count creates an empty rollout chunk that later enters training; a zero eval count reaches vLLM as an invalid request.

## Changes

- Add a reusable strictly-positive integer argparse type.
- Apply it to rollout and evaluation samples per prompt.
- Export the type through `openrlhf.utils`, matching existing CLI imports and test mocks.
- Add coverage for positive, zero, negative, and non-integer values.

## Verification

```text
--samples 8  -> accepted as 8
--samples 0  -> argparse error (exit 2)
--samples -1 -> argparse error (exit 2)
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_config_types.py -q
# 4 passed

.venv/bin/python -m pytest tests -q
# 21 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/config.py \
  openrlhf/utils/__init__.py \
  openrlhf/cli/train_ppo_ray.py \
  tests/test_config_types.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: Invalid zero/negative sample counts now fail during parsing
- Affected module: PPO rollout and evaluation CLI
- Performance impact: None
- Scope: All positive configurations are unchanged

## Checklist

- [x] The change addresses one CLI configuration issue.
- [x] Regression tests cover valid and invalid values.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
