### PR TITLE
Fix reverse-KL gradient on the KL-as-loss path (form + off-policy importance weight)

### DIFF
--- a/openrlhf/cli/train_ppo_ray.py
+++ b/openrlhf/cli/train_ppo_ray.py
@@ -427,6 +427,16 @@ if __name__ == "__main__":
             "In GRPO, k3 is utilized as the loss function, while k2, when used as the loss, is nearly equivalent to k1."
         ),
     )
+    parser.add_argument(
+        "--algo.kl.unbiased_gradient",
+        action="store_true",
+        default=False,
+        help=(
+            "When using KL as a loss, keep the chosen estimator's value but backprop the true reverse-KL "
+            "gradient with an importance-sampling correction (w = pi_theta / pi_theta_old) for the off-policy "
+            "inner loop. With this on, k1/k2/k3 share the same unbiased gradient. Default off = legacy behavior."
+        ),
+    )
     parser.add_argument("--actor.aux_loss_coef", type=float, default=0, help="MoE balancing loss")
     parser.add_argument(
         "--actor.entropy_coef",
@@ -681,7 +691,9 @@ if __name__ == "__main__":
         )
 
     if args.algo.kl.use_loss:
-        if args.algo.kl.estimator not in ["k2", "k3"]:
+        # With unbiased_gradient the estimator choice no longer affects the gradient (only the
+        # logged value / variance), so the k2/k3 recommendation does not apply.
+        if not args.algo.kl.unbiased_gradient and args.algo.kl.estimator not in ["k2", "k3"]:
             print(f"Recommend setting {args.algo.kl.estimator} to 'k2' or 'k3' when using KL as a loss")
     else:
         if args.algo.kl.estimator not in ["k1"]:

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/models/utils.py
+++ b/openrlhf/models/utils.py
@@ -61,38 +61,68 @@ def set_z3_leaf_modules(model: nn.Module, detect_hybrid: bool = True) -> None:
             print(f"Setting zero3 leaf: {cls.__name__}")
 
 
+# Upper bound for the importance weight w = π_θ/π_θ_old used by the unbiased-gradient KL
+# correction. IS weights are unbounded and explode off-policy, so we clamp for stability.
+KL_IS_WEIGHT_CLIP = 10.0
+
+
 def compute_approx_kl(
     log_probs: torch.Tensor,
     log_probs_base: torch.Tensor,
+    log_probs_old: Optional[torch.Tensor] = None,
     kl_estimator: str = "k1",
+    unbiased_gradient: bool = False,
 ) -> torch.Tensor:
     """
     Compute the approximate KL divergence between two distributions.
     Schulman blog: http://joschu.net/blog/kl-approx.html
 
     Args:
-        log_probs: Log probabilities of the new distribution.
-        log_probs_base: Log probabilities of the base distribution.
+        log_probs: Log probabilities of the new (current) policy π_θ.
+        log_probs_base: Log probabilities of the reference policy π_ref.
+        log_probs_old: Log probabilities of the rollout policy π_θ_old. Only used when
+            unbiased_gradient=True, to importance-weight the off-policy KL-loss gradient.
+        kl_estimator: k1 / k2 / k3 (Schulman). Selects the forward value.
+        unbiased_gradient: If True, keep the chosen estimator's forward value but backprop the
+            true reverse-KL gradient E_{y~π_θ_old}[w · k1 · ∇log π_θ] via a straight-through trick,
+            with w = π_θ/π_θ_old (clamped, detached). k1/k2/k3 then share the same (correct)
+            gradient and differ only in value/variance. If False, behaves exactly as the legacy
+            estimator (gradient flows through the estimator formula unchanged).
     """
 
     log_ratio = log_probs.float() - log_probs_base.float()
 
     if kl_estimator == "k1":
-        pass  # log_ratio is already p - q
+        value = log_ratio  # log_ratio is already p - q
     elif kl_estimator == "k2":
         # Non-negative KL approximation: (p - q)^2 / 2
         # http://joschu.net/blog/kl-approx.html
         # Approximately equivalent to one-step KL penalty with k1
         # used in https://arxiv.org/pdf/2310.10505.
-        log_ratio = log_ratio**2 / 2.0
+        value = log_ratio**2 / 2.0
     elif kl_estimator == "k3":
         # Non-negative KL approximation: exp(q - p) - 1 - (q - p)
         # http://joschu.net/blog/kl-approx.html
-        log_ratio = (-log_ratio).exp() - 1 + log_ratio
+        value = (-log_ratio).exp() - 1 + log_ratio
     else:
         raise ValueError(f"Unknown kl_estimator: {kl_estimator}")
 
-    return log_ratio.clamp(min=-10, max=10)
+    value = value.clamp(min=-10, max=10)
+
+    if not unbiased_gradient:
+        return value
+
+    # Unbiased, importance-sampling-corrected reverse-KL gradient. k2's pathwise gradient
+    # reproduces the score-function form ℓ·∇log π_θ = k1·∇log π_θ; multiplying by the detached
+    # IS weight w gives the off-policy estimator E_{y~π_θ_old}[w · k1 · ∇log π_θ] = ∇_θ D_KL(π_θ‖π_ref).
+    if log_probs_old is None:
+        w = 1.0
+    else:
+        w = (log_probs.float() - log_probs_old.float()).exp().clamp(max=KL_IS_WEIGHT_CLIP).detach()
+    grad_surrogate = w * (log_ratio**2 / 2.0)
+
+    # Straight-through: forward value = chosen estimator, backward gradient = ∇grad_surrogate.
+    return value.detach() + grad_surrogate - grad_surrogate.detach()
 
 
 def compute_reward(

--- a/openrlhf/trainer/ray/ppo_actor.py
+++ b/openrlhf/trainer/ray/ppo_actor.py
@@ -321,7 +321,9 @@ class ActorPPOTrainer(ABC):
                 kl = compute_approx_kl(
                     action_log_probs,
                     base_action_log_probs,
+                    log_probs_old=old_action_log_probs,
                     kl_estimator=self.args.algo.kl.estimator,
+                    unbiased_gradient=self.args.algo.kl.unbiased_gradient,
                 )
                 logprobs_diff = action_log_probs.float() - base_action_log_probs.float()
             else:

--- a/tests/test_kl_estimator_gradient.py
+++ b/tests/test_kl_estimator_gradient.py
@@ -1,0 +1,110 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import torch
+
+_TEST_PACKAGE = "_openrlhf_kl_test"
+
+
+def _load_utils_module():
+    root = Path(__file__).resolve().parents[1]
+    models_dir = root / "openrlhf" / "models"
+
+    pkg = types.ModuleType(_TEST_PACKAGE)
+    pkg.__path__ = [str(models_dir)]
+    sys.modules[_TEST_PACKAGE] = pkg
+
+    spec = importlib.util.spec_from_file_location(f"{_TEST_PACKAGE}.utils", models_dir / "utils.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"{_TEST_PACKAGE}.utils"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_utils = _load_utils_module()
+compute_approx_kl = _utils.compute_approx_kl
+KL_IS_WEIGHT_CLIP = _utils.KL_IS_WEIGHT_CLIP
+
+ESTIMATORS = ["k1", "k2", "k3"]
+
+
+def _grad_wrt_log_probs(log_probs, log_probs_base, **kwargs):
+    lp = log_probs.clone().detach().requires_grad_(True)
+    kl = compute_approx_kl(lp, log_probs_base, **kwargs)
+    kl.sum().backward()
+    return lp.grad
+
+
+def test_flag_off_matches_legacy():
+    # With unbiased_gradient=False the output must equal the legacy clamped estimator, byte-for-byte.
+    torch.manual_seed(42)
+    log_probs = torch.randn(4, 8)
+    log_probs_base = torch.randn(4, 8)
+    for est in ESTIMATORS:
+        log_ratio = log_probs.float() - log_probs_base.float()
+        if est == "k1":
+            legacy = log_ratio
+        elif est == "k2":
+            legacy = log_ratio**2 / 2.0
+        else:
+            legacy = (-log_ratio).exp() - 1 + log_ratio
+        legacy = legacy.clamp(min=-10, max=10)
+        got = compute_approx_kl(log_probs, log_probs_base, kl_estimator=est, unbiased_gradient=False)
+        assert torch.allclose(got, legacy), est
+
+
+def test_forward_value_preserved_under_correction():
+    # Straight-through must keep the chosen estimator's forward VALUE (only the gradient changes).
+    torch.manual_seed(42)
+    log_probs = torch.randn(4, 8)
+    log_probs_base = torch.randn(4, 8)
+    for est in ESTIMATORS:
+        legacy = compute_approx_kl(log_probs, log_probs_base, kl_estimator=est, unbiased_gradient=False)
+        corrected = compute_approx_kl(log_probs, log_probs_base, kl_estimator=est, unbiased_gradient=True)
+        assert torch.allclose(corrected, legacy), est
+
+
+def test_gradients_equal_across_estimators_on_policy():
+    # On-policy (log_probs_old=None -> w=1): k1/k2/k3 must share the SAME corrected gradient,
+    # equal to the analytic reverse-KL gradient  k1 * d/dtheta log pi_theta = log_ratio * 1.
+    torch.manual_seed(42)
+    log_probs = torch.randn(4, 8)
+    log_probs_base = torch.randn(4, 8)
+    analytic = log_probs.float() - log_probs_base.float()  # k1 coefficient; d(log_probs)/d(log_probs)=1
+
+    grads = [
+        _grad_wrt_log_probs(log_probs, log_probs_base, kl_estimator=e, unbiased_gradient=True) for e in ESTIMATORS
+    ]
+    for g, est in zip(grads, ESTIMATORS):
+        assert torch.allclose(g, analytic, atol=1e-5), est
+    assert torch.allclose(grads[0], grads[1], atol=1e-6)
+    assert torch.allclose(grads[1], grads[2], atol=1e-6)
+
+
+def test_importance_weight_scales_gradient_off_policy():
+    # Off-policy: gradient must scale by the clamped IS weight w = clamp(exp(log_probs - log_probs_old), max).
+    torch.manual_seed(42)
+    log_probs = torch.randn(4, 8)
+    log_probs_base = torch.randn(4, 8)
+    log_probs_old = log_probs - 0.3 * torch.randn(4, 8)  # theta != theta_old
+
+    w = (log_probs.float() - log_probs_old.float()).exp().clamp(max=KL_IS_WEIGHT_CLIP)
+    analytic = w * (log_probs.float() - log_probs_base.float())
+
+    for est in ESTIMATORS:
+        g = _grad_wrt_log_probs(
+            log_probs, log_probs_base, log_probs_old=log_probs_old, kl_estimator=est, unbiased_gradient=True
+        )
+        assert torch.allclose(g, analytic, atol=1e-5), est
+
+
+def test_k1_off_gradient_is_broken_baseline():
+    # Sanity that the legacy path really is the biased one: k1 without correction has a constant
+    # gradient (1 per element) that does NOT depend on the reference -> not a reverse-KL gradient.
+    torch.manual_seed(42)
+    log_probs = torch.randn(4, 8)
+    log_probs_base = torch.randn(4, 8)
+    g = _grad_wrt_log_probs(log_probs, log_probs_base, kl_estimator="k1", unbiased_gradient=False)
+    assert torch.allclose(g, torch.ones_like(g))


### PR DESCRIPTION
## Problem

Research on the role of the KL term in post-training particularly diversity collapse and reward hacking often turns on which divergence is actually being used as regularization: the reverse KL D_KL(pi_theta || pi_ref) or the forward KL D_KL(pi_ref || pi_theta). The current implementation differentiates k1, k2 or k3 directly, treating each as a gradient estimator for the reverse KL the config requests. None of them is unbiased in the setting the inner loop actually runs in. k2 is unbiased on-policy, but becomes biased once samples are drawn from pi_theta_old, and needs an importance weight to recover. k1 and k3 are biased in both regimes: k1's gradient vanishes in expectation, and k3's gradient descends the forward KL rather than the reverse one. (see the maths below)

## Fix

Add an opt-in flag `--algo.kl.unbiased_gradient` (default `False`, so existing runs are identical). When enabled, `compute_approx_kl` keeps the chosen estimator's forward value (for logging / reward continuity) but backpropagates
through the correct gradient estimator `w * k1 * grad log pi_theta`, where `w = pi_theta / pi_theta_old` is the importance weight (clamped and detached). See the proof below that this is unbiased.

## Relation to #1101
  This builds on #1101 (which fixes the on-policy gradient bias) by adding the missing off-policy importance weight.
  
## Tests

  `tests/test_kl_estimator_gradient.py` asserts:
  - flag off is identical to the legacy estimator (regression guard);
  - with the flag on, k1/k2/k3 produce the **same** gradient, equal to the analytic
    reverse-KL gradient (on-policy);
  - the gradient scales by the clamped importance weight off-policy;
  - the straight-through preserves each estimator's forward value
  
## Maths

<img width="703" height="889" alt="maths" src="https://github.com/user-attachments/assets/e80c940a-9373-4213-9127-0d1bd03a2e0e" />
