### PR TITLE
fix(deepspeed): validate gradient accumulation batches

### DIFF
--- a/openrlhf/utils/deepspeed/batch.py
+++ b/openrlhf/utils/deepspeed/batch.py
@@ -1,0 +1,28 @@
+def calculate_gradient_accumulation_steps(
+    train_batch_size: int,
+    micro_train_batch_size: int,
+    world_size: int,
+    ring_attn_size: int = 1,
+    tensor_parallel_size: int = 1,
+    dynamic_batch: bool = False,
+) -> int:
+    """Validate batch divisibility and return DeepSpeed accumulation steps."""
+    parallel_size = ring_attn_size * tensor_parallel_size
+    if min(train_batch_size, micro_train_batch_size, world_size, parallel_size) <= 0:
+        raise ValueError("Batch sizes, world size, and parallel sizes must be positive")
+    if world_size % parallel_size != 0:
+        raise ValueError(
+            f"world_size ({world_size}) must be divisible by ring_attn_size * tensor_parallel_size "
+            f"({ring_attn_size} * {tensor_parallel_size} = {parallel_size})"
+        )
+    if dynamic_batch:
+        return 1
+
+    data_parallel_size = world_size // parallel_size
+    batch_quantum = micro_train_batch_size * data_parallel_size
+    if train_batch_size % batch_quantum != 0:
+        raise ValueError(
+            f"train.batch_size ({train_batch_size}) must be divisible by train.micro_batch_size "
+            f"({micro_train_batch_size}) * data parallel size ({data_parallel_size}) = {batch_quantum}"
+        )
+    return train_batch_size // batch_quantum

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -26,6 +26,7 @@ from openrlhf.models.ring_attn_utils import get_ring_attn_group, set_ring_attn_g
 from openrlhf.utils.distributed_sampler import DistributedSampler
 from openrlhf.utils.distributed_util import torch_dist_barrier_and_cuda_sync
 
+from .batch import calculate_gradient_accumulation_steps
 from .deepspeed_utils import (
     _z3_params_to_fetch,
     get_eval_ds_config,
@@ -107,12 +108,13 @@ class DeepspeedStrategy(ABC):
         )
         self.setup_ring_attn(self.ds_device_mesh)
 
-        self.accumulated_gradient = (
-            self.train_batch_size
-            * self.ring_attn_size
-            * self.ds_tensor_parallel_size
-            // self.micro_train_batch_size
-            // self.world_size
+        self.accumulated_gradient = calculate_gradient_accumulation_steps(
+            self.train_batch_size,
+            self.micro_train_batch_size,
+            self.world_size,
+            self.ring_attn_size,
+            self.ds_tensor_parallel_size,
+            dynamic_batch=self.use_dynamic_batch,
         )
 
     def setup_ring_attn(self, ds_device_mesh):

--- a/tests/test_deepspeed_batch.py
+++ b/tests/test_deepspeed_batch.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+def _load_batch_module():
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "openrlhf.utils.deepspeed.batch", root / "openrlhf" / "utils" / "deepspeed" / "batch.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+calculate_gradient_accumulation_steps = _load_batch_module().calculate_gradient_accumulation_steps
+
+
+def test_gradient_accumulation_accounts_for_data_parallel_size():
+    assert calculate_gradient_accumulation_steps(128, 2, world_size=8) == 8
+    assert calculate_gradient_accumulation_steps(8, 2, world_size=8, ring_attn_size=2) == 1
+
+
+def test_dynamic_batch_uses_runtime_accumulation_control():
+    assert calculate_gradient_accumulation_steps(8, 2, world_size=8, dynamic_batch=True) == 1
+
+
+@pytest.mark.parametrize("train_batch_size", [8, 15])
+def test_gradient_accumulation_rejects_zero_or_fractional_steps(train_batch_size):
+    with pytest.raises(ValueError, match=r"micro_batch_size \(2\) \* data parallel size \(8\) = 16"):
+        calculate_gradient_accumulation_steps(train_batch_size, 2, world_size=8)
+
+
+def test_gradient_accumulation_rejects_incompatible_parallel_sizes():
+    with pytest.raises(ValueError, match=r"world_size \(8\) must be divisible"):
+        calculate_gradient_accumulation_steps(16, 2, world_size=8, ring_attn_size=3)


### PR DESCRIPTION
## Background

Closes #584.

Static DeepSpeed training computes gradient accumulation with integer division:

```python
train_batch_size * ring_size * tp_size // micro_batch_size // world_size
```

For the reported configuration (`train=8`, `micro=2`, `world=8`), this becomes zero. DeepSpeed then fails later with:

```text
Gradient accumulation steps: 0 has to be greater than 0
```

Non-divisible configurations can also be silently truncated before DeepSpeed rejects the inconsistent batch relationship.

## Changes

- Validate static batch divisibility against micro-batch size and effective data-parallel size.
- Return a precise error containing the required batch quantum.
- Validate world-size compatibility with Ring Attention and Tensor Parallel sizes.
- Preserve dynamic batching's runtime-controlled accumulation value of one.
- Add coverage for valid static, Ring Attention, dynamic, zero-step, fractional, and incompatible topology cases.

## Verification

```text
train=8, micro=2, world=8
-> ValueError: train.batch_size (8) must be divisible by
   train.micro_batch_size (2) * data parallel size (8) = 16

train=16, micro=2, world=8 -> accumulation=1
train=8, micro=2, world=8, ring=2 -> accumulation=1
```

Commands:

```bash
.venv/bin/python -m pytest tests/test_deepspeed_batch.py -q
# 5 passed

.venv/bin/python -m pytest tests -q
# 22 passed

.venv/bin/pre-commit run --files \
  openrlhf/utils/deepspeed/batch.py \
  openrlhf/utils/deepspeed/deepspeed.py \
  tests/test_deepspeed_batch.py
# all hooks passed
```

The full local test run used a minimal `deepspeed` import stub because DeepSpeed is not available on macOS.

## Impact

- Breaking change: Invalid static batch configurations now fail earlier
- Affected module: DeepSpeed batch setup
- Performance impact: None
- Scope: Valid static and dynamic configurations are unchanged

## Checklist

- [x] The change fixes the reported configuration failure.
- [x] Regression tests cover static and dynamic paths.
- [x] Existing tests pass locally.
- [x] Pre-commit hooks pass.
