### PR TITLE
fix(reward): rotate HTTP replicas across rollout requests

### DIFF
--- a/openrlhf/utils/agent.py
+++ b/openrlhf/utils/agent.py
@@ -1,6 +1,7 @@
 import asyncio
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from itertools import cycle
 
 import aiohttp
 
@@ -190,6 +191,7 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
     def __init__(self, remote_rm_url=None):
         reward_endpoints = [remote_rm_url] if isinstance(remote_rm_url, str) else remote_rm_url
         self.reward_endpoints = reward_endpoints or []
+        self._reward_endpoint_cycle = cycle(self.reward_endpoints)
 
         # Optional user-provided reward_func from a Python file.
         self.reward_func = None
@@ -329,10 +331,12 @@ class SingleTurnAgentExecutor(AgentExecutorBase):
         timeout = aiohttp.ClientTimeout(total=180)
 
         tasks = []
-        for i, rm in enumerate(self.reward_endpoints):
+        for i in range(num_servers):
             start_idx = i * batch_size
             if start_idx >= len(queries_list):
                 break
+            # Rollouts usually send one query, so rotate across calls as well as shards.
+            rm = next(self._reward_endpoint_cycle)
             end_idx = min((i + 1) * batch_size, len(queries_list))
             payload = {
                 "query": queries_list[start_idx:end_idx],

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib.util
 import logging
 import sys
+from collections import Counter
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -15,7 +16,10 @@ from tests.test_experience import Experience
 
 
 @pytest.mark.parametrize("query_count", [0, 1, 4, 6])
-def test_remote_rewards_skip_empty_shards(monkeypatch, query_count):
+@pytest.mark.parametrize("rounds", [1, 6])
+@pytest.mark.parametrize("concurrent", [False, True])
+@pytest.mark.parametrize("replicas", [1, 3])
+def test_remote_rewards_distribute_nonempty_shards(monkeypatch, query_count, rounds, concurrent, replicas):
     monkeypatch.setitem(sys.modules, "openrlhf.utils.logging_utils", SimpleNamespace(init_logger=logging.getLogger))
     spec = importlib.util.spec_from_file_location(
         "_openrlhf_agent_test", Path(__file__).resolve().parents[1] / "openrlhf" / "utils" / "agent.py"
@@ -25,10 +29,12 @@ def test_remote_rewards_skip_empty_shards(monkeypatch, query_count):
 
     async def run():
         received = []
+        requests_per_replica = Counter()
 
         async def get_reward(request):
             payload = await request.json()
             received.append(payload)
+            requests_per_replica[request.match_info["replica"]] += 1
             # The shipped reward server requires a nonempty query batch.
             if not payload["query"]:
                 raise web.HTTPBadRequest(text="empty query batch")
@@ -37,14 +43,26 @@ def test_remote_rewards_skip_empty_shards(monkeypatch, query_count):
         app = web.Application()
         app.router.add_post("/{replica}", get_reward)
         async with TestServer(app) as server:
-            executor = agent.SingleTurnAgentExecutor([str(server.make_url(f"/{i}")) for i in range(3)])
-            queries = [str(i) for i in range(query_count)]
-            prompts = [f"prompt-{i}" for i in range(query_count)]
-            labels = [f"label-{i}" for i in range(query_count)]
-            results = await executor._fetch_rewards_via_http(queries, prompts, labels)
+            executor = agent.SingleTurnAgentExecutor([str(server.make_url(f"/{i}")) for i in range(replicas)])
+            queries = [str(i) for i in range(query_count * rounds)]
+            prompts = [f"prompt-{i}" for i in range(query_count * rounds)]
+            labels = [f"label-{i}" for i in range(query_count * rounds)]
+            calls = [
+                executor._fetch_rewards_via_http(
+                    queries[i * query_count : (i + 1) * query_count],
+                    prompts[i * query_count : (i + 1) * query_count],
+                    labels[i * query_count : (i + 1) * query_count],
+                )
+                for i in range(rounds)
+            ]
+            results = await asyncio.gather(*calls) if concurrent else [await call for call in calls]
 
         assert all(payload["query"] for payload in received)
-        assert [reward for result in results for reward in result["rewards"]] == list(range(query_count))
+        counts = [requests_per_replica[str(i)] for i in range(replicas)]
+        assert max(counts) - min(counts) <= 1
+        assert [reward for batch in results for result in batch for reward in result["rewards"]] == list(
+            range(query_count * rounds)
+        )
         received.sort(key=lambda payload: int(payload["query"][0]))
         for key, expected in (("query", queries), ("prompts", prompts), ("labels", labels)):
             assert [value for payload in received for value in payload[key]] == expected


### PR DESCRIPTION
With multiple `--reward.remote_url` HTTP replicas, each rollout sends a single reward query. The sharding loop restarts at endpoint zero for every call, so only the first replica is used after empty shards are skipped.

Rotate endpoints across nonempty shards and successive calls with `itertools.cycle`, retaining the existing batching, retries and result ordering.

Validation: extended the existing local aiohttp regression to 32 cases covering empty/singleton/batched queries, repeated and concurrent calls, and one/three endpoints. Four cases fail before the fix; all pass afterward. Full suite on the updated main base: 88 passed, one optional module skipped because torchdata is unavailable. Compileall and changed-file pre-commit pass. A separate real-HTTP probe through `execute()` changes 30 requests from [30, 0, 0] to [10, 10, 10] while preserving reward alignment; generation is stubbed, and no GPU or throughput benchmark was run.

Related: #1325 fixed empty shards. Closed #1172 previously proposed round-robin routing as part of a broader async-reward rewrite; this patch keeps the existing reward-function API and adds a focused routing regression.
