### PR TITLE
fix(ppo): avoid NaNs when ICEPOP filters overflow ratios

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/models/loss.py
+++ b/openrlhf/models/loss.py
@@ -201,7 +201,7 @@ class PolicyLoss(nn.Module):
                 # ICEPOP: token-level filtering (set coefficients outside the interval to 0)
                 vllm_is = torch.exp(rollout_log_ratio).detach()
                 mask = (vllm_is >= low_threshold) & (vllm_is <= high_threshold)
-                vllm_is = vllm_is * mask
+                vllm_is = torch.where(mask, vllm_is, 0.0)
                 loss = vllm_is * loss
             elif self.vllm_is_correction_type == "seq-mask-tis":
                 # seq-mask-tis: use sequence-level geometric mean only for filtering,

--- a/tests/test_loss_aggregation.py
+++ b/tests/test_loss_aggregation.py
@@ -148,6 +148,27 @@ def test_policy_kl_metric_uses_policy_ratio_when_vllm_correction_is_enabled():
     assert torch.allclose(vllm_kl, (rollout_log_probs - old_log_probs).mean())
 
 
+def test_icepop_filters_overflowing_ratio_without_nan():
+    log_probs = torch.zeros((1, 2), requires_grad=True)
+    loss_fn = PolicyLoss(
+        enable_vllm_is_correction=True,
+        vllm_is_truncated_threshold=[0.5, 5.0],
+        vllm_is_correction_type="icepop",
+    )
+    loss, *_ = loss_fn(
+        log_probs,
+        torch.zeros_like(log_probs),
+        torch.ones_like(log_probs),
+        action_mask=torch.ones_like(log_probs),
+        rollout_log_probs=torch.tensor([[-1000.0, 0.0]]),
+    )
+    loss.backward()
+
+    assert torch.allclose(loss, torch.tensor(-0.5))
+    assert torch.isfinite(log_probs.grad).all()
+    assert log_probs.grad[0, 0] == 0
+
+
 def test_grad_accum_global_norm_matches_global_token_mean_over_window():
     # Two micro-batches in one optimizer-step window (gas=2) with UNEVEN token counts.
     mb0 = torch.tensor([[1.0, 2.0, 0.0]])  # 2 tokens


### PR DESCRIPTION
## Summary

ICEPOP is documented as filtering token importance weights outside the configured interval. The current branch computes `exp(old_log_probs - rollout_log_probs)` first and then multiplies by the boolean filter. A sufficiently stale token overflows to `inf`; rejecting it with multiplication produces `inf * 0 = NaN`, so one filtered token can poison the policy loss and gradient.

This replaces the multiplication with `torch.where`, which preserves every accepted coefficient and writes an exact zero for rejected coefficients. It does not change TIS or sequence-mask semantics.

This path is used by the shipped `train_prorlv2_math_hybrid_engine.sh`, `train_reinforce_baseline_ray_agent_async.sh`, and `train_reinforce_baseline_hybrid_engine.sh` recipes.

## Reproduction

With thresholds `[0.5, 5.0]`, one token ratio `exp(1000)`, and one accepted ratio `1`:

- main: `loss=NaN`, gradient `[[NaN, -0.5]]`
- this PR: `loss=-0.5`, gradient `[[0.0, -0.5]]`

The regression test checks the exact retained loss, finite gradients, and zero gradient for the rejected overflowing token.

## Tests

- Full CPU suite: 23 passed
- `python -m compileall -q openrlhf examples tests`
- pinned Black, isort, and autoflake checks
- Python 3.12 Linux syntax validation

The local CPU suite used a lightweight DeepSpeed import stub because DeepSpeed is unavailable on Windows; no production behavior was stubbed.