### PR TITLE
fix(kl): validate adaptive controller parameters

### DIFF
--- a/openrlhf/trainer/ppo_utils/kl_controller.py
+++ b/openrlhf/trainer/ppo_utils/kl_controller.py
@@ -8,6 +8,10 @@ class AdaptiveKLController:
     """
 
     def __init__(self, init_kl_coef, target, horizon):
+        if target <= 0:
+            raise ValueError(f"KL target must be positive, got {target}")
+        if horizon <= 0:
+            raise ValueError(f"KL horizon must be positive, got {horizon}")
         self.value = init_kl_coef
         self.target = target
         self.horizon = horizon

--- a/tests/test_kl_controller.py
+++ b/tests/test_kl_controller.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_kl_controller_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.trainer.ppo_utils.kl_controller",
+        root / "openrlhf" / "trainer" / "ppo_utils" / "kl_controller.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+AdaptiveKLController = _load_kl_controller_module().AdaptiveKLController
+
+
+@pytest.mark.parametrize(
+    ("target", "horizon", "message"),
+    [(0.0, 100, "target"), (-1.0, 100, "target"), (1.0, 0, "horizon"), (1.0, -1, "horizon")],
+)
+def test_adaptive_kl_controller_rejects_non_positive_parameters(target, horizon, message):
+    with pytest.raises(ValueError, match=message):
+        AdaptiveKLController(init_kl_coef=0.1, target=target, horizon=horizon)
+
+
+def test_adaptive_kl_controller_updates_with_valid_parameters():
+    controller = AdaptiveKLController(init_kl_coef=0.1, target=1.0, horizon=100)
+
+    controller.update(current=1.2, n_steps=10)
+
+    assert controller.value == pytest.approx(0.102)


### PR DESCRIPTION
## Background

`AdaptiveKLController` divides by both `target` and `horizon` during every update, but accepts non-positive values:

```text
target=0, horizon=100 -> ZeroDivisionError
target=1, horizon=0   -> coefficient becomes -inf
```

Invalid controller parameters can therefore fail after training starts or silently make the KL coefficient non-finite.

## Changes

- Require a positive adaptive KL target.
- Require a positive adaptive KL horizon.
- Raise actionable `ValueError` messages during controller construction.
- Add coverage for zero/negative parameters and a valid update.

## Verification

```text
target=0   -> ValueError
target=-1  -> ValueError
horizon=0  -> ValueError
horizon=-1 -> ValueError
target=1, horizon=100 -> valid update, coefficient=0.102
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_kl_controller.py -q
# 5 passed

.venv/bin/python -m pytest tests -q
# 22 passed

.venv/bin/pre-commit run --files \
  openrlhf/trainer/ppo_utils/kl_controller.py \
  tests/test_kl_controller.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: Invalid non-positive adaptive KL settings now fail at startup
- Affected module: adaptive KL control
- Performance impact: None
- Scope: Valid controller updates are unchanged

## Checklist

- [x] The change addresses one algorithm configuration issue.
- [x] Regression tests cover invalid and valid inputs.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
