### PR TITLE
fix(math): remove invalid percent escape

### DIFF
--- a/openrlhf/utils/math_utils.py
+++ b/openrlhf/utils/math_utils.py
@@ -99,7 +99,6 @@ def _strip_string(string: str) -> str:
     string = string.replace("\\$", "")
     string = _remove_right_units(string)
     string = string.replace("\\%", "")
-    string = string.replace("\%", "")
     string = string.replace(" .", " 0.")
     string = string.replace("{.", "{0.")
     if len(string) == 0:

--- a/tests/test_python_syntax.py
+++ b/tests/test_python_syntax.py
@@ -1,0 +1,11 @@
+import warnings
+from pathlib import Path
+
+
+def test_math_utils_compiles_with_syntax_warnings_as_errors():
+    root = Path(__file__).resolve().parents[1]
+    path = root / "openrlhf" / "utils" / "math_utils.py"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SyntaxWarning)
+        compile(path.read_text(), str(path), "exec")


### PR DESCRIPTION
## Background

`math_utils.py` contains an invalid Python string escape:

```python
string.replace("\%", "")
```

Python 3.12 emits a `SyntaxWarning`, and strict compatibility checks fail compilation:

```bash
python -W error::SyntaxWarning -m py_compile openrlhf/utils/math_utils.py
# SyntaxError: invalid escape sequence '\%'
```

The preceding line already performs the same replacement with the valid `"\\%"` spelling, so the invalid line is redundant.

## Changes

- Remove the redundant invalid escape.
- Add a regression test that compiles `math_utils.py` with `SyntaxWarning` treated as an error.

Runtime normalization behavior is unchanged.

## Verification

```bash
.venv/bin/python -W error::SyntaxWarning -m py_compile openrlhf/utils/math_utils.py
# passed

.venv/bin/python -m pytest tests/test_python_syntax.py -q
# 1 passed

.venv/bin/python -m pytest tests -q
# 18 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/math_utils.py \
  tests/test_python_syntax.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: No
- Affected module: Python 3.12 math utility import/compilation
- Performance impact: None
- Scope: Percent normalization behavior is unchanged

## Checklist

- [x] The change addresses one Python compatibility issue.
- [x] Regression coverage treats syntax warnings as errors.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
