### PR TITLE
use device-agnostic PyTorch accelerator APIs

### DIFF
--- a/openrlhf/trainer/ppo_utils/replay_buffer.py
+++ b/openrlhf/trainer/ppo_utils/replay_buffer.py
@@ -37,7 +37,9 @@ class NaiveReplayBuffer(ABC):
         self.limit = limit
         self.cpu_offload = cpu_offload
         self.packing_samples = packing_samples
-        self.target_device = torch.device(f"cuda:{torch.cuda.current_device()}")
+        self.target_device = (
+            f"{torch.accelerator.current_accelerator().type}:{torch.accelerator.current_device_index()}"
+        )
         self.items: List[Experience] = []
         self.dynamic_batch = dynamic_batch
         self.dynamic_indices: List[List[int]] = []
@@ -101,7 +103,7 @@ class NaiveReplayBuffer(ABC):
         # karmarkar_karp with num_mbs=0).
         expected_num_steps = args.rollout.batch_size * args.rollout.n_samples_per_prompt // args.train.batch_size
         num_steps = min(expected_num_steps, len(sample_lengths) // local_train_batch_size)
-        num_steps = torch.tensor(num_steps, dtype=torch.int, device=torch.cuda.current_device())
+        num_steps = torch.tensor(num_steps, dtype=torch.int, device=torch.accelerator.current_device_index())
         dist.all_reduce(num_steps, op=dist.ReduceOp.MIN, group=dp_group)
         num_steps = num_steps.item()
         if num_steps == 0:
@@ -126,7 +128,9 @@ class NaiveReplayBuffer(ABC):
                 )
             )
 
-        num_microbatches = torch.tensor(num_microbatches, dtype=torch.int, device=torch.cuda.current_device())
+        num_microbatches = torch.tensor(
+            num_microbatches, dtype=torch.int, device=torch.accelerator.current_device_index()
+        )
         num_microbatches = strategy.all_reduce(num_microbatches, op="max")
         num_microbatches = num_microbatches.tolist()
 
@@ -156,13 +160,13 @@ class NaiveReplayBuffer(ABC):
                 int(self.items[idx].action_mask.sum().item() > 0) for partition in partitions for idx in partition
             )
             global_valid_sample_num = torch.tensor(
-                valid_sample_num, dtype=torch.float, device=torch.cuda.current_device()
+                valid_sample_num, dtype=torch.float, device=torch.accelerator.current_device_index()
             )
             dist.all_reduce(global_valid_sample_num, op=dist.ReduceOp.SUM, group=dp_group)
             global_num_tokens = torch.tensor(
                 sum(int(self.items[idx].action_mask.sum().item()) for partition in partitions for idx in partition),
                 dtype=torch.float,
-                device=torch.cuda.current_device(),
+                device=torch.accelerator.current_device_index(),
             )
             dist.all_reduce(global_num_tokens, op=dist.ReduceOp.SUM, group=dp_group)
             sample_loss_scale = [len(partition) / sample_num for partition in partitions]

--- a/openrlhf/trainer/ray/launcher.py
+++ b/openrlhf/trainer/ray/launcher.py
@@ -61,8 +61,8 @@ class BaseModelActor(BaseDistributedActor):
         raise NotImplementedError()
 
     def empty_cache(self) -> None:
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        torch.accelerator.empty_cache()
+        torch.accelerator.synchronize()
 
     def execute_batch(self, method_name: str, all_data, start_idx, end_idx):
         """Process input data by calling specified function for each item in the lists.
@@ -133,7 +133,7 @@ class ReferenceModelActor(BaseModelActor):
         packed_seq_lens: Optional[list[int]] = None,
         mm_train_inputs_list=None,
     ) -> torch.Tensor:
-        device = torch.cuda.current_device()
+        device = torch.accelerator.current_device_index()
 
         # VLM: merge pre-processed multimodal inputs from all samples in batch
         mm_inputs = {}
@@ -187,7 +187,7 @@ class RewardModelActor(BaseModelActor):
         packed_seq_lens=None,
         pad_sequence=False,
     ) -> torch.Tensor:
-        device = torch.cuda.current_device()
+        device = torch.accelerator.current_device_index()
         with torch.no_grad():
             reward = self.model(
                 sequences.to(device),

--- a/openrlhf/trainer/ray/ppo_critic.py
+++ b/openrlhf/trainer/ray/ppo_critic.py
@@ -80,7 +80,7 @@ class CriticPPOTrainer(ABC):
             pin_memory=self.dataloader_pin_memory,
             collate_fn=self.replay_buffer.collate_fn,
         )
-        device = torch.cuda.current_device()
+        device = torch.accelerator.current_device_index()
 
         status_list = []
         status_mean = {}
@@ -266,7 +266,7 @@ class CriticModelActor(BaseModelActor):
         packed_seq_lens=None,
     ) -> torch.Tensor:
         """Generates critic values."""
-        device = torch.cuda.current_device()
+        device = torch.accelerator.current_device_index()
         self.critic.eval()
         with torch.no_grad():
             value = self.critic(
@@ -285,12 +285,12 @@ class CriticModelActor(BaseModelActor):
 
     def fit(self):
         """Train critic model with the replay buffer."""
-        torch.cuda.empty_cache()
+        torch.accelerator.empty_cache()
         self.critic.train()
         status = self.trainer.ppo_train()
         self.trainer.replay_buffer.clear()
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        torch.accelerator.empty_cache()
+        torch.accelerator.synchronize()
         return status
 
     def save_model(self):

--- a/openrlhf/trainer/ray/utils.py
+++ b/openrlhf/trainer/ray/utils.py
@@ -43,6 +43,7 @@ def ray_noset_visible_devices(env_vars=os.environ):
 def get_physical_gpu_id():
     import torch
 
-    device = torch.cuda.current_device()
-    props = torch.cuda.get_device_properties(device)
+    backend = getattr(torch, torch.accelerator.current_accelerator().type)
+    device = backend.current_device()
+    props = backend.get_device_properties(device)
     return str(props.uuid)

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -94,7 +94,7 @@ class DeepspeedStrategy(ABC):
 
         local_rank = int(os.environ.get("LOCAL_RANK", "-1"))
         if local_rank != -1:
-            torch.cuda.set_device(local_rank)
+            torch.accelerator.set_device_index(local_rank)
 
         # Initializes the distributed backend which will take care of synchronizing nodes/GPUs
         deepspeed.init_distributed(timeout=timeout)
@@ -103,7 +103,9 @@ class DeepspeedStrategy(ABC):
         self.world_size = dist.get_world_size()
         dp_size = self.world_size // self.ring_attn_size // self.ds_tensor_parallel_size
         self.ds_device_mesh = init_device_mesh(
-            "cuda", (dp_size, self.ring_attn_size, self.ds_tensor_parallel_size), mesh_dim_names=("dp", "sp", "tp")
+            torch.accelerator.current_accelerator().type,
+            (dp_size, self.ring_attn_size, self.ds_tensor_parallel_size),
+            mesh_dim_names=("dp", "sp", "tp"),
         )
         self.setup_ring_attn(self.ds_device_mesh)
 
@@ -395,7 +397,7 @@ class DeepspeedStrategy(ABC):
             else:
                 model = tp_model
             gc.collect()
-            torch.cuda.empty_cache()
+            torch.accelerator.empty_cache()
 
         # Infer optim kind from the DS type so actor/critic can disagree.
         optim_kind = "muon" if optim_dict.get("type") == "Muon" else "adam"
@@ -609,7 +611,7 @@ class DeepspeedStrategy(ABC):
             is_cpu_tensor = data.device.type == "cpu"
 
             if is_cpu_tensor:
-                data = data.to(torch.cuda.current_device())
+                data = data.to(torch.accelerator.current_device_index())
             if op == "mean":
                 data /= self.world_size
             dist.all_reduce(data, op=dist.ReduceOp.MAX if op == "max" else dist.ReduceOp.SUM)
@@ -628,8 +630,8 @@ class DeepspeedStrategy(ABC):
                 data = torch.Tensor([data])
             is_cpu_tensor = data.device.type == "cpu"
 
-            ret = [torch.zeros_like(data).to(torch.cuda.current_device()) for _ in range(self.world_size)]
-            dist.all_gather(ret, data.to(torch.cuda.current_device()))
+            ret = [torch.zeros_like(data).to(torch.accelerator.current_device_index()) for _ in range(self.world_size)]
+            dist.all_gather(ret, data.to(torch.accelerator.current_device_index()))
             return torch.cat(ret).cpu() if is_cpu_tensor else torch.cat(ret)
 
     def print(self, *msg):

--- a/openrlhf/utils/deepspeed/deepspeed_utils.py
+++ b/openrlhf/utils/deepspeed/deepspeed_utils.py
@@ -184,9 +184,9 @@ def offload_deepspeed_states(model, pin_memory=True, non_blocking=True):
         non_blocking=non_blocking,
     )
     model.empty_partition_cache()
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
     torch.distributed.barrier()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()
 
 
 def reload_deepspeed_states(model, non_blocking=True):
@@ -206,6 +206,6 @@ def reload_deepspeed_states(model, non_blocking=True):
     import torch
 
     model.reload_states(non_blocking=non_blocking)
-    torch.cuda.empty_cache()
+    torch.accelerator.empty_cache()
     torch.distributed.barrier()
-    torch.cuda.synchronize()
+    torch.accelerator.synchronize()

--- a/openrlhf/utils/loss_utils.py
+++ b/openrlhf/utils/loss_utils.py
@@ -64,7 +64,7 @@ def _optimizer_step_loss_norm(masks, dp_group, dp_size, gas):
     averaging DeepSpeed/DDP does across DP ranks. (slime applies the same idea via Megatron's
     per-token loss normalizer; DeepSpeed has no equivalent, so we sum the tokens here.)
     """
-    device = torch.cuda.current_device() if torch.cuda.is_available() else "cpu"
+    device = torch.accelerator.current_device_index() if torch.accelerator.is_available() else "cpu"
     num_tokens = torch.zeros((), dtype=torch.float32, device=device)
     num_samples = torch.zeros((), dtype=torch.float32, device=device)
     for mask in masks:


### PR DESCRIPTION
Relates to #1303
## Summary 
Replace CUDA-specific device-management calls with PyTorch's device-agnostic `torch.accelerator` APIs.

This removes CUDA assumptions from common OpenRLHF code paths and allows the affected code paths to use supported accelerators, including NVIDIA CUDA and Intel XPU, without vendor-specific branches.

This PR is intentionally limited to direct device-API substitutions. Feature-specific changes related to ring attention, and vLLM weight synchronization are excluded and will be submitted separately.

## Motivation

Several common OpenRLHF code paths use CUDA-specific APIs for operations that are not inherently CUDA-specific, including:

- Selecting the current device
- Retrieving the current device index
- Clearing unused accelerator memory
- Synchronizing accelerator operations
- Reading device properties
- Creating device meshes

These calls prevent the affected paths from running with a non-CUDA PyTorch build, even when the active accelerator provides equivalent functionality.

PyTorch's `torch.accelerator` namespace provides a common interface for device management across supported accelerator backends. This PR uses that interface where the underlying operation is equivalent across devices.

## Changes

### Device-management operations

Apply the following direct substitutions:

```text
torch.cuda.empty_cache()
    -> torch.accelerator.empty_cache()

torch.cuda.synchronize()
    -> torch.accelerator.synchronize()

torch.cuda.set_device(local_rank)
    -> torch.accelerator.set_device_index(local_rank)
```

### Device-index operations

Replace:

```python
torch.cuda.current_device()
```

with:

```python
torch.accelerator.current_device_index()
```

Both APIs return the integer index of the currently selected device.

This intentionally does not use:

```python
torch.accelerator.current_accelerator()
```

`current_accelerator()` identifies the accelerator device type, whereas `current_device_index()` preserves the selected device index required for correct multi-device placement.

### Device-type operations

Use the active accelerator type when an API requires a device-type string:

```python
accelerator_type = torch.accelerator.current_accelerator().type

device_mesh = init_device_mesh(
    accelerator_type,
    mesh_shape,
)
```

### Device-property lookup

`torch.cuda.get_device_properties()` does not have a direct generic equivalent under `torch.accelerator`.

Resolve the active accelerator module and call its backend-specific property
API:

```python
accelerator = torch.accelerator.current_accelerator()
accelerator_module = getattr(torch, accelerator.type)

properties = accelerator_module.get_device_properties(
    torch.accelerator.current_device_index()
)
```

This preserves backend-specific device-property access without hard-coding `torch.cuda`.

## Files Changed

This PR modifies seven files:

```text
openrlhf/trainer/ray/launcher.py
openrlhf/trainer/ray/ppo_critic.py
openrlhf/trainer/ray/utils.py
openrlhf/trainer/ppo_utils/replay_buffer.py
openrlhf/utils/deepspeed/deepspeed.py
openrlhf/utils/deepspeed/deepspeed_utils.py
openrlhf/utils/loss_utils.py
```

Each file contains only device-API portability changes.

Device-API changes inside feature-specific files, including ring attention, vLLM device placement, and vLLM weight synchronization, are intentionally excluded and will be submitted with their respective changes.

## Validation

### NVIDIA CUDA

Validated from a clean checkout of this PR on a multi-GPU NVIDIA system.

Validation environment:

```text
PyTorch: 2.11.0+cu130
```

The repository test suite passes:

```bash
python -m pytest tests
```

The following end-to-end workflows completed successfully:

- GRPO using `group_norm`
- PPO with a critic using `gae`

The tests exercised:

- Device selection and device-index handling
- Actor and critic forward passes
- Rollout generation
- Backward propagation
- Optimizer updates
- Cache cleanup
- Accelerator synchronization
- Device-mesh creation
- Device-property lookup

The migrated APIs preserved the behavior of the original CUDA-specific calls in the tested workflows. No regressions were observed.

### Intel XPU

Validated the migrated device-management APIs on Intel XPU.

Validation environment:

```text
PyTorch: 2.12.0+xpu
```

The following behavior was confirmed:

- `current_device_index()` returns the active backend device index
- `set_device_index(i)` binds execution to the selected XPU device
- `current_accelerator().type` resolves the device type used for device-mesh creation
- `get_device_properties()` resolves through the active accelerator module
- Device indices are preserved across the tested XPU devices

Full XPU end-to-end training requires additional feature-specific compatibility changes outside the scope of this PR, including the follow-up attention-import work.

End-to-end XPU results are therefore reported with the combined enablement changes rather than attributed to this device-API-only PR.

### Multi-device behavior

The device-index substitutions preserve the integer device index returned by the original CUDA APIs.

In particular:

```text
torch.cuda.current_device()
    -> torch.accelerator.current_device_index()
```

This preserves the distinction between device indices such as device 0 and device 1 rather than reducing the value to only the accelerator type.

Device-index preservation was validated on the tested multi-device CUDA and XPU configurations, with each rank bound to its assigned physical device index.

## Compatibility

### NVIDIA CUDA

On a CUDA-enabled PyTorch build, `torch.accelerator` delegates the migrated operations to the active CUDA backend.

The tested NVIDIA workflows completed successfully without requiring CUDA-specific branches in the migrated code.

### Intel XPU

On an XPU-enabled PyTorch build, the same code resolves to the Intel XPU backend without requiring CUDA-specific calls or explicit vendor branching.

### CPU-only execution

This PR targets accelerator-backed execution paths.

The modified call sites are expected to run after an accelerator has been selected and initialized. This PR does not add a CPU fallback for accelerator-only training workflows.

## Scope

This PR changes device-API selection only.

It does not change:

- PPO, GRPO, or reward-model algorithms
- Loss calculations
- Model architecture
- Dataset processing
- Ray scheduling
- DeepSpeed configuration
- vLLM engine behavior
- Distributed communication backends

No new dependency is introduced.

## Test Checklist

### NVIDIA CUDA

- [x] Repository test suite passes on PyTorch `2.11.0+cu130`
- [x] GRPO using `group_norm` completes end to end
- [x] PPO with a critic using `gae` completes end to end
- [x] Real forward, backward, and optimizer-update execution validated
- [x] Multi-GPU device-index preservation confirmed
- [x] No regressions observed in the tested CUDA workflows

### Intel XPU

- [x] Migrated device APIs validated on PyTorch `2.12.0+xpu`
- [x] Device-type resolution confirmed
- [x] Device-property lookup confirmed
- [x] Device-index preservation confirmed across the tested XPU devices
- [x] Multi-device rank-to-device binding confirmed

### Code Quality

- [x] `pre-commit run --all-files` passes