### PR TITLE
fix(deepspeed): match tied lm_head key by suffix under PEFT wrapping in save_model

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,7 +6,9 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
+def preprocess_data(
+    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
+):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/utils/deepspeed/deepspeed.py
+++ b/openrlhf/utils/deepspeed/deepspeed.py
@@ -553,9 +553,15 @@ class DeepspeedStrategy(ABC):
             state_dict_keys = set(model_to_save.state_dict().keys())
             output_state_dict_keys = set(output_state_dict.keys())
 
-            # corner case for tie_word_embeddings, such as Qwen2-0.5B
-            if getattr(model_to_save.config, "tie_word_embeddings", False) and "lm_head.weight" in state_dict_keys:
-                state_dict_keys.remove("lm_head.weight")
+            # corner case for tie_word_embeddings, such as Qwen2-0.5B: ZeRO-3's
+            # consolidated state dict omits the tied lm_head weight (it shares
+            # storage with the embedding). PEFT prefixes every key with
+            # "base_model.model.", so a LoRA-wrapped save always tripped this
+            # assertion (#747) unless we match the key by suffix.
+            if getattr(model_to_save.config, "tie_word_embeddings", False):
+                state_dict_keys -= {
+                    k for k in state_dict_keys if k == "lm_head.weight" or k.endswith(".lm_head.weight")
+                }
 
             assert state_dict_keys.issubset(
                 output_state_dict_keys

--- a/tests/test_deepspeed_save_model.py
+++ b/tests/test_deepspeed_save_model.py
@@ -1,0 +1,157 @@
+"""Regression tests for DeepspeedStrategy.save_model's tie_word_embeddings
+corner case (issue #747).
+
+ZeRO-3's consolidated state dict omits the tied lm_head weight (it shares
+storage with the token embedding), so save_model special-cases it out of the
+"missing key" assertion. That special case only matched the bare
+"lm_head.weight" key. PEFT wraps every parameter name with a
+"base_model.model." prefix, so a LoRA-wrapped save of a tied-embedding model
+(e.g. Qwen2-0.5B/1.5B/3B) always tripped the assertion.
+
+These tests exercise the real save_model code path with a PEFT-wrapped tiny
+model and a stand-in for DeepSpeed's ZeRO-3 consolidation, mocking only the
+CUDA-only flash_attn import and the distributed barrier so it runs single
+process on CPU.
+"""
+
+import importlib.machinery
+import sys
+import tempfile
+import types
+from types import SimpleNamespace
+
+import pytest
+import torch.nn as nn
+
+peft = pytest.importorskip("peft")
+pytest.importorskip("deepspeed")
+pytest.importorskip("torchdata")
+
+
+def _make_stub(name):
+    mod = types.ModuleType(name)
+    mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+    mod.__path__ = []
+    return mod
+
+
+@pytest.fixture
+def ds_module(monkeypatch):
+    """Import openrlhf.utils.deepspeed.deepspeed with flash_attn stubbed out.
+
+    flash_attn only ships CUDA builds, but it is merely imported (never
+    called) for the code path under test, so a bare stub is enough to make
+    the module importable on a CPU-only machine.
+    """
+    flash_attn_mod = _make_stub("flash_attn")
+    bert_padding_mod = _make_stub("flash_attn.bert_padding")
+    for fn in ("index_first_axis", "pad_input", "rearrange", "unpad_input"):
+        setattr(bert_padding_mod, fn, lambda *a, **k: None)
+    utils_pkg = _make_stub("flash_attn.utils")
+    distributed_mod = _make_stub("flash_attn.utils.distributed")
+    distributed_mod.all_gather = lambda *a, **k: None
+    utils_pkg.distributed = distributed_mod
+    flash_attn_mod.bert_padding = bert_padding_mod
+    flash_attn_mod.utils = utils_pkg
+
+    for name, mod in (
+        ("flash_attn", flash_attn_mod),
+        ("flash_attn.bert_padding", bert_padding_mod),
+        ("flash_attn.utils", utils_pkg),
+        ("flash_attn.utils.distributed", distributed_mod),
+    ):
+        monkeypatch.setitem(sys.modules, name, mod)
+
+    import openrlhf.utils.deepspeed.deepspeed as module
+
+    # Single-process test: no real process group to barrier/sync on.
+    monkeypatch.setattr(module, "torch_dist_barrier_and_cuda_sync", lambda: None)
+    return module
+
+
+class _TinyConfig:
+    tie_word_embeddings = True
+
+    def to_json_file(self, path):
+        with open(path, "w") as f:
+            f.write("{}")
+
+
+class _TinyModel(nn.Module):
+    """Minimal tied-embedding-shaped model: a real lm_head param plus a
+    same-named submodule, so PEFT's "base_model.model." prefix and DeepSpeed's
+    tied-weight dedup both apply the way they do to Qwen2/Qwen2.5-0.5B-3B."""
+
+    def __init__(self):
+        super().__init__()
+        self.config = _TinyConfig()
+        self.model = nn.Module()
+        self.model.embed_tokens = nn.Embedding(10, 4)
+        self.q_proj = nn.Linear(4, 4)
+        self.lm_head = nn.Linear(4, 10, bias=False)
+
+    def forward(self, x):
+        return self.lm_head(self.q_proj(self.model.embed_tokens(x)))
+
+
+def _strategy(ds_module, zero_stage=3):
+    strategy = object.__new__(ds_module.DeepspeedStrategy)
+    strategy.args = SimpleNamespace(ds=SimpleNamespace(zero_stage=zero_stage, tensor_parallel_size=1))
+    strategy.ds_tensor_parallel_size = 1
+    strategy.stage = zero_stage
+    return strategy
+
+
+def _tokenizer():
+    return SimpleNamespace(save_pretrained=lambda *a, **k: None)
+
+
+def test_save_model_lora_tied_embeddings_zero3(ds_module):
+    """PEFT-prefixed tied lm_head key must not trip the mismatch assertion."""
+    base = _TinyModel()
+    peft_model = peft.get_peft_model(base, peft.LoraConfig(target_modules=["q_proj"]))
+    peft_model.save_pretrained = lambda *a, **k: None
+
+    tied_key = "base_model.model.lm_head.weight"
+    full_state = peft_model.state_dict()
+    assert tied_key in full_state
+
+    # Stand-in for DeepSpeed ZeRO-3's _consolidated_16bit_state_dict(), which
+    # omits the tied lm_head weight because it shares storage with embed_tokens.
+    consolidated = {k: v for k, v in full_state.items() if k != tied_key}
+    peft_model._consolidated_16bit_state_dict = lambda: consolidated
+
+    strategy = _strategy(ds_module)
+    with tempfile.TemporaryDirectory() as tmp:
+        strategy.save_model(peft_model, _tokenizer(), tmp)  # must not raise
+
+
+def test_save_model_plain_tied_embeddings_zero3(ds_module):
+    """Original (non-PEFT) tie_word_embeddings corner case keeps working."""
+    model = _TinyModel()
+    model.save_pretrained = lambda *a, **k: None
+
+    tied_key = "lm_head.weight"
+    full_state = model.state_dict()
+    assert tied_key in full_state
+    consolidated = {k: v for k, v in full_state.items() if k != tied_key}
+    model._consolidated_16bit_state_dict = lambda: consolidated
+
+    strategy = _strategy(ds_module)
+    with tempfile.TemporaryDirectory() as tmp:
+        strategy.save_model(model, _tokenizer(), tmp)  # must not raise
+
+
+def test_save_model_genuine_mismatch_still_raises(ds_module):
+    """A real (non-lm_head) missing key must still fail loudly."""
+    model = _TinyModel()
+    model.save_pretrained = lambda *a, **k: None
+
+    full_state = model.state_dict()
+    consolidated = {k: v for k, v in full_state.items() if k != "q_proj.weight"}
+    model._consolidated_16bit_state_dict = lambda: consolidated
+
+    strategy = _strategy(ds_module)
+    with tempfile.TemporaryDirectory() as tmp:
+        with pytest.raises(AssertionError, match="q_proj.weight"):
+            strategy.save_model(model, _tokenizer(), tmp)


### PR DESCRIPTION
## Summary

- match the tied `lm_head.weight` key by suffix (not exact name) in `DeepspeedStrategy.save_model`'s `tie_word_embeddings` corner case

## Root cause and impact

DeepSpeed ZeRO-3's consolidated state dict omits the tied `lm_head` weight because it shares storage with the token embedding, so `save_model` special-cases that one key out of its "missing key" assertion. The special case only matched the bare `"lm_head.weight"` string. PEFT prefixes every parameter name with `"base_model.model."`, so for any LoRA adapter on a `tie_word_embeddings=True` model (e.g. Qwen2/Qwen2.5-0.5B/1.5B/3B) the check never fired and saving under `zero_stage=3` always raised:

```
AssertionError: mismatch keys {'base_model.model.lm_head.weight'}
```

exactly as reported in #747. Matching by suffix instead of exact name finds the tied key regardless of wrapping depth (PEFT or otherwise) while a genuine missing key still fails the assertion.

Fixes #747.

## Validation

- New regression test (`tests/test_deepspeed_save_model.py`) exercises the real `save_model` code path with a PEFT-`LoraConfig`-wrapped tied-embedding model. Confirmed **red on `main`** (`AssertionError: mismatch keys {'base_model.model.lm_head.weight'}`, reproducing #747 verbatim) and **green with this fix**.
- Two more tests guard against regressions: the original non-LoRA `tie_word_embeddings` corner case still passes, and a genuinely missing (non-`lm_head`) key still raises.
- Full repo test suite: **25 passed** (22 pre-existing + 3 new).
- `pre-commit run --all-files`: **passed** on the changed files.

## Note on verification scope (CPU-only, no GPU/DeepSpeed cluster)

`save_model`'s ZeRO-3 branch calls DeepSpeed's real `model._consolidated_16bit_state_dict()`, which requires a live multi-process ZeRO-3 engine and cannot run on a single CPU-only machine. The tests instead stand in for that call with a state dict built by removing exactly the tied key DeepSpeed is documented (and the original bug report confirms) to omit — this reproduces the exact reported assertion and validates the fix's key-matching logic, but does not exercise DeepSpeed's real ZeRO-3 consolidation path end-to-end. Flagging this gap explicitly rather than presenting it as a full distributed-mode verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
