### PR TITLE
fix(data): retain trainable turns before a truncated prompt

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]
@@ -152,8 +150,13 @@ class SFTDataset(Dataset):
                 add_special_tokens=False,
             )
             prompt_ids_len = prompt_token["attention_mask"].int().sum().item()
-            # filter the sample whose length is greater than max_length (2 for answer length)
-            if not prompt or not response or prompt_ids_len >= self.max_length - 2:
+            # Multi-turn training can use earlier answers even when the final prompt is truncated.
+            has_trainable_response = (
+                any(start_idx < self.max_length - 2 for start_idx, _ in response_ranges)
+                if self.multiturn
+                else prompt_ids_len < self.max_length - 2
+            )
+            if not prompt or not response or not has_trainable_response:
                 prompt = None
         else:
             prompt_ids_len = 0

--- a/tests/test_sft_truncation.py
+++ b/tests/test_sft_truncation.py
@@ -1,0 +1,62 @@
+from argparse import Namespace
+
+import pytest
+import torch
+from datasets import Dataset
+from tokenizers import Tokenizer
+from tokenizers.models import WordLevel
+from tokenizers.pre_tokenizers import WhitespaceSplit
+from transformers import PreTrainedTokenizerFast
+
+from openrlhf.datasets import SFTDataset
+
+
+@pytest.mark.parametrize("multiturn", [False, True])
+@pytest.mark.parametrize("long_final_prompt", [False, True])
+@pytest.mark.parametrize("earlier_answer", [False, True])
+def test_sft_keeps_trainable_turns_after_truncation(multiturn, long_final_prompt, earlier_answer):
+    vocabulary = ["[UNK]", "[EOS]", "[PAD]", "user", "assistant", "hi", "good", "long", "answer"]
+    backend = Tokenizer(WordLevel(dict(zip(vocabulary, range(len(vocabulary)))), unk_token="[UNK]"))
+    backend.pre_tokenizer = WhitespaceSplit()
+    tokenizer = PreTrainedTokenizerFast(
+        tokenizer_object=backend, unk_token="[UNK]", eos_token="[EOS]", pad_token="[PAD]"
+    )
+    tokenizer.chat_template = (
+        "{% for message in messages %}{{ message['role'] }} {{ message['content'] }} [EOS] {% endfor %}"
+        "{% if add_generation_prompt %}assistant {% endif %}"
+    )
+    strategy = Namespace(
+        args=Namespace(data=Namespace(input_key="messages", output_key=None, apply_chat_template=True))
+    )
+    messages = []
+    if earlier_answer:
+        messages.extend([{"role": "user", "content": "hi"}, {"role": "assistant", "content": "good"}])
+    messages.extend(
+        [
+            {"role": "user", "content": "long " * (40 if long_final_prompt else 1)},
+            {"role": "assistant", "content": "answer"},
+        ]
+    )
+    dataset = SFTDataset(
+        Dataset.from_list([{"messages": messages}]),
+        tokenizer,
+        max_length=16,
+        strategy=strategy,
+        num_processors=None,
+        multiturn=multiturn,
+    )
+    expected = not long_final_prompt or (multiturn and earlier_answer)
+    assert len(dataset) == int(expected)
+    if expected:
+        input_ids, attention_mask, loss_mask = dataset[0]
+        assert input_ids.shape == attention_mask.shape == loss_mask.shape
+        target_ids = input_ids.roll(-1, dims=-1)
+        trained_ids = target_ids[loss_mask.bool()].tolist()
+        assert tokenizer.convert_tokens_to_ids("long") not in trained_ids
+        if multiturn and earlier_answer:
+            assert tokenizer.convert_tokens_to_ids("good") in trained_ids
+        if not long_final_prompt:
+            assert tokenizer.convert_tokens_to_ids("answer") in trained_ids
+        batch = dataset.collate_fn([dataset[0], dataset[0]])
+        for original, collated in zip((input_ids, attention_mask, loss_mask), batch):
+            torch.testing.assert_close(collated, torch.cat([original, original]))


### PR DESCRIPTION
With `data.multiturn=true`, an SFT conversation can contain trainable assistant answers before a long final prompt. The dataset currently applies the final prompt's length cutoff to the whole row, dropping those earlier answers as well. Check whether any assistant span survives the existing cutoff in multi-turn mode; retain the existing single-turn filtering rule.

The regression uses the actual SFTDataset constructor, item access and collator with a real Hugging Face dataset and locally constructed tokenizer. It covers long/short final prompts, with/without an earlier answer, and single/multi-turn modes, and checks which target tokens receive loss.

Validation (CPU, Python 3.11.15, Torch 2.13.0, Transformers 5.15.0):

- Original regression: **1 failed, 7 passed**. A row with a usable earlier answer was incorrectly removed only in the long-final-prompt multi-turn case.
- Fixed regression: **8 passed**.
- Full repository pytest suite: **30 passed**, 14 warnings, no skips.
- `python -m compileall -q openrlhf examples tests`: passed.
- All applicable configured pre-commit hooks on the changed files: passed.

```bash
python -m pytest -q
python -m compileall -q openrlhf examples tests
pre-commit run --files openrlhf/datasets/sft_dataset.py tests/test_sft_truncation.py
```

No GPU training was run. DeepSpeed 0.19.5 was installed with native-op compilation disabled to run the existing CPU unit tests. The new dataset regression uses a Namespace only to hold the CLI data configuration; it does not replace dataset/tokenizer logic.

Duplicate checks: reviewed all open PRs and searches for multiturn/filter and response_ranges. #1227 changes Qwen3 thinking-template mask construction and output-field normalization; its patch retains the final-prompt filter and does not fix this row-selection condition.

AI assistance: OpenAI Codex assisted with investigation, implementation and testing.
