### PR TITLE
fix(agent): propagate multi-turn rollout truncation

### DIFF
--- a/openrlhf/datasets/sft_dataset.py
+++ b/openrlhf/datasets/sft_dataset.py
@@ -6,9 +6,7 @@ from torch.utils.data import Dataset
 from openrlhf.utils.utils import zero_pad_sequences
 
 
-def preprocess_data(
-    data, input_template=None, input_key="input", output_key=None, apply_chat_template=None
-):
+def preprocess_data(data, input_template=None, input_key="input", output_key=None, apply_chat_template=None):
     if apply_chat_template:
         if output_key:
             prompt_message = data[input_key]

--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -80,6 +80,7 @@ class MultiTurnAgentExecutor(AgentExecutorBase):
         total_reward = 0
         final_scores = 0
         extra_logs = {}
+        is_truncated = False
 
         if sampling_params.logprobs is not None:
             rollout_log_probs = [0.0] * len(current_obs_tokens)
@@ -101,6 +102,7 @@ class MultiTurnAgentExecutor(AgentExecutorBase):
             )
             action_tokens = request_output.outputs[0].token_ids
             action_text = request_output.outputs[0].text
+            is_truncated = request_output.outputs[0].finish_reason == "length"
 
             # Record action range in token space
             action_start = len(current_obs_tokens)
@@ -176,6 +178,7 @@ class MultiTurnAgentExecutor(AgentExecutorBase):
             "observation_tokens": current_obs_tokens,
             "action_ranges": action_ranges,
             "rollout_log_probs": rollout_log_probs,
+            "truncated": is_truncated,
             "extra_logs": extra_logs,
         }
         return final_response

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,100 @@
+import asyncio
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from tests.test_experience import Experience
+
+
+@pytest.fixture
+def agent_modules(monkeypatch):
+    # Exercise the executor and reward pipeline without launching GPU workers.
+    monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", SimpleNamespace(init_logger=logging.getLogger))
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ppo_utils.experience", SimpleNamespace(Experience=Experience))
+    monkeypatch.setitem(sys.modules, "openrlhf.trainer.ray.vllm_engine", MagicMock())
+    monkeypatch.setitem(sys.modules, "ray", MagicMock())
+    monkeypatch.setitem(sys.modules, "vllm", MagicMock())
+    root = Path(__file__).resolve().parents[1]
+    modules = []
+    for path in ("utils/agent.py", "trainer/ppo_utils/samples_generator.py", "trainer/ppo_utils/length_penalty.py"):
+        spec = importlib.util.spec_from_file_location(Path(path).stem, root / "openrlhf" / path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        modules.append(module)
+    return modules
+
+
+@pytest.mark.parametrize("finish_reasons", [("stop",), ("length",), ("stop", "stop"), ("stop", "length")])
+@pytest.mark.parametrize("with_logprobs", [False, True])
+@pytest.mark.parametrize("penalty_coef", [0.0, 0.5, -0.5])
+def test_multiturn_truncation_reaches_reward_penalty(agent_modules, finish_reasons, with_logprobs, penalty_coef):
+    agent, samples, penalties = agent_modules
+
+    class Environment(agent.AgentInstanceBase):
+        def __init__(self):
+            self.steps = 0
+
+        async def step(self, states):
+            self.steps += 1
+            return {
+                "rewards": torch.tensor(1.0),
+                "environment_feedback": " ",
+                "done": self.steps == len(finish_reasons),
+            }
+
+    class Engine:
+        calls = 0
+
+        async def generate(self, token_ids, params, **kwargs):
+            reason = finish_reasons[self.calls]
+            self.calls += 1
+            count = params.max_tokens if reason == "length" else 2
+            return SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        token_ids=[65] * count,
+                        text="A" * count,
+                        finish_reason=reason,
+                        logprobs=[{65: SimpleNamespace(logprob=-0.1)}] * count if with_logprobs else None,
+                    )
+                ]
+            )
+
+    def tokenizer(text, **kwargs):
+        return {"input_ids": torch.tensor([[ord(char) for char in text]])}
+
+    engine = Engine()
+    response = asyncio.run(
+        agent.MultiTurnAgentExecutor(Environment).execute(
+            "prompt",
+            "label",
+            SimpleNamespace(max_tokens=None, logprobs=1 if with_logprobs else None),
+            64,
+            tokenizer,
+            engine,
+        )
+    )
+    expected_truncated = finish_reasons[-1] == "length"
+    assert response.get("truncated", False) is expected_truncated
+    assert engine.calls == len(finish_reasons)
+    assert response["reward"] == len(finish_reasons)
+
+    generator = samples.SamplesGenerator.__new__(samples.SamplesGenerator)
+    experience = generator._process_response_into_experience(response, max_len=64)
+    assert experience.truncated.item() is expected_truncated
+    assert experience.sequences.shape[1] <= 64
+    if with_logprobs:
+        assert experience.rollout_log_probs.shape == experience.action_mask.shape
+
+    count = penalties.apply_stop_properly_penalty([experience], penalty_coef)
+    expected_reward = float(len(finish_reasons))
+    if expected_truncated:
+        expected_reward = penalty_coef if penalty_coef < 0 else expected_reward * penalty_coef
+    assert count == int(expected_truncated)
+    assert experience.rewards.item() == expected_reward


### PR DESCRIPTION
MultiTurnAgentExecutor drops vLLM's `finish_reason="length"`, so sample conversion marks those rollouts as untruncated. This underreports truncation metrics and bypasses the stop-properly reward penalty when enabled.

Carry the final generation's truncation flag in the executor response, matching SingleTurnAgentExecutor and reusing the existing sample conversion and penalty logic.

Validation: 24 regression cases covering stop/length endings over one or two turns, with and without logprobs, and three penalty coefficients. The unpatched code fails all 12 length cases; the patched full test suite passes (46 tests). Compileall and pre-commit pass. A separate CPU probe using the shipped AgentInstance, 30 public texts and tiny-model generation also passes; no full GPU training run was performed.
