### PR TITLE
fix(data): avoid scanning saved datasets during split selection

### DIFF
--- a/openrlhf/datasets/utils.py
+++ b/openrlhf/datasets/utils.py
@@ -1,6 +1,6 @@
 import os
 
-from datasets import interleave_datasets, load_dataset, load_from_disk
+from datasets import Dataset, interleave_datasets, load_dataset, load_from_disk
 
 
 def exist_and_not_none(d, key):
@@ -74,7 +74,7 @@ def blending_datasets(
             strategy.print(f"loaded {dataset} from files")
 
         # Select dataset
-        if dataset_split and dataset_split in data:
+        if dataset_split and not isinstance(data, Dataset) and dataset_split in data:
             data = data[dataset_split]
         data = data.select(range(min(max_count, len(data))))
         data_list.append(data)

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from datasets import Dataset, DatasetDict
+
+
+@pytest.mark.parametrize(
+    "as_dict,split",
+    [(False, "train"), (False, "validation"), (False, None), (True, "train"), (True, "validation")],
+)
+def test_saved_dataset_split_selection_does_not_scan_rows(tmp_path, monkeypatch, as_dict, split):
+    spec = importlib.util.spec_from_file_location(
+        "_dataset_utils_test", Path(__file__).resolve().parents[1] / "openrlhf/datasets/utils.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    train = Dataset.from_dict({"text": [f"train-{i}" for i in range(6)]})
+    validation = Dataset.from_dict({"text": [f"validation-{i}" for i in range(3)]})
+    data = DatasetDict(train=train, validation=validation) if as_dict else train
+    data.save_to_disk(str(tmp_path / "data"))
+    original_iter = Dataset.__iter__
+    visited = []
+
+    def track_rows(self):
+        for row in original_iter(self):
+            visited.append(row)
+            yield row
+
+    monkeypatch.setattr(Dataset, "__iter__", track_rows)
+    strategy = SimpleNamespace(print=lambda *args: None, is_rank_0=lambda: False)
+    result = module.blending_datasets(str(tmp_path / "data"), strategy=strategy, max_count=2, dataset_split=split)
+
+    assert visited == []
+    expected = validation if as_dict and split == "validation" else train
+    assert result.to_dict() == expected.select(range(2)).to_dict()


### PR DESCRIPTION
When `load_from_disk()` returns a flat Hugging Face `Dataset`, checking `dataset_split in data` iterates and formats every row: `Dataset` has no split-key membership operation. This happens before `max_count` is applied, so selecting a small prefix still scans the entire saved dataset.

Skip split membership for an already-flat `Dataset`, preserving the existing selection behavior for split dictionaries and other loader results.

Validation: five CPU regressions using actual `Dataset`/`DatasetDict` save/load; the two flat-Dataset split checks fail before the fix. Public SQuAD, CMRC and HumanEval data reproduce 10,570 / 3,219 / 164 extra row visits while selecting ten records; the fix eliminates those visits and preserves all returned records. Concatenation and probability interleaving also retain identical output. Full suite: 65 passed, one optional module skipped for missing torchdata. Compileall and changed-file pre-commit pass. No GPU training or end-to-end throughput benchmark was run.
