### PR TITLE
fix(eval): retain tail batches in SFT, DPO and RM

### DIFF
--- a/openrlhf/cli/train_dpo.py
+++ b/openrlhf/cli/train_dpo.py
@@ -117,6 +117,7 @@ def train(args):
             True,
             False,
             eval_dataset.collate_fn,
+            drop_last=False,
             num_workers=args.data.dataloader_num_workers,
         )
 

--- a/openrlhf/cli/train_rm.py
+++ b/openrlhf/cli/train_rm.py
@@ -94,6 +94,7 @@ def train(args):
         True,
         False,
         eval_dataset.collate_fn,
+        drop_last=False,
         num_workers=args.data.dataloader_num_workers,
     )
 

--- a/openrlhf/cli/train_sft.py
+++ b/openrlhf/cli/train_sft.py
@@ -95,6 +95,7 @@ def train(args):
             True,
             False,
             eval_dataset.collate_fn,
+            drop_last=False,
             num_workers=args.data.dataloader_num_workers,
         )
 

--- a/tests/test_eval_dataloader.py
+++ b/tests/test_eval_dataloader.py
@@ -1,0 +1,51 @@
+"""Exercise CLI loader calls without initializing training models or CUDA."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from tests.test_deepspeed_save_model import ds_module  # noqa: F401
+
+
+@pytest.mark.parametrize("cli", ["train_sft", "train_dpo", "train_rm"])
+@pytest.mark.parametrize("size,replicas,batch_size", [(1, 1, 2), (3, 8, 1), (10, 2, 2), (8, 2, 2), (0, 2, 2)])
+def test_eval_keeps_tail_and_training_still_drops_it(ds_module, monkeypatch, cli, size, replicas, batch_size):
+    # Execute the actual CLI call expressions; model construction requires GPUs.
+    path = Path(__file__).resolve().parents[1] / "openrlhf" / "cli" / f"{cli}.py"
+    calls = {
+        node.args[0].id: node
+        for node in ast.walk(ast.parse(path.read_text()))
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) and node.func.attr == "setup_dataloader"
+    }
+    dataset = torch.utils.data.TensorDataset(torch.arange(size))
+    dataset.collate_fn = torch.utils.data.default_collate
+    strategy = object.__new__(ds_module.DeepspeedStrategy)
+    strategy.seed = 42
+    strategy.ds_device_mesh = {"dp": SimpleNamespace(get_group=lambda: None)}
+    monkeypatch.setattr(ds_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(ds_module.dist, "get_world_size", lambda **_: replicas)
+    args = SimpleNamespace(
+        train=SimpleNamespace(micro_batch_size=batch_size), data=SimpleNamespace(dataloader_num_workers=0)
+    )
+    for name in ("eval_dataset", "train_dataset"):
+        observed, lengths = [], []
+        for rank in range(replicas):
+            monkeypatch.setattr(ds_module.dist, "get_rank", lambda **_: rank)
+            loader = eval(
+                compile(ast.Expression(calls[name]), str(path), "eval"),
+                {
+                    "strategy": strategy,
+                    "args": args,
+                    name: dataset,
+                },
+            )
+            lengths.append(len(loader))
+            observed.extend(index for batch in loader for index in batch[0].tolist())
+        assert len(set(lengths)) == 1
+        if name == "eval_dataset":
+            assert set(observed) == set(range(size))
+        else:
+            assert len(observed) == size // (replicas * batch_size) * replicas * batch_size


### PR DESCRIPTION
SFT, DPO and RM evaluation loaders inherit `drop_last=True` from the training loader setup. This discards evaluation tail records and can make a nonempty evaluation set appear empty, causing evaluation to be skipped. For RM this also skips updating reward normalization statistics.

This draft passes `drop_last=False` at the three evaluation call sites and adds regression coverage using the existing sampler and loader. Training loaders are unchanged.

**Not ready to merge:** retaining tail batches exposes two unresolved metric issues:

- RM and DPO average batch metrics without weighting batch sizes. Running the existing RM evaluator on controlled scores with batches of 2 and 1 reports accuracy 0.5 instead of 2/3. Loss is also incorrectly weighted. SFT aggregation needs coordination with #1216.
- The distributed sampler repeats initial records to equalize rank sizes. Those repetitions currently enter metrics, including RM's persisted reward mean/std. Padding needs an explicit treatment before this can provide population-level evaluation statistics.

Validation of the current data-retention change:

- Regression tests: 9 failures and 6 passes before; complete project suite: 78 passes after.
- `python -m compileall -q openrlhf examples tests` and pre-commit checks passed.
- 54 before/after loader checks with public SQuAD, CMRC and HumanEval records retained every distinct record with unchanged contents after the change.

The regression tests execute the CLI loader call expressions and use the real strategy, sampler and StatefulDataLoader with simulated ranks. Public-record checks validate data loading, not model accuracy. No real distributed collective, GPU training or end-to-end model evaluation is claimed. Passing these checks does not resolve the metric issues above.
