### PR TITLE
fix(ppo): preserve ragged batches in balance_experiences

### DIFF
--- a/openrlhf/trainer/ppo_utils/experience.py
+++ b/openrlhf/trainer/ppo_utils/experience.py
@@ -299,5 +299,5 @@ def balance_experiences(experiences, args):
     if len(last_half) > len(first_half):
         interval_items.append(last_half[0])
 
-    interval_merged = list(zip(*interval_items))
-    return [make_experience_batch(items) for items in interval_merged]
+    interval_merged = itertools.zip_longest(*interval_items)
+    return [make_experience_batch([item for item in items if item is not None]) for items in interval_merged]

--- a/tests/test_experience.py
+++ b/tests/test_experience.py
@@ -1,0 +1,74 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+def _load_experience_module():
+    root = Path(__file__).resolve().parents[1]
+
+    utils_module = types.ModuleType("openrlhf.utils.utils")
+
+    def zero_pad_sequences(sequences, side="left", value=0, stack=False):
+        max_len = max(sequence.size(-1) for sequence in sequences)
+        padded = []
+        for sequence in sequences:
+            pad_len = max_len - sequence.size(-1)
+            padding = (pad_len, 0) if side == "left" else (0, pad_len)
+            padded.append(F.pad(sequence, padding, value=value))
+        return torch.stack(padded) if stack else torch.cat(padded)
+
+    utils_module.zero_pad_sequences = zero_pad_sequences
+    original_utils_module = sys.modules.get("openrlhf.utils.utils")
+    sys.modules["openrlhf.utils.utils"] = utils_module
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "_openrlhf_experience_test", root / "openrlhf" / "trainer" / "ppo_utils" / "experience.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if original_utils_module is None:
+            sys.modules.pop("openrlhf.utils.utils", None)
+        else:
+            sys.modules["openrlhf.utils.utils"] = original_utils_module
+
+
+_experience_module = _load_experience_module()
+Experience = _experience_module.Experience
+balance_experiences = _experience_module.balance_experiences
+
+
+def _make_experience(index, length):
+    return Experience(
+        sequences=torch.full((1, length), index, dtype=torch.long),
+        attention_mask=torch.ones((1, length), dtype=torch.long),
+        action_mask=torch.ones((1, length - 1), dtype=torch.bool),
+        total_length=torch.tensor([length]),
+        prompts=[f"sample-{index}"],
+    )
+
+
+@pytest.mark.parametrize("sample_count", [4, 5, 9])
+def test_balance_experiences_preserves_divisible_and_ragged_batches(sample_count):
+    args = SimpleNamespace(
+        actor=SimpleNamespace(num_nodes=1, num_gpus_per_node=4),
+        ds=SimpleNamespace(ring_attn_size=1, tensor_parallel_size=1),
+    )
+    inputs = [_make_experience(index, sample_count - index + 1) for index in range(sample_count)]
+
+    outputs = balance_experiences(inputs, args)
+
+    output_prompts = [prompt for batch in outputs for prompt in batch.prompts]
+    batch_sizes = [len(batch.sequences) for batch in outputs]
+    assert len(outputs) == 4
+    assert all(size > 0 for size in batch_sizes)
+    assert sum(batch_sizes) == sample_count
+    assert sorted(output_prompts) == sorted(f"sample-{index}" for index in range(sample_count))


### PR DESCRIPTION
## Summary

- use `zip_longest` when transposing dynamically balanced experience chunks
- omit only missing tail entries instead of truncating every longer chunk
- add divisible and ragged regression cases that verify all sample IDs are preserved

## Root cause and impact

`balance_experiences()` can produce a shorter final chunk whenever the number of rollout samples is not divisible by the effective actor count. Plain `zip()` truncates the transpose to that shortest chunk, silently dropping samples and returning fewer batches than actors. The following Ray dispatch then fails before training.

Filtering `None` values from `zip_longest()` preserves every experience and still returns one non-empty batch per effective actor for all currently valid inputs.

Closes #1296.

## Validation

- CPU regression and repository test suite: **20 passed**
- project pre-commit hooks on both changed files: **passed**

The regression covers 4, 5, and 9 samples for 4 effective actors, checking output batch count, non-empty batches, total sample count, and exact prompt-ID preservation.
