### PR TITLE
fix(reward): avoid empty HTTP reward shards

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -328,6 +328,8 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
         tasks = []
         for i, rm in enumerate(self.reward_endpoints):
             start_idx = i * batch_size
+            if start_idx >= len(queries_list):
+                break
             end_idx = min((i + 1) * batch_size, len(queries_list))
             payload = {
                 "query": queries_list[start_idx:end_idx],

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,48 @@
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+
+
+@pytest.mark.parametrize("query_count", [0, 1, 4, 6])
+def test_remote_rewards_skip_empty_shards(monkeypatch, query_count):
+    monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", SimpleNamespace(init_logger=logging.getLogger))
+    spec = importlib.util.spec_from_file_location(
+        "_openrlhf_agent_test", Path(__file__).resolve().parents[1] / "openrlhf" / "utils" / "agent.py"
+    )
+    agent = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(agent)
+
+    async def run():
+        received = []
+
+        async def get_reward(request):
+            payload = await request.json()
+            received.append(payload)
+            # The shipped reward server requires a nonempty query batch.
+            if not payload["query"]:
+                raise web.HTTPBadRequest(text="empty query batch")
+            return web.json_response({"rewards": [float(q) for q in payload["query"]]})
+
+        app = web.Application()
+        app.router.add_post("/{replica}", get_reward)
+        async with TestServer(app) as server:
+            executor = agent.SingleTurnAgentExecutor([str(server.make_url(f"/{i}")) for i in range(3)])
+            queries = [str(i) for i in range(query_count)]
+            prompts = [f"prompt-{i}" for i in range(query_count)]
+            labels = [f"label-{i}" for i in range(query_count)]
+            results = await executor._fetch_rewards_via_http(queries, prompts, labels)
+
+        assert all(payload["query"] for payload in received)
+        assert [reward for result in results for reward in result["rewards"]] == list(range(query_count))
+        received.sort(key=lambda payload: int(payload["query"][0]))
+        for key, expected in (("query", queries), ("prompts", prompts), ("labels", labels)):
+            assert [value for payload in received for value in payload[key]] == expected
+
+    asyncio.run(run())


### PR DESCRIPTION
When `--reward.remote_url` contains multiple HTTP endpoints, `SingleTurnAgentExecutor.execute()` sends one query to `_fetch_rewards_via_http()`. The sharding loop also posts empty batches to the remaining endpoints. The shipped reward server accesses `queries[0]`, so those requests fail; after retries, `asyncio.gather()` raises and the valid reward is lost.

Stop creating requests once no queries remain. A local aiohttp regression covers 0, 1, 4, and 6 queries across three endpoints, checks that no empty payload reaches the server, and verifies reward order and prompt/label alignment.

Validation:
- Before the fix: 3 regression cases fail, 1 passes. After: all 4 pass.
- `python -m pytest -q --ignore=tests/test_loss_aggregation.py`: 18 passed.
- `python -m compileall -q openrlhf examples tests`, Black, isort, and `git diff --check` passed.
- Full test collection requires DeepSpeed, which is unavailable in this local macOS environment. No GPU training run was performed.

Related closed PR #1172 proposed a broader async/round-robin redesign; this patch only skips empty shards and preserves the existing API and assignment.

This change and its regression tests were prepared with Codex.
