### PR TITLE
fix(ppo): preserve accepted rollouts at dynamic-filter exhaustion

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/trainer/ppo_utils/samples_generator.py
+++ b/openrlhf/trainer/ppo_utils/samples_generator.py
@@ -184,10 +184,6 @@ class SamplesGenerator:
                     # Dispatch replacement for filtered prompt.
                     new_prompts, new_labels, new_images, exhausted = _collect_prompt_batch(dataloader_iter, 1)
                     prompts_consumed += len(new_prompts)
-                    if exhausted and not new_prompts:
-                        for remaining_ref in pending_refs:
-                            ray.cancel(remaining_ref)
-                        return [], prompts_consumed, True
                     if new_prompts:
                         new_refs = self._dispatch_prompts_to_vllm(
                             new_prompts, new_labels, images=new_images, **generate_kwargs

--- a/tests/test_samples_generator.py
+++ b/tests/test_samples_generator.py
@@ -1,0 +1,87 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+class _Pbar:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def set_postfix(self, *_args, **_kwargs):
+        pass
+
+    def update(self, *_args, **_kwargs):
+        pass
+
+
+@pytest.fixture
+def samples_generator_module(monkeypatch):
+    fake_ray = types.ModuleType("ray")
+    fake_ray.cancelled = []
+    fake_ray.wait = lambda refs, **_: (refs[:1], refs[1:])
+    fake_ray.get = lambda ref: ref
+    fake_ray.cancel = fake_ray.cancelled.append
+    monkeypatch.setitem(sys.modules, "ray", fake_ray)
+
+    fake_vllm = types.ModuleType("vllm")
+    fake_vllm.SamplingParams = object
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=_Pbar))
+
+    experience_module = types.ModuleType("openrlhf.trainer.ppo_utils.experience")
+    experience_module.Experience = object
+    monkeypatch.setitem(sys.modules, experience_module.__name__, experience_module)
+
+    engine_module = types.ModuleType("openrlhf.trainer.ray.vllm_engine")
+    engine_module.batch_vllm_engine_call = lambda *_args, **_kwargs: None
+    monkeypatch.setitem(sys.modules, engine_module.__name__, engine_module)
+
+    logging_module = types.ModuleType("openrlhf.utils.logging_utils")
+    logging_module.init_logger = lambda *_args, **_kwargs: SimpleNamespace(info=lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, logging_module.__name__, logging_module)
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_samples_generator_test",
+        root / "openrlhf" / "trainer" / "ppo_utils" / "samples_generator.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module, fake_ray
+
+
+def test_dynamic_filtering_preserves_terminal_accepted_rollouts(samples_generator_module):
+    module, fake_ray = samples_generator_module
+    generator = module.SamplesGenerator.__new__(module.SamplesGenerator)
+    generator.args = SimpleNamespace(algo=SimpleNamespace(dynamic_filtering_range=(0.0, 1.0)))
+
+    def group(prefix, scores):
+        return [
+            SimpleNamespace(name=f"{prefix}-{index}", scores=torch.tensor([score]))
+            for index, score in enumerate(scores)
+        ]
+
+    refs = [group("accepted", [0.0, 1.0]), group("rejected", [0.0, 0.0]), group("pending", [0.0, 1.0])]
+    generator._dispatch_prompts_to_vllm = lambda *_args, **_kwargs: refs
+    generator._process_response_into_experience = lambda response, **_kwargs: response
+
+    dataloader = iter((None, [f"prompt-{index}"], [None], [None]) for index in range(3))
+    experiences, prompts_consumed, exhausted = generator._generate_vllm(
+        dataloader, num_prompts=3, dynamic_filtering=True
+    )
+
+    assert [experience.name for experience in experiences] == [
+        "accepted-0",
+        "accepted-1",
+        "pending-0",
+        "pending-1",
+    ]
+    assert prompts_consumed == 3
+    assert exhausted is True
+    assert fake_ray.cancelled == []


### PR DESCRIPTION
## Summary

- let already-dispatched vLLM refs finish when dynamic filtering cannot obtain a replacement prompt
- preserve accepted terminal rollouts instead of returning an unconditional empty list
- add a deterministic CPU regression covering accepted → rejected → pending accepted groups at dataloader exhaustion

Closes #1310

## Root cause and fix

`SamplesGenerator._generate_vllm()` accumulated valid results in `accepted_experiences`, but a later filtered group with no replacement prompt cancelled every pending ref and returned `[]`. That discarded both the accumulated results and potentially valid pending results.

The fix removes that early return. When the loader is exhausted, no replacement is dispatched and the existing loop simply drains the refs that are already in flight. The method's existing final return then reports the accepted experiences and `exhausted=True`.

This is intentionally a four-line deletion with no new control-flow branch.

## Tests

- `pytest -q tests/test_samples_generator.py` — `1 passed`
- full test suite — `23 passed`
- `python -m compileall -q openrlhf examples tests`
- project pre-commit hooks on the changed files
- `bash -n` on all runnable example scripts

The new regression test calls the real `_generate_vllm()` method with a deterministic fake Ray completion order. It fails on unpatched `main` because the result is empty and the pending accepted ref is cancelled; it passes after the fix with all four accepted experiences preserved and no cancellations.

`examples/scripts/train_ppo_ray_slurm.sh` was excluded from the shell check because its literal `<OPENRLHF_ROOT_PATH>` template placeholder already fails `bash -n` unchanged on `main`.
