### PR TITLE
chore: upgrade vllm to 0.29.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ sudo pip uninstall xgboost transformer_engine flash_attn pynvml -y
 
 # 3. Install OpenRLHF (choose one)
 pip install openrlhf                    # Basic
-pip install openrlhf[vllm]              # + vLLM 0.27.1 (recommended)
+pip install openrlhf[vllm]              # + vLLM 0.29.0 (recommended)
 pip install openrlhf[vllm_latest]       # + Latest vLLM
 pip install openrlhf[vllm,ring,liger]   # + All optimizations
 ```
@@ -313,7 +313,7 @@ pip install -e .
 ```
 
 > [!TIP]
-> We recommend **vLLM 0.27.1+** for best performance. See [Dockerfiles](./dockerfile/) and [Nvidia-Docker Install Script](./examples/scripts/nvidia_docker_install.sh).
+> We recommend **vLLM 0.29.0+** for best performance. See [Dockerfiles](./dockerfile/) and [Nvidia-Docker Install Script](./examples/scripts/nvidia_docker_install.sh).
 
 ### Prepare Datasets
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -293,7 +293,7 @@ sudo pip uninstall xgboost transformer_engine flash_attn pynvml -y
 
 # 3. OpenRLHFをインストール（1つ選択）
 pip install openrlhf                    # 基本
-pip install openrlhf[vllm]              # + vLLM 0.27.1（推奨）
+pip install openrlhf[vllm]              # + vLLM 0.29.0（推奨）
 pip install openrlhf[vllm_latest]       # + 最新vLLM
 pip install openrlhf[vllm,ring,liger]   # + すべての最適化
 ```
@@ -307,7 +307,7 @@ pip install -e .
 ```
 
 > [!TIP]
-> 最高のパフォーマンスのために**vLLM 0.27.1+**を推奨します。[Dockerfiles](./dockerfile/)と[Nvidia-Dockerインストールスクリプト](./examples/scripts/nvidia_docker_install.sh)を参照してください。
+> 最高のパフォーマンスのために**vLLM 0.29.0+**を推奨します。[Dockerfiles](./dockerfile/)と[Nvidia-Dockerインストールスクリプト](./examples/scripts/nvidia_docker_install.sh)を参照してください。
 
 詳細な使用方法、データセット準備、学習例については、英語版READMEの該当セクションを参照してください。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -298,7 +298,7 @@ sudo pip uninstall xgboost transformer_engine flash_attn pynvml -y
 
 # 3. 安装 OpenRLHF（选择一个）
 pip install openrlhf                    # 基础
-pip install openrlhf[vllm]              # + vLLM 0.27.1（推荐）
+pip install openrlhf[vllm]              # + vLLM 0.29.0（推荐）
 pip install openrlhf[vllm_latest]       # + 最新 vLLM
 pip install openrlhf[vllm,ring,liger]   # + 所有优化
 ```
@@ -312,7 +312,7 @@ pip install -e .
 ```
 
 > [!TIP]
-> 我们推荐 **vLLM 0.27.1+** 以获得最佳性能。参见 [Dockerfiles](./dockerfile/) 和 [Nvidia-Docker 安装脚本](./examples/scripts/nvidia_docker_install.sh)。
+> 我们推荐 **vLLM 0.29.0+** 以获得最佳性能。参见 [Dockerfiles](./dockerfile/) 和 [Nvidia-Docker 安装脚本](./examples/scripts/nvidia_docker_install.sh)。
 
 ### 准备数据集
 

--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -16,7 +16,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y tzdata
 RUN apt-get -y install build-essential git python3-dev python3-pip libopenexr-dev libxi-dev libglfw3-dev libglew-dev libomp-dev libxinerama-dev libxcursor-dev gdb
 RUN pip uninstall xgboost transformer_engine torchao flash_attn pynvml opencv-python-headless -y
 # Keep the training and rollout stacks on one resolver-selected PyTorch/CUDA ABI.
-RUN pip install vllm==0.27.1 deepspeed==0.19.5 transformers==5.15.0
+RUN pip install vllm==0.29.0 deepspeed==0.19.5 transformers==5.15.0
 # Rebuild the existing FlashAttention dependency after vLLM has installed its
 # exact PyTorch dependency, so the extension uses the same ABI.
 RUN MAX_JOBS=8 pip install flash-attn==2.8.3 --no-build-isolation

--- a/openrlhf/trainer/ray/vllm_engine.py
+++ b/openrlhf/trainer/ray/vllm_engine.py
@@ -104,8 +104,6 @@ class RolloutRayActor:
 
             os.environ["RAY_ADDRESS"] = global_worker.gcs_client.address
 
-        os.environ["VLLM_USE_V1"] = "1"
-
     async def init_process_group(
         self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray
     ):

--- a/setup.py
+++ b/setup.py
@@ -74,8 +74,8 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=_fetch_requirements("requirements.txt"),
     extras_require={
-        "vllm": ["vllm==0.27.1"],
-        "vllm_latest": ["vllm>=0.27.1"],
+        "vllm": ["vllm==0.29.0"],
+        "vllm_latest": ["vllm>=0.29.0"],
         "ring": ["ring_flash_attn"],
         "liger": ["liger_kernel"],
     },


### PR DESCRIPTION
vLLM 0.29 removed the VLLM_USE_V1 environment variable (V1 is the only engine), so drop the now-inert assignment in vllm_engine.py. Verified the full engine API surface OpenRLHF uses against 0.29.0: AsyncEngineArgs fields, sleep/wake_up/pause_generation/collective_rpc signatures, StatelessProcessGroup/PyNcclCommunicator weight-sync internals, logprobs_mode values, and rollout output structures are all unchanged. vllm==0.29.0 still resolves torch==2.13.0, so the pinned deepspeed==0.19.5, transformers==5.15.0 and the flash-attn 2.8.3 build are unaffected.