### PR TITLE
fix(data): filter preference pairs collapsed by truncation

### DIFF
--- a/openrlhf/datasets/reward_dataset.py
+++ b/openrlhf/datasets/reward_dataset.py
@@ -98,6 +98,24 @@ class RewardDataset(Dataset):
         self.rejects = processed_dataset["reject"]
         self.extras = processed_dataset["extra"]
 
+    def _tokenize(self, text):
+        text = text.rstrip("\n")
+        if not text.endswith(self.tokenizer.eos_token):
+            text += " " + self.tokenizer.eos_token
+        token = self.tokenizer(
+            text,
+            max_length=self.max_length,
+            padding=False,
+            truncation=True,
+            return_tensors="pt",
+            add_special_tokens=False,
+        )
+
+        # to avoid EOS_token truncation
+        token["input_ids"][0][-1] = self.tokenizer.eos_token_id
+        token["attention_mask"][0][-1] = True
+        return token
+
     def process_data(self, data):
         prompt, chosen, reject, margin = preprocess_data(
             data,
@@ -124,6 +142,14 @@ class RewardDataset(Dataset):
             if prompt_ids_len >= self.max_length - 2:
                 prompt = None
 
+        if prompt is not None:
+            chosen_token = self._tokenize(prompt + chosen)
+            reject_token = self._tokenize(prompt + reject)
+            same_input_ids = chosen_token["input_ids"].equal(reject_token["input_ids"])
+            same_attention_mask = chosen_token["attention_mask"].equal(reject_token["attention_mask"])
+            if same_input_ids and same_attention_mask:
+                prompt = None
+
         return {
             "prompt": prompt,
             "chosen": chosen,
@@ -138,35 +164,8 @@ class RewardDataset(Dataset):
     def __getitem__(self, idx):
         prompt, chosen, reject, extra = self.prompts[idx], self.chosens[idx], self.rejects[idx], self.extras[idx]
 
-        chosen = (prompt + chosen).rstrip("\n")
-        if not chosen.endswith(self.tokenizer.eos_token):
-            chosen += " " + self.tokenizer.eos_token
-        chosen_token = self.tokenizer(
-            chosen,
-            max_length=self.max_length,
-            padding=False,
-            truncation=True,
-            return_tensors="pt",
-            add_special_tokens=False,
-        )
-
-        reject = (prompt + reject).rstrip("\n")
-        if not reject.endswith(self.tokenizer.eos_token):
-            reject += " " + self.tokenizer.eos_token
-        reject_token = self.tokenizer(
-            reject,
-            max_length=self.max_length,
-            padding=False,
-            truncation=True,
-            return_tensors="pt",
-            add_special_tokens=False,
-        )
-
-        # to avoid EOS_token truncation
-        chosen_token["input_ids"][0][-1] = self.tokenizer.eos_token_id
-        reject_token["input_ids"][0][-1] = self.tokenizer.eos_token_id
-        chosen_token["attention_mask"][0][-1] = True
-        reject_token["attention_mask"][0][-1] = True
+        chosen_token = self._tokenize(prompt + chosen)
+        reject_token = self._tokenize(prompt + reject)
 
         return (
             chosen_token["input_ids"],

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/tests/test_reward_dataset.py
+++ b/tests/test_reward_dataset.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+from datasets import Dataset
+
+from openrlhf.datasets import RewardDataset
+
+
+class _Tokenizer:
+    eos_token = "<eos>"
+    eos_token_id = 99
+    pad_token_id = 0
+
+    def __call__(self, text, max_length, **_kwargs):
+        token_ids = {
+            "prompt": 1,
+            "common": 2,
+            "chosen": 3,
+            "rejected": 4,
+            self.eos_token: self.eos_token_id,
+        }
+        input_ids = torch.tensor([[token_ids[token] for token in text.split()[:max_length]]])
+        return {"input_ids": input_ids, "attention_mask": torch.ones_like(input_ids)}
+
+
+def _build_dataset(chosen, rejected, is_dpo):
+    data = Dataset.from_list([{"prompt": "prompt ", "chosen": chosen, "rejected": rejected}])
+    strategy = SimpleNamespace(
+        args=SimpleNamespace(
+            data=SimpleNamespace(
+                prompt_key="prompt",
+                chosen_key="chosen",
+                rejected_key="rejected",
+                apply_chat_template=False,
+            )
+        )
+    )
+    return RewardDataset(data, _Tokenizer(), 5, strategy, is_dpo=is_dpo, num_processors=None)
+
+
+@pytest.mark.parametrize("is_dpo", [False, True])
+def test_filters_pair_whose_difference_is_truncated(is_dpo):
+    dataset = _build_dataset("common common common common chosen", "common common common common rejected", is_dpo)
+
+    assert len(dataset) == 0
+
+
+@pytest.mark.parametrize("is_dpo", [False, True])
+def test_filters_pair_whose_last_difference_is_replaced_by_eos(is_dpo):
+    dataset = _build_dataset("common common common chosen", "common common common rejected", is_dpo)
+
+    assert len(dataset) == 0
+
+
+@pytest.mark.parametrize("is_dpo", [False, True])
+def test_keeps_pair_with_difference_inside_retained_tokens(is_dpo):
+    dataset = _build_dataset("chosen common", "rejected common", is_dpo)
+
+    assert len(dataset) == 1
+    chosen_ids, _, rejected_ids, _, _ = dataset[0]
+    assert not torch.equal(chosen_ids, rejected_ids)


### PR DESCRIPTION
## Summary

- filter RM/DPO pairs whose chosen and rejected model inputs become identical after truncation and EOS replacement
- reuse one tokenization path for preprocessing validation and `__getitem__`
- add RM/DPO regression coverage for differences beyond truncation, differences overwritten at the EOS boundary, and valid retained differences

Closes #1311

## Root cause and fix

`RewardDataset` previously filtered long DPO prompts but never checked the final pair. Chosen and rejected sequences were independently truncated, then their last retained tokens were overwritten with EOS. A long shared answer prefix could therefore erase the only preference-defining difference while the sample remained in the dataset.

The patch extracts the existing text cleanup, tokenization, truncation, and EOS overwrite into `_tokenize()`. `process_data()` uses that exact path to compare the final chosen/rejected `input_ids` and `attention_mask`; identical pairs reuse the existing `prompt=None` filter. `__getitem__()` uses the same helper, so validation cannot drift from the tensors consumed by RM/DPO training.

Dataset construction now performs one-time tokenization of both sides for validation. This is intentional: filtering in `__getitem__`, the collator, or the loss would leave dataset length and distributed sharding inconsistent. The runtime model-input format is unchanged, and the helper reduces duplicated production logic (28 added / 29 removed lines in `reward_dataset.py`).

## Tests

- fail-before: `tests/test_reward_dataset.py` produced `4 failed, 2 passed` on unpatched `main`
- pass-after: targeted tests — `6 passed`
- full test suite — `28 passed`
- real Qwen3.5-0.8B tokenizer check:
  - unpatched RM/DPO: dataset length `1`, chosen/rejected IDs identical
  - patched RM/DPO: dataset length `0`, collapsed pair filtered
- `python -m compileall -q openrlhf examples tests`
- project pre-commit hooks on the changed files
- `bash -n` on all runnable example scripts

The tests are parameterized over RM and DPO and cover:

1. the only difference lies beyond `max_length`;
2. the difference is the final retained token and is overwritten by EOS;
3. the difference remains inside the retained range and the pair is kept.

`examples/scripts/train_ppo_ray_slurm.sh` was excluded from the shell check because its literal `<OPENRLHF_ROOT_PATH>` template placeholder already fails `bash -n` unchanged on `main`.
