### PR TITLE
fix: authenticate remote reward HTTP and bind loopback by default

### DIFF
--- a/examples/scripts/serve_remote_rm.sh
+++ b/examples/scripts/serve_remote_rm.sh
@@ -1,7 +1,10 @@
 set -x
 
+# Default bind is 127.0.0.1. Multi-node deploys must pass --host <reachable-ip>.
+# Optional auth: --api-key or OPENRLHF_RM_API_KEY.
 python -m openrlhf.cli.serve_rm \
     --reward.model_name_or_path OpenRLHF/Llama-3-8b-rm-700k \
+    --host 127.0.0.1 \
     --port 5000 \
     --ds.param_dtype bf16 \
     --ds.attn_implementation flash_attention_2 \

--- a/openrlhf/cli/serve_rm.py
+++ b/openrlhf/cli/serve_rm.py
@@ -1,20 +1,77 @@
 import argparse
+import hmac
+import os
 
-import torch
-import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 
-from openrlhf.models import get_llm_for_sequence_regression
-from openrlhf.utils import get_tokenizer
 from openrlhf.utils.config import hierarchize
 from openrlhf.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
 
+def build_parser():
+    parser = argparse.ArgumentParser()
+    # Reward Model
+    parser.add_argument("--reward.model_name_or_path", type=str, default=None, help="HF model name or path")
+    parser.add_argument(
+        "--reward.normalize_enable", action="store_true", default=False, help="Enable Reward Normalization"
+    )
+    parser.add_argument("--ds.value_head_prefix", type=str, default="score")
+    parser.add_argument("--data.max_len", type=int, default=2048)
+
+    parser.add_argument("--port", type=int, default=5000, help="Port number for the server")
+    parser.add_argument(
+        "--host",
+        type=str,
+        default="127.0.0.1",
+        help="Bind address (default: 127.0.0.1). Multi-node deploys must set --host to a reachable address explicitly.",
+    )
+    parser.add_argument(
+        "--api-key",
+        type=str,
+        default=None,
+        help="Shared secret for POST /get_reward (or set OPENRLHF_RM_API_KEY). "
+        "When set, require Authorization: Bearer <key> or X-Api-Key.",
+    )
+
+    # Performance
+    parser.add_argument("--ds.load_in_4bit", action="store_true", default=False)
+    parser.add_argument(
+        "--ds.param_dtype",
+        type=str,
+        default="bf16",
+        choices=["bf16", "fp16"],
+        help="Model data type",
+    )
+    parser.add_argument(
+        "--ds.attn_implementation",
+        type=str,
+        default="flash_attention_2",
+        help="Attention implementation (e.g., eager, flash_attention_2, flash_attention_3, kernels-community/vllm-flash-attn3)",
+    )
+    parser.add_argument(
+        "--ds.experts_implementation",
+        type=str,
+        default=None,
+        choices=["eager", "batched_mm", "grouped_mm", "deepgemm"],
+        help="MoE expert computation strategy passed to transformers from_pretrained (default: auto — transformers picks grouped_mm when supported, else eager)",
+    )
+    parser.add_argument("--data.disable_fast_tokenizer", action="store_true", default=False)
+    parser.add_argument("--ds.packing_samples", action="store_true", default=False)
+    parser.add_argument("--batch_size", type=int, default=None)
+
+    # ModelScope parameters
+    parser.add_argument("--use_ms", action="store_true", default=False)
+    return parser
+
+
 class RewardModelProxy:
     def __init__(self, args):
+        from openrlhf.models import get_llm_for_sequence_regression
+        from openrlhf.utils import get_tokenizer
+
         self.reward_model = get_llm_for_sequence_regression(
             args.reward.model_name_or_path,
             "reward",
@@ -40,6 +97,8 @@ class RewardModelProxy:
         self.batch_size = args.batch_size
 
     def get_reward(self, queries):
+        import torch
+
         if self.batch_size is None:
             batch_size = len(queries)
         else:
@@ -71,62 +130,20 @@ class RewardModelProxy:
         return {k: v.to(device) for k, v in batch.items()}
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    # Reward Model
-    parser.add_argument("--reward.model_name_or_path", type=str, default=None, help="HF model name or path")
-    parser.add_argument(
-        "--reward.normalize_enable", action="store_true", default=False, help="Enable Reward Normalization"
-    )
-    parser.add_argument("--ds.value_head_prefix", type=str, default="score")
-    parser.add_argument("--data.max_len", type=int, default=2048)
-
-    parser.add_argument("--port", type=int, default=5000, help="Port number for the server")
-    parser.add_argument("--host", type=str, default="0.0.0.0", help="IP for the server")
-
-    # Performance
-    parser.add_argument("--ds.load_in_4bit", action="store_true", default=False)
-    parser.add_argument(
-        "--ds.param_dtype",
-        type=str,
-        default="bf16",
-        choices=["bf16", "fp16"],
-        help="Model data type",
-    )
-    parser.add_argument(
-        "--ds.attn_implementation",
-        type=str,
-        default="flash_attention_2",
-        help="Attention implementation (e.g., eager, flash_attention_2, flash_attention_3, kernels-community/vllm-flash-attn3)",
-    )
-    parser.add_argument(
-        "--ds.experts_implementation",
-        type=str,
-        default=None,
-        choices=["eager", "batched_mm", "grouped_mm", "deepgemm"],
-        help="MoE expert computation strategy passed to transformers from_pretrained (default: auto — transformers picks grouped_mm when supported, else eager)",
-    )
-    parser.add_argument("--data.disable_fast_tokenizer", action="store_true", default=False)
-    parser.add_argument("--ds.packing_samples", action="store_true", default=False)
-    parser.add_argument("--batch_size", type=int, default=None)
-
-    # ModelScope parameters
-    parser.add_argument("--use_ms", action="store_true", default=False)
-
-    args = hierarchize(parser.parse_args())
-
-    if args.use_ms:
-        from modelscope.utils.hf_util import patch_hub
-
-        # Patch hub to download models from modelscope to speed up.
-        patch_hub()
-
-    # server
-    reward_model = RewardModelProxy(args)
+def create_app(reward_model, api_key=None):
     app = FastAPI()
 
     @app.post("/get_reward")
     async def get_reward(request: Request):
+        if api_key:
+            x_key = request.headers.get("x-api-key") or ""
+            auth = request.headers.get("authorization") or ""
+            bearer = auth[7:].strip() if auth.lower().startswith("bearer ") else ""
+            ok = (bool(bearer) and hmac.compare_digest(bearer, api_key)) or (
+                bool(x_key) and hmac.compare_digest(x_key, api_key)
+            )
+            if not ok:
+                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
         data = await request.json()
         queries = data.get("query")
         rewards = reward_model.get_reward(queries)
@@ -134,4 +151,24 @@ if __name__ == "__main__":
         logger.info(f"Sent JSON: {result}")
         return JSONResponse(result)
 
+    return app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    args = hierarchize(build_parser().parse_args())
+
+    if args.use_ms:
+        from modelscope.utils.hf_util import patch_hub
+
+        # Patch hub to download models from modelscope to speed up.
+        patch_hub()
+
+    api_key = args.api_key or os.environ.get("OPENRLHF_RM_API_KEY")
+    if not api_key:
+        logger.warning("POST /get_reward is unauthenticated; set --api-key or OPENRLHF_RM_API_KEY")
+
+    reward_model = RewardModelProxy(args)
+    app = create_app(reward_model, api_key)
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")

--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from abc import ABC, abstractmethod
 from copy import deepcopy
 
@@ -324,6 +325,11 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
         num_servers = len(self.reward_endpoints)
         batch_size = (len(queries_list) + num_servers - 1) // num_servers
         timeout = aiohttp.ClientTimeout(total=180)
+        api_key = os.environ.get("OPENRLHF_RM_API_KEY")
+        headers = {}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+            headers["X-Api-Key"] = api_key
 
         tasks = []
         for i, rm in enumerate(self.reward_endpoints):
@@ -339,11 +345,24 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
                 for _ in range(try_max_times):
                     try:
                         async with aiohttp.ClientSession(timeout=timeout) as session:
-                            async with session.post(url, json=data) as response:
+                            async with session.post(url, json=data, headers=headers) as response:
                                 response.raise_for_status()
-                                return await response.json()
+                                result = await response.json()
+                        rewards = result.get("rewards") if isinstance(result, dict) else None
+                        expected = len(data["query"])
+                        if (
+                            not isinstance(rewards, list)
+                            or len(rewards) != expected
+                            or any(isinstance(r, bool) or not isinstance(r, (int, float)) for r in rewards)
+                        ):
+                            raise ValueError(
+                                f"Remote RM returned malformed rewards: expected {expected} numbers, got {rewards!r}"
+                            )
+                        return result
                     except aiohttp.ClientError as e:
                         logger.info(f"Request error, please check: {e}")
+                    except ValueError:
+                        raise
                     except Exception as e:  # pragma: no cover - defensive
                         logger.info(f"Unexpected error, please check: {e}")
                     await asyncio.sleep(1)

--- a/tests/test_remote_rm_http.py
+++ b/tests/test_remote_rm_http.py
@@ -1,0 +1,73 @@
+import asyncio
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Avoid openrlhf.utils.__init__ (sympy/pylatexenc) so these stay CPU-light.
+_UTILS = Path(__file__).resolve().parents[1] / "openrlhf" / "utils"
+if "openrlhf.utils" not in sys.modules:
+    _utils_pkg = types.ModuleType("openrlhf.utils")
+    _utils_pkg.__path__ = [str(_UTILS)]
+    sys.modules["openrlhf.utils"] = _utils_pkg
+
+
+def test_serve_rm_default_host_is_loopback():
+    pytest.importorskip("fastapi")
+    from openrlhf.cli.serve_rm import build_parser
+
+    assert build_parser().get_default("host") == "127.0.0.1"
+
+
+def test_missing_key_rejected_when_server_has_key():
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from openrlhf.cli.serve_rm import create_app
+
+    class FakeRewardModel:
+        def get_reward(self, queries):
+            return [1.0] * len(queries)
+
+    client = TestClient(create_app(FakeRewardModel(), api_key="secret"))
+    response = client.post("/get_reward", json={"query": ["hello"]})
+    assert response.status_code == 401
+
+
+def test_wrong_length_rewards_rejected_on_client():
+    from openrlhf.utils.agent import SingleTurnAgentExecutor
+
+    executor = SingleTurnAgentExecutor("http://127.0.0.1:9/get_reward")
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        async def json(self):
+            return {"rewards": [1.0, 2.0], "scores": [1.0, 2.0]}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        def post(self, url, json=None, headers=None):
+            return FakeResponse()
+
+    async def run():
+        with patch("openrlhf.utils.agent.aiohttp.ClientSession", return_value=FakeSession()):
+            await executor._fetch_rewards_via_http(["q"], ["p"], ["l"])
+
+    with pytest.raises(ValueError, match="malformed rewards"):
+        asyncio.run(run())


### PR DESCRIPTION
## Summary
- Default `serve_rm` host is 127.0.0.1 instead of 0.0.0.0.
- Optional shared-secret header on POST /get_reward.
- Client rejects malformed reward payloads instead of training on them.

Fixes #1317

## Test plan
- [ ] compileall
- [ ] new CPU tests for host default, auth, payload shape