### PR TITLE
fix(ppo): process terminal synchronous rollout batches

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -528,8 +528,10 @@ class PPOTrainer(BasePPOTrainer):
                 )
                 generation_time = time.time() - t_gen_start
                 total_consumed_prompts += prompts_consumed
-                if is_exhausted:
-                    break
+                if not rollout_samples:
+                    if is_exhausted:
+                        break
+                    continue
 
                 # Run PPO update on this batch and bump the global step counter.
                 status, global_step = self.train_step(rollout_samples, global_step)
@@ -562,6 +564,9 @@ class PPOTrainer(BasePPOTrainer):
                     self.save_best_checkpoint(eval_logs, global_step, client_states)
 
                 pbar.update(prompts_consumed)
+
+                if is_exhausted:
+                    break
 
         # Close trackers
         if self.wandb_logger:

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -1,0 +1,118 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _Pbar:
+    def __init__(self, iterable, **_):
+        self.iterable = iterable
+
+    def __iter__(self):
+        return iter(self.iterable)
+
+    def update(self, _):
+        pass
+
+
+@pytest.fixture
+def ppo_module(monkeypatch):
+    fake_ray = MagicMock()
+    fake_ray.remote.side_effect = lambda obj=None, **_: (lambda cls: cls) if obj is None else obj
+    fake_ray.get.side_effect = lambda value: value
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=_Pbar))
+
+    # Keep this control-flow test importable without Ray, vLLM, DeepSpeed, or datasets.
+    for name in (
+        "openrlhf.datasets",
+        "openrlhf.datasets.utils",
+        "openrlhf.trainer.ppo_utils.experience",
+        "openrlhf.trainer.ppo_utils.experience_maker",
+        "openrlhf.trainer.ppo_utils.kl_controller",
+        "openrlhf.trainer.ppo_utils.samples_generator",
+        "openrlhf.trainer.ray.launcher",
+        "openrlhf.trainer.ray.vllm_engine",
+        "openrlhf.utils.deepspeed",
+        "openrlhf.utils.logging_utils",
+        "openrlhf.utils.utils",
+    ):
+        monkeypatch.setitem(sys.modules, name, MagicMock())
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_ppo_trainer_test",
+        root / "openrlhf" / "trainer" / "ppo_trainer.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    module.tqdm = _Pbar
+    return module
+
+
+class _Loader:
+    def __len__(self):
+        return 129
+
+    def state_dict(self):
+        return {"done": True}
+
+
+class _Generator:
+    def __init__(self, result):
+        self.result = result
+        self.calls = 0
+
+    def generate_samples(self, **_):
+        self.calls += 1
+        if self.calls > 1:
+            raise AssertionError("The terminal result must end the episode")
+        return self.result
+
+
+def _trainer(module, result):
+    trainer = module.PPOTrainer.__new__(module.PPOTrainer)
+    trainer.args = SimpleNamespace(
+        train=SimpleNamespace(num_episodes=1),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        eval=SimpleNamespace(steps=float("inf"), temperature=1.0, n_samples_per_prompt=1),
+    )
+    trainer.prompts_dataloader = _Loader()
+    trainer.eval_dataloader = None
+    trainer.samples_generator = _Generator(result)
+    trainer.generate_kwargs = {}
+    trainer.init_checkpoint_states = lambda: {
+        "episode": 0,
+        "global_step": 0,
+        "total_consumed_prompts": 0,
+        "data_loader_state_dict": {},
+    }
+    trainer.restore_best_checkpoint_state = lambda _: None
+    trainer.save_logs_and_checkpoints = lambda *_: None
+    trainer.wandb_logger = trainer.tensorboard_logger = None
+    return trainer
+
+
+def test_sync_fit_processes_nonempty_exhausted_rollout(ppo_module):
+    tail = [f"rollout-{i}" for i in range(129)]
+    trainer = _trainer(ppo_module, (tail, None, 129, True))
+    calls = []
+    trainer.train_step = lambda samples, step: (calls.append(samples) or ({}, step + 1))
+
+    trainer.fit()
+
+    assert calls == [tail]
+    assert trainer.samples_generator.calls == 1
+
+
+def test_sync_fit_does_not_train_empty_exhausted_result(ppo_module):
+    trainer = _trainer(ppo_module, ([], None, 0, True))
+    trainer.train_step = lambda *_: pytest.fail("empty terminal result must not be trained")
+
+    trainer.fit()
+
+    assert trainer.samples_generator.calls == 1


### PR DESCRIPTION
## Summary

- process a non-empty synchronous rollout result even when it also reports dataloader exhaustion
- terminate immediately for an empty exhausted result
- stop after processing the terminal batch so the iterator is not restarted in the same episode

## Root cause and impact

`SamplesGenerator.generate_samples()` validly returns a non-empty final batch with `is_exhausted=True`; exhaustion describes the dataloader and internal buffer state after that returned batch was collected. The synchronous `PPOTrainer.fit()` loop checked the flag before `train_step()`, silently discarding the tail. A dataset smaller than the rollout batch could therefore finish with zero PPO updates and no error.

The new ordering matches `_collect_prompt_batch()`'s documented contract and the existing asynchronous controller behavior.

Closes #1297.

## Validation

- CPU regression and repository test suite: **19 passed**
- project pre-commit hooks on both changed files: **passed**

The tests execute the real `PPOTrainer.fit()` control flow with lightweight Ray/vLLM/DeepSpeed stubs. They cover both a 129-sample non-empty terminal result (trained exactly once) and an empty terminal result (never trained).
