### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ Your sponsorship can help us maintain and improve OpenRLHF. If you find this pro
 
 ## Starchart
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.com/#OpenRLHF/OpenRLHF&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.dera.page/#OpenRLHF/OpenRLHF&type=date)
 
 ## Contributors
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -393,7 +393,7 @@ python -m openrlhf.cli.lora_combiner \
 
 ## スターヒストリー
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.com/#OpenRLHF/OpenRLHF&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.dera.page/#OpenRLHF/OpenRLHF&type=date)
 
 ## コントリビューター
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -789,7 +789,7 @@ python -m openrlhf.cli.lora_combiner \
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.com/#OpenRLHF/OpenRLHF&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=OpenRLHF/OpenRLHF&type=Date)](https://star-history.dera.page/#OpenRLHF/OpenRLHF&type=date)
 
 ## 贡献者
 

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]


### PR DESCRIPTION
The star history chart is currently broken because the upstream provider no longer works reliably under GitHub stargazer API restrictions. This switches the charts in the English, Chinese, and Japanese READMEs to a maintained alternative that serves the same chart without requiring an API token, so the chart renders correctly again.