### PR TITLE
docs: add AGENTS.md and simplicity-first skill for AI assistants

### DIFF
--- a/.claude/skills/simplicity-first/SKILL.md
+++ b/.claude/skills/simplicity-first/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: simplicity-first
+description: Simplicity gate for ALL code written, fixed, or reviewed in this repo. Invoke BEFORE writing any code change and when reviewing any diff. Treats over-complex or oversized code as a correctness bug, not a style issue.
+---
+
+# Simplicity is the first principle
+
+**Human readability comes first; coding-agent traceability is the minimum
+gate.** A human should understand the code in one pass. An agent must at least
+be able to trace a feature from CLI flag to executed branch, tensor/record,
+metric, and test without reconstructing hidden control flow. Every rule below
+is an instance of that ordering. These are hard correctness rules, not style
+preferences. A violation is a bug and must be fixed before the change ships.
+
+1. **Code a human can't follow at a glance is a bug.** If a reviewer can't read
+   a function top-to-bottom in one pass, restructure or delete it. Nesting,
+   indirection, and clever constructs count against correctness — cleverness
+   that costs comprehension is a defect, whatever it saves.
+
+2. **Too much / redundant code is a bug.** Solve the problem in the fewest lines
+   that stay readable. Prefer deleting code over adding it. A fix that adds more
+   than ~20 lines for a problem statable in one sentence is suspect — find the
+   smaller fix first.
+
+3. **Simplicity is the core engineering metric.** When two designs both work,
+   ship the one with less code, fewer concepts, fewer files. Never add config,
+   record types, or return-shape changes "for the future".
+
+4. **No over-encapsulation.** No new class / dataclass / helper / module for a
+   single call site. A helper needs 3+ real call sites AND nontrivial logic —
+   otherwise inline it. Never wrap trivial code. Never change a function
+   signature or return shape to thread data that only one caller needs.
+
+5. **Simplicity is not deletion of capability.** Features, performance knobs,
+   and observability are intentional — do not remove them in the name of
+   simplicity. Knobs default ON stay ON. Simplify the implementation, keep
+   the behavior surface.
+
+## Checklist before finishing any change
+
+- Would a human reading this cold understand it in one pass? That is the gate.
+- Could this diff be half the size? If unsure, make it smaller.
+- Any new class or file? Justify each with 3+ call sites, or delete it.
+- Any signature / return-shape change? Verify every caller genuinely needs it.
+- Comments: concise "why" only, 2-4 lines max, written for an external reader —
+  no job ids, commit hashes, single-run metrics, or internal paths; keep
+  upstream issue/PR links.
+- One problem = one minimal diff. Do not batch unrelated "improvements".
+- A "bug" that cannot trigger under the real recipes is not worth fixing.

--- a/.gitignore
+++ b/.gitignore
@@ -152,4 +152,6 @@ core
 exp
 wandb
 .claude/*
+!.claude/skills
+!.claude/skills/**
 *tmp*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# OpenRLHF — working rules for AI assistants
+
+## Code standards (hard rules, not preferences)
+
+The priority order is explicit: **human readability comes first; coding-agent
+traceability is the minimum gate.** A human should understand code in one pass,
+and an agent must be able to trace a feature from CLI flag to executed branch,
+tensor/record, metric, and test without reconstructing hidden control flow.
+
+1. Over-complex or hard-to-follow code is a **bug**, not a style issue.
+2. Reduce complexity and line count — prefer deleting code over adding it.
+3. No over-encapsulation: a helper needs 3+ real call sites AND nontrivial
+   logic; never wrap trivial code or add classes/files for one call site.
+4. Do NOT remove features, performance knobs, or observability in the name
+   of simplicity — knobs default ON stay ON.
+5. A "bug" that cannot trigger under the shipped recipes is not worth fixing.
+
+Details: `.claude/skills/simplicity-first` (invoke before any code change).
+
+## Comments
+
+Concise "why" only, 2-4 lines, written for an external reader: no job ids,
+commit hashes, single-run metrics, or internal cluster paths; keep upstream
+issue/PR links.
+
+## Workflow
+
+- Reviews report findings only; fixes ship as one minimal diff per issue
+  after approval.
+- Verify with `python -m compileall -q openrlhf examples tests` and
+  `python -m pytest -q`; shell scripts with `bash -n`.


### PR DESCRIPTION
Working rules for coding agents: human readability first, agent traceability as the minimum gate, and simplicity treated as a correctness gate rather than a style preference. The simplicity-first skill is the detailed checklist AGENTS.md points to; unignore .claude/skills so it ships with the repo.