### PR TITLE
fix(ppo): preserve best metric across regular checkpoint resume

### DIFF
--- a/openrlhf/trainer/ppo_trainer.py
+++ b/openrlhf/trainer/ppo_trainer.py
@@ -205,7 +205,7 @@ class BasePPOTrainer(ABC):
             self.best_eval_metric_key = checkpoint_metric_key
         if checkpoint_metric_value is not None:
             self.best_eval_metric_value = checkpoint_metric_value
-            self._latest_eval_metric_value = checkpoint_metric_value
+            self._latest_eval_metric_value = checkpoint_states.get("latest_eval_metric_value", checkpoint_metric_value)
 
     def fit(self, global_step: int = 0) -> None:
         raise NotImplementedError("fit method is not implemented")
@@ -361,6 +361,7 @@ class BasePPOTrainer(ABC):
             client_states = client_states or {}
             client_states["best_eval_metric_key"] = metric_key
             client_states["best_eval_metric_value"] = current_value
+            client_states["latest_eval_metric_value"] = current_value
             client_states["checkpoint_metric_key"] = metric_key
 
             tag = f"best_global_step{global_step}"
@@ -391,6 +392,9 @@ class BasePPOTrainer(ABC):
         # save ckpt
         client_states = client_states or {}
         if global_step % self.args.ckpt.save_steps == 0:
+            client_states["best_eval_metric_key"] = self.best_eval_metric_key
+            client_states["best_eval_metric_value"] = self.best_eval_metric_value
+            client_states["latest_eval_metric_value"] = self._latest_eval_metric_value
             tag = f"global_step{global_step}"
             metric_value = self._latest_eval_metric_value
             metric_key = client_states.get("checkpoint_metric_key") or self.best_eval_metric_key or None

--- a/tests/test_ppo_trainer.py
+++ b/tests/test_ppo_trainer.py
@@ -116,3 +116,63 @@ def test_sync_fit_does_not_train_empty_exhausted_result(ppo_module):
     trainer.fit()
 
     assert trainer.samples_generator.calls == 1
+
+
+def _checkpoint_trainer(module):
+    trainer = module.BasePPOTrainer.__new__(module.BasePPOTrainer)
+    trainer.args = SimpleNamespace(logger=SimpleNamespace(logging_steps=1), ckpt=SimpleNamespace(save_steps=1))
+    trainer.actor_model_group = MagicMock()
+    trainer.actor_model_group.async_run_method.return_value = []
+    trainer.critic_model_group = None
+    trainer.wandb_logger = trainer.tensorboard_logger = None
+    trainer.best_eval_metric_key = ""
+    trainer.best_eval_metric_value = float("-inf")
+    trainer._latest_eval_metric_value = None
+    return trainer
+
+
+@pytest.mark.parametrize("best,latest", [(0.8, 0.5), (0.0, -0.2), (-0.2, -0.5)])
+def test_regular_checkpoint_restores_best_and_latest_metrics(ppo_module, tmp_path, best, latest):
+    import torch
+
+    trainer = _checkpoint_trainer(ppo_module)
+    trainer.save_best_checkpoint({"eval_math_pass1": best}, 1)
+    trainer.save_best_checkpoint({"eval_math_pass1": latest}, 2)
+    trainer.save_logs_and_checkpoints(3, client_states={"global_step": 3})
+    saved = trainer.actor_model_group.async_run_method.call_args.kwargs["client_states"]
+    path = tmp_path / "client_state.pt"
+    torch.save(saved, path)
+
+    resumed = _checkpoint_trainer(ppo_module)
+    resumed.restore_best_checkpoint_state(torch.load(path, weights_only=True))
+    assert resumed.best_eval_metric_key == "eval_math_pass1"
+    assert resumed.best_eval_metric_value == best
+    assert resumed._latest_eval_metric_value == latest
+    resumed.save_best_checkpoint({"eval_math_pass1": (best + latest) / 2}, 4)
+    resumed.actor_model_group.async_run_method.assert_not_called()
+    resumed.save_best_checkpoint({"eval_math_pass1": best + 0.1}, 5)
+    assert resumed.actor_model_group.async_run_method.call_args.kwargs["tag"] == "best_global_step5"
+
+
+def test_best_checkpoint_overwrites_previous_latest_metric(ppo_module):
+    trainer = _checkpoint_trainer(ppo_module)
+    trainer.save_best_checkpoint({"eval_math_pass1": 0.8}, 1, {"latest_eval_metric_value": 0.2})
+    saved = trainer.actor_model_group.async_run_method.call_args.kwargs["client_states"]
+    resumed = _checkpoint_trainer(ppo_module)
+    resumed.restore_best_checkpoint_state(saved)
+    assert resumed.best_eval_metric_value == resumed._latest_eval_metric_value == 0.8
+
+
+@pytest.mark.parametrize(
+    "state,best,latest",
+    [
+        ({}, float("-inf"), None),
+        ({"best_eval_metric_key": "eval_math_pass1", "best_eval_metric_value": 0.0}, 0.0, 0.0),
+        ({"best_eval_metric_value": 0.8, "latest_eval_metric_value": None}, 0.8, None),
+    ],
+)
+def test_restore_checkpoint_metric_compatibility(ppo_module, state, best, latest):
+    trainer = _checkpoint_trainer(ppo_module)
+    trainer.restore_best_checkpoint_state(state)
+    assert trainer.best_eval_metric_value == best
+    assert trainer._latest_eval_metric_value == latest


### PR DESCRIPTION
Regular PPO checkpoints omit the historical best evaluation metric. Resuming from one resets the best threshold to `-inf`, so a worse subsequent evaluation can be saved as the new best and delete the previous best checkpoint.

Persist best metric key/value in regular checkpoint client state and retain the latest evaluation value separately for checkpoint rotation. The existing restore path accepts older checkpoints using its previous fallback. Both synchronous and asynchronous PPO use these base methods.

Validation: full pytest suite (70 passed), compileall and pre-commit. Regression tests cover save/load, worse and better evaluations, zero/negative metrics and older metadata. A CPU file-system probe ran the actual trainer decisions and strategy checkpoint rotation: the old best survives a worse evaluation after resume and is replaced by a real improvement. Ray transport and DeepSpeed engine serialization were stand-ins; no GPU training was run.
