### PR TITLE
fix(actor): compute entropy from temperature-scaled logits

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/models/actor.py
+++ b/openrlhf/models/actor.py
@@ -265,6 +265,10 @@ class Actor(nn.Module):
         output = self.model(sequences, attention_mask=foward_attention_mask, position_ids=position_ids, **mm_inputs)
         # https://github.com/OpenRLHF/OpenRLHF/pull/634
         output["logits"] = output["logits"].to(torch.float32)
+        # Scale once here so the entropy below and the log probs describe the same
+        # temperature-scaled policy that the rollout sampled from.
+        if self.temperature != 1.0:
+            output["logits"].div_(self.temperature)
 
         if return_entropy:
             assert return_output
@@ -282,7 +286,7 @@ class Actor(nn.Module):
                 )
             return output
 
-        log_probs = log_probs_from_logits(output["logits"], rolled_sequences, temperature=self.temperature)
+        log_probs = log_probs_from_logits(output["logits"], rolled_sequences)
 
         if self.packing_samples:
             log_probs = gather_and_pad_tensor(log_probs, ring_attn_group, ring_attn_pad_len, indices, batch, seqlen)

--- a/tests/test_actor_entropy_temperature.py
+++ b/tests/test_actor_entropy_temperature.py
@@ -1,0 +1,90 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from transformers.modeling_outputs import CausalLMOutputWithPast
+
+_TEST_PACKAGE = "_openrlhf_actor_test"
+
+
+def _load_actor_module():
+    root = Path(__file__).resolve().parents[1]
+    models_dir = root / "openrlhf" / "models"
+
+    # Keep this CPU test importable without DeepSpeed, flash-attn, or peft.
+    for name in (
+        "deepspeed",
+        "flash_attn",
+        "flash_attn.bert_padding",
+        "flash_attn.utils",
+        "flash_attn.utils.distributed",
+        "peft",
+        "peft.tuners",
+        "peft.tuners.lora",
+    ):
+        if name not in sys.modules:
+            stub = MagicMock()
+            stub.__spec__ = importlib.machinery.ModuleSpec(name, None)
+            sys.modules[name] = stub
+
+    pkg = types.ModuleType(_TEST_PACKAGE)
+    pkg.__path__ = [str(models_dir)]
+    sys.modules[_TEST_PACKAGE] = pkg
+
+    # compute_entropy is wrapped in torch.compile at import time; run it eagerly here.
+    original_compile = torch.compile
+    torch.compile = lambda fn=None, **_: fn if fn is not None else (lambda f: f)
+    try:
+        for name in ("utils", "ring_attn_utils", "actor"):
+            spec = importlib.util.spec_from_file_location(f"{_TEST_PACKAGE}.{name}", models_dir / f"{name}.py")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[f"{_TEST_PACKAGE}.{name}"] = module
+            spec.loader.exec_module(module)
+    finally:
+        torch.compile = original_compile
+
+    return sys.modules[f"{_TEST_PACKAGE}.actor"]
+
+
+Actor = _load_actor_module().Actor
+
+
+class _TableLM(torch.nn.Module):
+    """Logits are a fixed per-token table so the expected values are easy to recompute."""
+
+    def __init__(self, vocab_size=11):
+        super().__init__()
+        generator = torch.Generator().manual_seed(0)
+        self.table = torch.nn.Parameter(torch.randn(vocab_size, vocab_size, generator=generator))
+
+    def forward(self, input_ids, attention_mask=None, position_ids=None, **_):
+        return CausalLMOutputWithPast(logits=self.table[input_ids])
+
+
+@pytest.mark.parametrize("temperature", [0.5, 1.5])
+def test_entropy_matches_temperature_scaled_policy(temperature):
+    actor = Actor(_TableLM(), temperature=temperature)
+    actor.packing_samples = False
+
+    generator = torch.Generator().manual_seed(1)
+    sequences = torch.randint(0, 11, (2, 6), generator=generator)
+    attention_mask = torch.ones_like(sequences)
+    action_mask = torch.ones(2, 5, dtype=torch.long)
+
+    action_log_probs, output = actor(
+        sequences, action_mask, attention_mask=attention_mask, return_output=True, return_entropy=True
+    )
+
+    policy_logits = _TableLM()(sequences).logits / temperature
+    next_tokens = torch.roll(sequences, shifts=-1, dims=1).unsqueeze(-1)
+    expected_log_probs = torch.log_softmax(policy_logits, dim=-1).gather(-1, next_tokens).squeeze(-1)[:, :-1]
+    expected_entropy = torch.distributions.Categorical(logits=policy_logits).entropy()[:, :-1]
+
+    assert torch.allclose(action_log_probs, expected_log_probs, atol=1e-5)
+    # The entropy bonus must describe the same policy the log probs (and the sampler) use.
+    assert torch.allclose(output.entropy, expected_entropy, atol=1e-5)


### PR DESCRIPTION
## Summary

- apply `--rollout.temperature` to the actor logits once, right after the fp32 cast
- compute the entropy bonus and the policy log probs from the same scaled logits
- add a CPU regression test that drives `Actor.forward` with a tiny table model

## Root cause and impact

`Actor.forward` called `compute_entropy(output["logits"])` before `log_probs_from_logits` divided the same tensor in place by `self.temperature`. With `--rollout.temperature != 1.0` the entropy bonus (`--actor.entropy_coef`) and the logged `entropy_loss` described `softmax(logits)`, while the trained policy and the vLLM sampler use `softmax(logits / T)`. On a small table model the per-token gap is up to 1.03 nats at T=0.5 and 0.44 nats at T=1.5.

Scaling once up front keeps the in-place, allocation-free behaviour from #857 and makes both quantities describe the same policy. Behaviour at temperature 1.0 is unchanged. This matches TRL's `GRPOTrainer`, which divides logits by the sampling temperature before computing entropy.

## Validation

- `python -m pytest -q`: 24 passed (new test fails on main, passes with the fix)
- `python -m compileall -q openrlhf examples tests`: clean
- pre-commit hooks on both changed files (autoflake, isort, black 26.5.1): passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vZKTbRaDh8FuXSbVpQomD
