### PR TITLE
fix(ppo): drain terminal oversampling buffer before restarting the loader

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/trainer/ppo_utils/samples_generator.py
+++ b/openrlhf/trainer/ppo_utils/samples_generator.py
@@ -93,7 +93,7 @@ class SamplesGenerator:
         may produce more samples than one training step needs.  Extras are kept
         in ``_sample_buffer`` and served in subsequent calls without hitting vLLM.
         """
-        if getattr(self, "_dataloader_iter", None) is None:
+        if getattr(self, "_dataloader_iter", None) is None and not getattr(self, "_sample_buffer", None):
             self._dataloader_iter = iter(self.prompts_dataloader)
             self._sample_buffer: List[Experience] = []
 

--- a/tests/test_samples_generator.py
+++ b/tests/test_samples_generator.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_terminal_oversampling_buffer_is_drained_before_next_episode(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ray", MagicMock())
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=lambda iterable, **kwargs: iterable))
+    monkeypatch.setitem(sys.modules, "vllm", SimpleNamespace(SamplingParams=object))
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ppo_utils.experience", MagicMock())
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ray.vllm_engine", MagicMock())
+    monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", MagicMock())
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_samples_generator_test",
+        root / "openrlhf" / "trainer" / "ppo_utils" / "samples_generator.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1, vllm_generate_batch_size=4),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        vllm=SimpleNamespace(enable_sleep=False),
+    )
+    loader = MagicMock()
+    loader.__iter__.side_effect = lambda: iter([0, 1, 2])
+    generator = module.SamplesGenerator(SimpleNamespace(args=args), loader, None, None, [])
+
+    def generate(dataloader_iter, num_prompts, dynamic_filtering, **kwargs):
+        del dynamic_filtering, kwargs
+        generated = []
+        for _ in range(num_prompts):
+            try:
+                generated.append(next(dataloader_iter))
+            except StopIteration:
+                break
+        return generated, len(generated), len(generated) < num_prompts
+
+    generator._generate_vllm = generate
+
+    first, _, first_prompts, first_exhausted = generator.generate_samples()
+    first_buffer = list(generator._sample_buffer)
+    second, _, second_prompts, second_exhausted = generator.generate_samples()
+    third, _, third_prompts, third_exhausted = generator.generate_samples()
+
+    assert (first, first_prompts, first_exhausted) == ([0, 1], 3, False)
+    assert first_buffer == [2]
+    assert (second, second_prompts, second_exhausted) == ([2], 0, True)
+    assert (third, third_prompts, third_exhausted) == ([0, 1], 3, False)
+    assert loader.__iter__.call_count == 2


### PR DESCRIPTION
# fix(ppo): drain terminal oversampling buffer before restarting the loader

Fixes #1320

## What changed

- Reinitialize the prompt dataloader only when both its iterator and the oversampling buffer are empty.
- Add a regression test covering the terminal tail, the exhausted signal, and the following episode.

## Why

With async oversampling, a final generation call can exhaust the dataloader while leaving more generated experiences than one training chunk can consume. The generator correctly returns `is_exhausted=False` so its caller requests the tail, but the next call previously treated the `None` iterator as a new episode and cleared the non-empty buffer.

For prompt IDs `[0, 1, 2]`, generation batch 4, and rollout batch 2, v0.11.0 returns `[0, 1]` twice and never reports exhaustion. After this change it returns `[0, 1]`, then `[2]` with `is_exhausted=True`; only the next call starts the following episode.

## Scope

The production change is one condition in `SamplesGenerator.generate_samples()`. Normal batches, empty datasets, exact generation boundaries, and non-oversampled runs keep their existing behavior.

## Tests

```text
python -m pytest -q tests/test_samples_generator.py
1 passed

PYTHONPATH=../OpenRLHF-audit-report-20260904/test_stubs python -m pytest -q
23 passed

python -m compileall -q openrlhf examples tests
passed
```

The local full-suite run injected only a minimal DeepSpeed import stub because DeepSpeed is not installed in that venv. `git diff --check`, isort, and Black's formatting API also passed. No GPU is needed because the failure is entirely in the sampler's deterministic buffer/iterator state machine.

After publication, pre-commit.ci also mechanically reformatted the existing `preprocess_data` signature in `openrlhf/datasets/sft_dataset.py`. That bot-authored, behavior-neutral formatting change is unrelated to the fix.

## Checklist

- [x] The committed regression test fails on the affected base revision and passes with this change.
- [x] The regression test fails when the one-line fix is reverted.
- [x] The buffered tail is returned before the next episode initializes.
- [x] Full unit suite and syntax compilation pass.
