### PR TITLE
fix(eval): weight RM and DPO metrics by sample count

### DIFF
--- a/openrlhf/trainer/dpo_trainer.py
+++ b/openrlhf/trainer/dpo_trainer.py
@@ -261,7 +261,7 @@ class DPOTrainer(ABC):
             )
             acc_sum = 0
             loss_sum = 0
-            times = 0
+            num_samples = 0
             device = next(self.model.parameters()).device
             for data in eval_dataloader:
                 chosen_ids, c_mask, reject_ids, r_mask, prompt_id_lens = data
@@ -281,14 +281,15 @@ class DPOTrainer(ABC):
                 loss, chosen_reward, reject_reward = self.loss_fn(
                     chosen_logps, rejected_logps, reference_chosen_logps, reference_rejected_logps
                 )
-                acc_sum += (chosen_reward > reject_reward).float().mean().item()
-                loss_sum += loss.item()
-                times += 1
+                batch_size = chosen_reward.numel()
+                acc_sum += (chosen_reward > reject_reward).sum().item()
+                loss_sum += loss.item() * batch_size
+                num_samples += batch_size
                 step_bar.update()
 
             logs = {
-                "eval_loss": loss_sum / times,
-                "acc_mean": acc_sum / times,
+                "eval_loss": loss_sum / num_samples,
+                "acc_mean": acc_sum / num_samples,
             }
             logs = self.strategy.all_reduce(logs)
             step_bar.set_postfix(logs)

--- a/openrlhf/trainer/rm_trainer.py
+++ b/openrlhf/trainer/rm_trainer.py
@@ -255,6 +255,7 @@ class RewardModelTrainer(ABC):
             acc = 0
             rewards = []
             loss_sum = 0
+            num_samples = 0
             device = next(self.model.parameters()).device
             for data in eval_dataloader:
                 chosen_ids, c_mask, reject_ids, r_mask, margin = data
@@ -275,12 +276,14 @@ class RewardModelTrainer(ABC):
                 loss = self.loss_fn(chosen_reward, reject_reward, margin)
 
                 rewards += [chosen_reward.flatten(), reject_reward.flatten()]
-                acc += (chosen_reward > reject_reward).float().mean().item()
-                loss_sum += loss.item()
+                batch_size = chosen_reward.numel()
+                acc += (chosen_reward > reject_reward).sum().item()
+                loss_sum += loss.item() * batch_size
+                num_samples += batch_size
                 step_bar.update()
 
-            acc_mean = acc / eval_dataloader.__len__()
-            loss_mean = loss_sum / eval_dataloader.__len__()
+            acc_mean = acc / num_samples
+            loss_mean = loss_sum / num_samples
 
             rewards = torch.cat(rewards).float()
             rewards = self.strategy.all_gather(rewards)

--- a/tests/test_preference_eval.py
+++ b/tests/test_preference_eval.py
@@ -1,0 +1,72 @@
+"""Check preference eval on CPU with fixed model scores."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from tqdm import tqdm
+
+
+@pytest.mark.parametrize("trainer_name", ["rm", "dpo"])
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+@pytest.mark.parametrize("metric,expected", [("acc_mean", 2 / 3), ("eval_loss", 0.91781775)])
+def test_preference_eval_weights_each_pair_equally(trainer_name, batch_size, metric, expected):
+    root = Path(__file__).resolve().parents[1]
+    path = root / "openrlhf" / "trainer" / f"{trainer_name}_trainer.py"
+    tree = ast.parse(path.read_text())
+    evaluate = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "evaluate")
+    namespace = {"torch": torch, "tqdm": tqdm, "nn": nn, "F": F}
+    # Use the real evaluator and losses. Their module imports need GPU dependencies.
+    loss_tree = ast.parse((root / "openrlhf" / "models" / "loss.py").read_text())
+    loss_class = "PairWiseLoss" if trainer_name == "rm" else "DPOLoss"
+    loss_node = next(node for node in loss_tree.body if isinstance(node, ast.ClassDef) and node.name == loss_class)
+    namespace["Tuple"] = tuple
+    exec(compile(ast.Module(body=[evaluate, loss_node], type_ignores=[]), str(path), "exec"), namespace)
+
+    model = nn.Linear(1, 1)
+    model.config = SimpleNamespace()
+    reference = nn.Linear(1, 1)
+    logged = []
+    strategy = SimpleNamespace(
+        is_rank_0=lambda: True,
+        all_reduce=lambda values: values,
+        all_gather=lambda values: values,
+        _unwrap_model=lambda value: value,
+        print=lambda *args: None,
+    )
+    trainer = SimpleNamespace(
+        model=model,
+        ref_model=reference,
+        strategy=strategy,
+        margin_loss=False,
+        loss_fn=namespace[loss_class]() if trainer_name == "rm" else namespace[loss_class](beta=1.0),
+        _wandb=SimpleNamespace(log=logged.append),
+        _tensorboard=None,
+    )
+
+    def forward(current_model, chosen_ids, chosen_mask, rejected_ids, rejected_mask, *args):
+        chosen, rejected = chosen_ids[:, 0].float(), rejected_ids[:, 0].float()
+        if current_model is reference:
+            chosen, rejected = torch.zeros_like(chosen), torch.zeros_like(rejected)
+        return (chosen, rejected, None) if trainer_name == "rm" else (chosen, rejected, None, None)
+
+    trainer.concatenated_forward = forward
+    # The first two pairs are ranked correctly; the last pair is incorrect and has a larger loss.
+    chosen = torch.tensor([[-1], [-1], [-4]])
+    rejected = torch.tensor([[-2], [-2], [-2]])
+    dataset = torch.utils.data.TensorDataset(
+        chosen.unsqueeze(1),
+        torch.ones_like(chosen).unsqueeze(1),
+        rejected.unsqueeze(1),
+        torch.ones_like(rejected).unsqueeze(1),
+        torch.zeros(3),
+    )
+    loader = torch.utils.data.DataLoader(dataset, batch_size=batch_size, drop_last=False)
+    namespace["evaluate"](trainer, loader, steps=7)
+
+    assert logged[0][f"eval/{metric}"] == pytest.approx(expected)
+    assert model.training


### PR DESCRIPTION
This is a small follow-up to #1332. That PR keeps the last partial batch in eval and notes that RM and DPO still give each batch the same weight.

For example, suppose three preference pairs have two correct results and one incorrect result. A batch size of 2 gives batches of 2 and 1. Their accuracies are 1 and 0, so the current code reports 0.5. The result over all three pairs should be 2/3. Loss has the same problem.

The CPU test uses the same three pairs for each row:

| Batch size | Current accuracy | Current loss | Accuracy with this fix | Loss with this fix |
| --- | --- | --- | --- | --- |
| 1 | 0.6667 | 0.9178 | 0.6667 | 0.9178 |
| 2 | 0.5000 | 1.2201 | 0.6667 | 0.9178 |
| 3 | 0.6667 | 0.9178 | 0.6667 | 0.9178 |

The proposed change counts correct pairs and weights each batch loss by its pair count. Both metrics then use the total pair count. It applies to the RM and DPO evaluators.

The current `all_reduce` stays in place. The default sampler gives each rank the same number of pairs, so the rank means still have equal weight. Repeated records from sampler padding still count. This PR does not address that separate issue or SFT metrics.

Would it make sense to keep this as a separate fix for batch weights, then address sampler duplicates in a later change? Happy to discuss this approach! 


