### PR TITLE
fix(async): persist oversampling buffer state across checkpoints

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -362,6 +362,10 @@ class BasePPOTrainer(ABC):
             client_states["best_eval_metric_key"] = metric_key
             client_states["best_eval_metric_value"] = current_value
             client_states["checkpoint_metric_key"] = metric_key
+            sample_buffer_state = client_states.pop("sample_buffer_state", None)
+            if sample_buffer_state:
+                sample_buffer_ref, size = sample_buffer_state
+                client_states["sample_buffer"] = ray.get(sample_buffer_ref)[-size:]
 
             tag = f"best_global_step{global_step}"
             refs = self.actor_model_group.async_run_method(
@@ -432,7 +436,9 @@ class BasePPOTrainer(ABC):
             checkpoint_states = ray.get(self.actor_model_group.async_run_method(method_name="get_checkpoint_states"))[
                 0
             ]
-            logger.info(f"checkpoint_states: {checkpoint_states}")
+            checkpoint_log = dict(checkpoint_states)
+            checkpoint_log["sample_buffer"] = len(checkpoint_log.get("sample_buffer", []))
+            logger.info(f"checkpoint_states: {checkpoint_log}")
             return checkpoint_states
         return {
             "episode": 0,

--- a/openrlhf/trainer/ppo_trainer_async.py
+++ b/openrlhf/trainer/ppo_trainer_async.py
@@ -62,6 +62,8 @@ class GenerateSamplesActor:
             tokenizer=tokenizer,
             vllm_engines=vllm_engines,
         )
+        self._sample_buffer_ref = None
+        self._dataloader_exhausted = False
 
         self.vllm_lock = vllm_lock
         self._partial_rollout = getattr(strategy.args.train, "partial_rollout_enable", False)
@@ -73,8 +75,12 @@ class GenerateSamplesActor:
     def get_max_steps(self):
         return self.max_steps
 
-    def load_state_dict(self, state_dict):
+    def load_state_dict(self, state_dict, sample_buffer=None, dataloader_exhausted=False):
         self.prompts_dataloader.load_state_dict(state_dict)
+        self.samples_generator._sample_buffer = list(sample_buffer or [])
+        self.samples_generator._dataloader_iter = iter(()) if dataloader_exhausted else iter(self.prompts_dataloader)
+        self._dataloader_exhausted = dataloader_exhausted
+        self._sample_buffer_ref = ray.put(self.samples_generator._sample_buffer) if sample_buffer else None
 
     def _should_eval(self, global_step):
         return (
@@ -139,12 +145,33 @@ class GenerateSamplesActor:
                     if not self._partial_rollout:
                         ray.get(self.vllm_lock.release.remote())
 
+                if (
+                    self.samples_generator._dataloader_iter is None
+                    or total_consumed_prompts >= (episode + 1) * dataset_length
+                ):
+                    self._dataloader_exhausted = True
+                elif prompts_consumed:
+                    self._dataloader_exhausted = False
+
+                # Queue entries share one generated tail and identify its remaining suffix.
+                # This avoids serializing overlapping Experience lists for every training chunk.
+                if prompts_consumed and self.samples_generator._sample_buffer:
+                    self._sample_buffer_ref = ray.put(self.samples_generator._sample_buffer)
+                elif not self.samples_generator._sample_buffer:
+                    self._sample_buffer_ref = None
+
                 produced = bool(rollout_samples)
                 if produced:
                     client_states = {
                         "episode": episode,
                         "total_consumed_prompts": total_consumed_prompts,
                         "data_loader_state_dict": self.prompts_dataloader.state_dict(),
+                        "dataloader_exhausted": self._dataloader_exhausted,
+                        "sample_buffer_state": (
+                            (self._sample_buffer_ref, len(self.samples_generator._sample_buffer))
+                            if self._sample_buffer_ref is not None
+                            else None
+                        ),
                     }
                     self.rollout_queue.put(
                         (rollout_samples, client_states, filter_pass_rate, generation_time), block=True
@@ -245,7 +272,14 @@ class TrainingActor(BasePPOTrainer):
 
             client_states.update({"global_step": global_step})
             self._latest_client_states = client_states
-            self.save_logs_and_checkpoints(global_step, status, client_states)
+            checkpoint_states = client_states
+            if global_step % self.args.ckpt.save_steps == 0:
+                checkpoint_states = dict(client_states)
+                sample_buffer_state = checkpoint_states.pop("sample_buffer_state", None)
+                if sample_buffer_state:
+                    sample_buffer_ref, size = sample_buffer_state
+                    checkpoint_states["sample_buffer"] = ray.get(sample_buffer_ref)[-size:]
+            self.save_logs_and_checkpoints(global_step, status, checkpoint_states)
 
         if self.wandb_logger:
             self.wandb_logger.close()
@@ -336,7 +370,11 @@ class PPOTrainerAsync:
         if global_step > 0:
             ray.get(
                 [
-                    self.generator_actor.load_state_dict.remote(checkpoint_states["data_loader_state_dict"]),
+                    self.generator_actor.load_state_dict.remote(
+                        checkpoint_states["data_loader_state_dict"],
+                        checkpoint_states.get("sample_buffer"),
+                        checkpoint_states.get("dataloader_exhausted", False),
+                    ),
                     self.trainer_actor.broadcast_to_vllm.remote(),
                 ]
             )

--- a/openrlhf/trainer/ppo_utils/samples_generator.py
+++ b/openrlhf/trainer/ppo_utils/samples_generator.py
@@ -93,7 +93,7 @@ class SamplesGenerator:
         may produce more samples than one training step needs.  Extras are kept
         in ``_sample_buffer`` and served in subsequent calls without hitting vLLM.
         """
-        if getattr(self, "_dataloader_iter", None) is None:
+        if getattr(self, "_dataloader_iter", None) is None and not getattr(self, "_sample_buffer", None):
             self._dataloader_iter = iter(self.prompts_dataloader)
             self._sample_buffer: List[Experience] = []
 

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -17,6 +17,14 @@ class _Pbar:
     def update(self, _):
         pass
 
+    def close(self):
+        pass
+
+
+class _ObjectRef:
+    def __init__(self, value):
+        self.value = tuple(value)
+
 
 @pytest.fixture
 def ppo_module(monkeypatch):
@@ -51,6 +59,25 @@ def ppo_module(monkeypatch):
     monkeypatch.setitem(sys.modules, spec.name, module)
     spec.loader.exec_module(module)
     module.tqdm = _Pbar
+    return module
+
+
+@pytest.fixture
+def ppo_async_module(ppo_module, monkeypatch):
+    monkeypatch.setitem(sys.modules, "ray.util.queue", SimpleNamespace(Queue=MagicMock()))
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ppo_trainer", ppo_module)
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_ppo_trainer_async_test",
+        root / "openrlhf" / "trainer" / "ppo_trainer_async.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    module.tqdm = _Pbar
+    module.ray.put.side_effect = lambda value: _ObjectRef(value)
+    module.ray.get.side_effect = lambda value: list(value.value) if isinstance(value, _ObjectRef) else value
     return module
 
 
@@ -116,3 +143,197 @@ def test_sync_fit_does_not_train_empty_exhausted_result(ppo_module):
     trainer.fit()
 
     assert trainer.samples_generator.calls == 1
+
+
+def test_async_checkpoint_restores_oversampling_buffer(ppo_async_module):
+    actor = ppo_async_module.GenerateSamplesActor.__new__(ppo_async_module.GenerateSamplesActor)
+    actor.prompts_dataloader = MagicMock()
+    actor.prompts_dataloader.__iter__.return_value = iter([4, 5])
+    actor.samples_generator = SimpleNamespace()
+
+    actor.load_state_dict({"position": 4}, [2, 3], False)
+
+    actor.prompts_dataloader.load_state_dict.assert_called_once_with({"position": 4})
+    assert actor.samples_generator._sample_buffer == [2, 3]
+    assert next(actor.samples_generator._dataloader_iter) == 4
+    assert not actor._dataloader_exhausted
+    assert ppo_async_module.ray.get(actor._sample_buffer_ref) == [2, 3]
+
+    legacy_actor = ppo_async_module.GenerateSamplesActor.__new__(ppo_async_module.GenerateSamplesActor)
+    legacy_actor.prompts_dataloader = MagicMock()
+    legacy_actor.prompts_dataloader.__iter__.return_value = iter([4, 5])
+    legacy_actor.samples_generator = SimpleNamespace()
+    legacy_actor.load_state_dict({"position": 4})
+
+    assert legacy_actor.samples_generator._sample_buffer == []
+    assert not legacy_actor._dataloader_exhausted
+    assert legacy_actor._sample_buffer_ref is None
+
+
+def test_async_client_states_share_one_buffer_snapshot(ppo_async_module):
+    samples_generator = SimpleNamespace(_sample_buffer=[], _dataloader_iter=object(), calls=0)
+
+    def generate_samples(**_):
+        samples_generator.calls += 1
+        if samples_generator.calls == 1:
+            samples_generator._sample_buffer = [2, 3, 4, 5]
+            return [0, 1], None, 3, False
+        if samples_generator.calls == 2:
+            samples_generator._sample_buffer = [4, 5]
+            return [2, 3], None, 0, False
+        if samples_generator.calls == 3:
+            samples_generator._sample_buffer = []
+            return [4, 5], None, 0, False
+        samples_generator._dataloader_iter = None
+        return [], None, 0, True
+
+    samples_generator.generate_samples = generate_samples
+    actor = ppo_async_module.GenerateSamplesActor.__new__(ppo_async_module.GenerateSamplesActor)
+    actor.args = SimpleNamespace(train=SimpleNamespace(num_episodes=1))
+    actor.prompts_dataloader = MagicMock()
+    actor.prompts_dataloader.__len__.return_value = 3
+    actor.prompts_dataloader.state_dict.return_value = {"position": 3}
+    actor.eval_dataloader = None
+    actor.samples_generator = samples_generator
+    actor.generate_kwargs = {}
+    actor._partial_rollout = True
+    actor.rollout_slots = MagicMock()
+    actor.rollout_slots.get.return_value = 0
+    actor.rollout_queue = MagicMock()
+    actor._sample_buffer_ref = None
+    actor._dataloader_exhausted = False
+    actor._last_eval_step = -1
+    actor._eval_just_done = False
+
+    actor.fit(episode=0, total_consumed_prompts=0)
+
+    payloads = [call.args[0] for call in actor.rollout_queue.put.call_args_list if isinstance(call.args[0], tuple)]
+    states = [payload[1] for payload in payloads]
+
+    assert len(states) == 3
+    assert all(state["dataloader_exhausted"] for state in states)
+    first_ref, first_size = states[0]["sample_buffer_state"]
+    second_ref, second_size = states[1]["sample_buffer_state"]
+    assert first_ref is second_ref
+    assert ppo_async_module.ray.get(first_ref)[-first_size:] == [2, 3, 4, 5]
+    assert ppo_async_module.ray.get(second_ref)[-second_size:] == [4, 5]
+    assert states[2]["sample_buffer_state"] is None
+    assert ppo_async_module.ray.put.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ("buffer", "expected_batches"),
+    [
+        ([], []),
+        ([2], [[2]]),
+        ([2, 3], [[2, 3]]),
+        ([2, 3, 4, 5], [[2, 3], [4, 5]]),
+    ],
+)
+def test_async_exhausted_state_survives_buffer_drain(ppo_async_module, buffer, expected_batches):
+    samples_generator = SimpleNamespace()
+
+    def generate_samples(**_):
+        chunk_size = 2
+        if len(samples_generator._sample_buffer) < chunk_size and samples_generator._dataloader_iter is not None:
+            try:
+                next(samples_generator._dataloader_iter)
+            except StopIteration:
+                samples_generator._dataloader_iter = None
+        rollout_samples = samples_generator._sample_buffer[:chunk_size]
+        samples_generator._sample_buffer = samples_generator._sample_buffer[chunk_size:]
+        exhausted = samples_generator._dataloader_iter is None and not samples_generator._sample_buffer
+        return rollout_samples, None, 0, exhausted
+
+    samples_generator.generate_samples = generate_samples
+    actor = ppo_async_module.GenerateSamplesActor.__new__(ppo_async_module.GenerateSamplesActor)
+    actor.args = SimpleNamespace(train=SimpleNamespace(num_episodes=1))
+    actor.prompts_dataloader = MagicMock()
+    actor.prompts_dataloader.__len__.return_value = 4
+    actor.prompts_dataloader.state_dict.return_value = {"finished": True}
+    actor.eval_dataloader = None
+    actor.samples_generator = samples_generator
+    actor.generate_kwargs = {}
+    actor._partial_rollout = True
+    actor.rollout_slots = MagicMock()
+    actor.rollout_slots.get.return_value = 0
+    actor.rollout_queue = MagicMock()
+    actor._last_eval_step = -1
+    actor._eval_just_done = False
+
+    actor.load_state_dict({"finished": True}, buffer, True)
+    actor.fit(episode=0, total_consumed_prompts=4)
+
+    payloads = [call.args[0] for call in actor.rollout_queue.put.call_args_list if isinstance(call.args[0], tuple)]
+    assert [payload[0] for payload in payloads] == expected_batches
+    for index, (_, state, _, _) in enumerate(payloads):
+        remaining = buffer[(index + 1) * 2 :]
+        assert state["dataloader_exhausted"] is True
+        if remaining:
+            sample_buffer_ref, size = state["sample_buffer_state"]
+            assert ppo_async_module.ray.get(sample_buffer_ref)[-size:] == remaining
+        else:
+            assert state["sample_buffer_state"] is None
+    assert ppo_async_module.ray.put.call_count == bool(buffer)
+
+
+def test_async_buffer_is_materialized_only_for_checkpoint(ppo_async_module):
+    buffer_ref = _ObjectRef([2, 3, 4, 5])
+    first_state = {"sample_buffer_state": (buffer_ref, 4)}
+    second_state = {"sample_buffer_state": (buffer_ref, 2)}
+    payloads = [
+        (["rollout-1"], first_state, None, 0.1),
+        (["rollout-2"], second_state, None, 0.1),
+    ]
+    actor = ppo_async_module.TrainingActor.__new__(ppo_async_module.TrainingActor)
+    actor.args = SimpleNamespace(
+        algo=SimpleNamespace(dynamic_filtering_enable=False), ckpt=SimpleNamespace(save_steps=2)
+    )
+    actor.rollout_queue = MagicMock()
+    actor.rollout_queue.get.side_effect = [*payloads, "done"]
+    actor.rollout_slots = MagicMock()
+    actor.train_step = MagicMock(side_effect=lambda samples, step: ({"samples": samples}, step + 1))
+    actor.save_logs_and_checkpoints = MagicMock()
+    actor.save_best_checkpoint = MagicMock()
+    actor.wandb_logger = None
+    actor.tensorboard_logger = None
+
+    actor.fit(global_step=0)
+
+    first_saved_state = actor.save_logs_and_checkpoints.call_args_list[0].args[2]
+    second_saved_state = actor.save_logs_and_checkpoints.call_args_list[1].args[2]
+    assert first_saved_state["sample_buffer_state"] == (buffer_ref, 4)
+    assert "sample_buffer" not in first_saved_state
+    assert second_saved_state["sample_buffer"] == [4, 5]
+    assert "sample_buffer_state" not in second_saved_state
+
+
+def test_async_buffer_is_materialized_for_best_checkpoint(ppo_async_module):
+    buffer_ref = _ObjectRef([2, 3, 4, 5])
+    client_state = {"sample_buffer_state": (buffer_ref, 2)}
+    payloads = [
+        (["rollout"], client_state, None, 0.1),
+        ("eval", 1, {"reward": 1.0}),
+    ]
+    actor = ppo_async_module.TrainingActor.__new__(ppo_async_module.TrainingActor)
+    actor.args = SimpleNamespace(
+        algo=SimpleNamespace(dynamic_filtering_enable=False), ckpt=SimpleNamespace(save_steps=float("inf"))
+    )
+    actor.rollout_queue = MagicMock()
+    actor.rollout_queue.get.side_effect = [*payloads, "done"]
+    actor.rollout_slots = MagicMock()
+    actor.train_step = MagicMock(side_effect=lambda samples, step: ({"samples": samples}, step + 1))
+    actor.save_logs_and_checkpoints = MagicMock()
+    actor.wandb_logger = None
+    actor.tensorboard_logger = None
+    actor.best_eval_metric_key = "reward"
+    actor.best_eval_metric_value = float("-inf")
+    actor.actor_model_group = MagicMock()
+    actor.actor_model_group.async_run_method.return_value = []
+    actor.critic_model_group = None
+
+    actor.fit(global_step=0)
+
+    best_state = actor.actor_model_group.async_run_method.call_args.kwargs["client_states"]
+    assert best_state["sample_buffer"] == [4, 5]
+    assert "sample_buffer_state" not in best_state

--- a/tests/test_samples_generator.py
+++ b/tests/test_samples_generator.py
@@ -1,0 +1,55 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def test_terminal_oversampling_buffer_is_drained_before_next_episode(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ray", MagicMock())
+    monkeypatch.setitem(sys.modules, "tqdm", SimpleNamespace(tqdm=lambda iterable, **kwargs: iterable))
+    monkeypatch.setitem(sys.modules, "vllm", SimpleNamespace(SamplingParams=object))
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ppo_utils.experience", MagicMock())
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ray.vllm_engine", MagicMock())
+    monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", MagicMock())
+
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_samples_generator_test",
+        root / "openrlhf" / "trainer" / "ppo_utils" / "samples_generator.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+
+    args = SimpleNamespace(
+        rollout=SimpleNamespace(batch_size=2, n_samples_per_prompt=1, vllm_generate_batch_size=4),
+        algo=SimpleNamespace(dynamic_filtering_enable=False),
+        vllm=SimpleNamespace(enable_sleep=False),
+    )
+    loader = MagicMock()
+    loader.__iter__.side_effect = lambda: iter([0, 1, 2])
+    generator = module.SamplesGenerator(SimpleNamespace(args=args), loader, None, None, [])
+
+    def generate(dataloader_iter, num_prompts, dynamic_filtering, **kwargs):
+        del dynamic_filtering, kwargs
+        generated = []
+        for _ in range(num_prompts):
+            try:
+                generated.append(next(dataloader_iter))
+            except StopIteration:
+                break
+        return generated, len(generated), len(generated) < num_prompts
+
+    generator._generate_vllm = generate
+
+    first, _, first_prompts, first_exhausted = generator.generate_samples()
+    first_buffer = list(generator._sample_buffer)
+    second, _, second_prompts, second_exhausted = generator.generate_samples()
+    third, _, third_prompts, third_exhausted = generator.generate_samples()
+
+    assert (first, first_prompts, first_exhausted) == ([0, 1], 3, False)
+    assert first_buffer == [2]
+    assert (second, second_prompts, second_exhausted) == ([2], 0, True)
+    assert (third, third_prompts, third_exhausted) == ([0, 1], 3, False)
+    assert loader.__iter__.call_count == 2


### PR DESCRIPTION
# fix(async): persist oversampling buffer state across checkpoints

Fixes #1322

Depends on the terminal-tail fix in PR #1321 (`cd4fd27`). Please merge #1321 first; this PR's diff against `main` will then reduce to the checkpoint-specific commit.

## What changed

- Associate each queued rollout with the generated-but-untrained buffer suffix at that exact training boundary.
- Put each newly generated tail in Ray's object store once; later chunks share that reference and record only the remaining suffix length.
- Materialize the suffix only when writing a regular or best checkpoint, avoiding overlapping copies in every queue payload.
- Persist whether the current episode's prompt loader is exhausted, including exact generation-batch boundaries.
- Restore the buffer, loader cursor, and exhaustion state before async generation resumes.
- Keep checkpoints created before this change loadable when the new fields are absent.

## Why

With `vllm_generate_batch_size > rollout.batch_size`, generation advances the prompt dataloader by the larger generation batch but trains only one rollout-sized chunk. The remaining generated experiences live in `_sample_buffer`.

The checkpoint previously stored the already-advanced dataloader cursor but not that buffer. A minimal generation-batch 4 / rollout-batch 2 run trained `[0, 1]`, saved loader position 4, and resumed at `[4, 5]`; buffered rollouts `[2, 3]` were silently lost.

An explicit exhaustion bit is also needed. `StatefulDataLoader` does not report exhaustion until another read is attempted, so a dataset ending exactly at a generation boundary otherwise checkpoints the final trained state as non-exhausted and can restart the same episode after resume.

## Design and compatibility

- Async generation may be ahead of training, so each queue item must retain its own checkpoint boundary.
- A nested Ray `ObjectRef` keeps the immutable generated tail alive without serializing the same `Experience` objects into every overlapping queue state.
- Buffer-only calls remove a prefix, so the remaining length identifies the exact suffix. Any call that consumes new prompts creates a fresh object-store snapshot.
- Only persistent checkpoints contain the materialized `sample_buffer`; transient ObjectRefs are never written to disk.
- Old checkpoints default to an empty buffer and non-exhausted loader. They remain loadable, although data already omitted by an old checkpoint cannot be reconstructed.

## Tests

```text
python -m pytest -q tests/test_ppo_trainer.py
10 passed

PYTHONPATH=../OpenRLHF-audit-report-20260904/test_stubs python -m pytest -q
31 passed

python -m compileall -q openrlhf examples tests
passed
```

The full-suite command used this import-only stub because DeepSpeed is not installed in the local environment:

```python
class _Utils:
    @staticmethod
    def set_z3_leaf_modules(*args, **kwargs):
        pass


utils = _Utils()
```

New regression coverage verifies:

- old checkpoint defaults and non-exhausted restore;
- one shared snapshot across multiple queue states, with exact suffix recovery;
- exhausted restore with empty, partial, exact, and multiple full chunks;
- exact generation-boundary exhaustion across every queued state;
- lazy materialization for regular checkpoints and best checkpoints;
- combined behavior with the terminal-tail fix.

`git diff --check`, isort, and Black's formatting API passed for the PR diff. No GPU is required because this is deterministic controller and checkpoint-state logic.

After publication, pre-commit.ci also mechanically reformatted the existing `preprocess_data` signature in `openrlhf/datasets/sft_dataset.py`. That bot-authored, behavior-neutral formatting change is unrelated to the fix.

## Pinned-dependency runtime validation

The committed unit tests isolate controller behavior with lightweight mocks. I additionally validated the external boundaries using the repository's exact Ray 2.55.0 dependency and the pinned DeepSpeed 0.19.5 checkpoint implementation:

- A generator actor created the buffer `ObjectRef`, placed it as a nested value in `ray.util.queue.Queue`, dropped its local Python reference, and a different actor resolved the same object ID and suffix (`same_id=True`, `remaining=[4, 5]`).
- A real `Experience` containing CPU tensors survived an on-disk `torch.save` / `torch.load(weights_only=False)` client-state round trip. DeepSpeed 0.19.5's `TorchCheckpointEngine.load()` explicitly uses that load mode.

The complete smoke script, output, and pinned DeepSpeed source link are in [this validation comment](https://github.com/OpenRLHF/OpenRLHF/pull/1323#issuecomment-5542686112).

## Checklist

- [x] The committed regression suite fails on the affected base revision and passes on this branch.
- [x] One generated tail is stored once rather than copied into every queue payload.
- [x] Persistent checkpoints contain no Ray ObjectRefs.
- [x] Exact-boundary and exhausted-buffer restore cases are covered.
- [x] Full unit suite and syntax compilation pass.
